### PR TITLE
[Fix] Typo docs-geocoding-api.leaf

### DIFF
--- a/Resources/Views/docs-geocoding-api.leaf
+++ b/Resources/Views/docs-geocoding-api.leaf
@@ -199,7 +199,7 @@
         </tr>
         <tr>
           <th scope="row">elevation</th>
-          <td>Floating ppint</td>
+          <td>Floating point</td>
           <td>Elevation above mean sea level of this location</td>
         </tr>
         <tr>


### PR DESCRIPTION
I fixed a typo I recently discovered: `Floating ppint` -> `Floating point`