### PR TITLE
Typo in Lisbon city option

### DIFF
--- a/Resources/Views/docs.leaf
+++ b/Resources/Views/docs.leaf
@@ -80,7 +80,7 @@
               <option data-latitude="52.3738" data-longitude="4.8910" data-asl="-1">Amsterdam</option>
               <option data-latitude="59.9138" data-longitude="10.7387" data-asl="12">Oslo</option>
               <option data-latitude="52.2297" data-longitude="21.0122" data-asl="93">Warsaw</option>
-              <option data-latitude="38.7072" data-longitude="-9.1355" data-asl="15">Lisabon</option>
+              <option data-latitude="38.7072" data-longitude="-9.1355" data-asl="15">Lisbon</option>
               <option data-latitude="46.9480" data-longitude="7.4481" data-asl="513">Bern</option>
               <option data-latitude="50.4422" data-longitude="30.5367" data-asl="168">Kiev</option>
               <option data-latitude="59.3328" data-longitude="18.0645" data-asl="15">Stockholm</option>


### PR DESCRIPTION
Fix typo 'Lisabon' on city options