### PR TITLE
docker: build docker images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,24 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  cache_version: 2
+
+jobs:
+  linux:
+    runs-on: ubuntu-22.04
+    container: ubuntu:jammy
+    name: Docker on Ubuntu
+    steps:
+    - name: Install Docker
+      run: apt-get update && apt-get -qq -y install docker docker-compose
+    - uses: actions/checkout@v3
+    - name: Build Docker Image
+      run: docker-compose build
+    - name: Run Docker Image
+      run: docker-compose up -d open-meteo


### PR DESCRIPTION
This may avoid the docker image to become broken in the future.
With this you are two layers deep into Docker and the build takes a solid 12 minutes, but it may help in the long run