### PR TITLE
Gridable: fix compiler warning

### DIFF
--- a/Sources/App/Domains/Gridable.swift
+++ b/Sources/App/Domains/Gridable.swift
@@ -79,7 +79,7 @@ extension Gridable {
     
     /// Read elevation for a single grid point
     func readElevation(gridpoint: Int, elevationFile: OmFileReader<MmapFile>) throws -> ElevationOrSea {
-        var elevation = try readFromStaticFile(gridpoint: gridpoint, file: elevationFile)
+        let elevation = try readFromStaticFile(gridpoint: gridpoint, file: elevationFile)
         if elevation.isNaN {
             return .noData
         }


### PR DESCRIPTION
```swift
/build/Sources/App/Domains/Gridable.swift:82:13: warning: variable 'elevation' was never mutated; consider changing to 'let' constant
        var elevation = try readFromStaticFile(gridpoint: gridpoint, file: elevationFile)
        ~~~ ^
        let
```