### PR TITLE
GFS: support for additional gfs013 variables

### DIFF
--- a/Sources/App/Gfs/GfsController.swift
+++ b/Sources/App/Gfs/GfsController.swift
@@ -191,6 +191,7 @@ enum GfsDailyWeatherVariable: String, RawRepresentableString {
 
 enum GfsVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case apparent_temperature
+    case relativehumidity_2m
     case relativehumitidy_2m
     case dewpoint_2m
     case windspeed_10m
@@ -327,10 +328,10 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(raw: .surface(.temperature_2m), time: time)
                 try prefetchData(raw: .surface(.wind_u_component_10m), time: time)
                 try prefetchData(raw: .surface(.wind_v_component_10m), time: time)
-                try prefetchData(raw: .surface(.relativehumidity_2m), time: time)
+                try prefetchData(derived: .surface(.relativehumidity_2m), time: time)
                 try prefetchData(raw: .surface(.shortwave_radiation), time: time)
             case .relativehumitidy_2m:
-                try prefetchData(raw: .surface(.relativehumidity_2m), time: time)
+                try prefetchData(derived: .surface(.relativehumidity_2m), time: time)
             case .windspeed_10m:
                 try prefetchData(raw: .surface(.wind_u_component_10m), time: time)
                 try prefetchData(raw: .surface(.wind_v_component_10m), time: time)
@@ -347,11 +348,11 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(raw: .surface(.latent_heatflux), time: time)
             case .vapor_pressure_deficit:
                 try prefetchData(raw: .surface(.temperature_2m), time: time)
-                try prefetchData(raw: .surface(.relativehumidity_2m), time: time)
+                try prefetchData(derived: .surface(.relativehumidity_2m), time: time)
             case .et0_fao_evapotranspiration:
                 try prefetchData(raw: .surface(.shortwave_radiation), time: time)
                 try prefetchData(raw: .surface(.temperature_2m), time: time)
-                try prefetchData(raw: .surface(.relativehumidity_2m), time: time)
+                try prefetchData(derived: .surface(.relativehumidity_2m), time: time)
                 try prefetchData(raw: .surface(.wind_u_component_10m), time: time)
                 try prefetchData(raw: .surface(.wind_v_component_10m), time: time)
             case .rain:
@@ -368,7 +369,7 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 break
             case .dewpoint_2m:
                 try prefetchData(raw: .surface(.temperature_2m), time: time)
-                try prefetchData(raw: .surface(.relativehumidity_2m), time: time)
+                try prefetchData(derived: .surface(.relativehumidity_2m), time: time)
             case .diffuse_radiation_instant:
                 try prefetchData(raw: .surface(.diffuse_radiation), time: time)
             case .direct_normal_irradiance:
@@ -391,6 +392,10 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(raw: .surface(.windgusts_10m), time: time)
                 try prefetchData(raw: .surface(.visibility), time: time)
                 try prefetchData(raw: .surface(.lifted_index), time: time)
+            case .relativehumidity_2m:
+                try prefetchData(raw: .surface(.temperature_2m), time: time)
+                try prefetchData(raw: .surface(.surface_pressure), time: time)
+                try prefetchData(raw: .surface(.specific_humidity_2m), time: time)
             }
         case .pressure(let v):
             switch v.variable {
@@ -433,7 +438,7 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
             case .apparent_temperature:
                 let windspeed = try get(derived: .surface(.windspeed_10m), time: time).data
                 let temperature = try get(raw: .surface(.temperature_2m), time: time).data
-                let relhum = try get(raw: .surface(.relativehumidity_2m), time: time).data
+                let relhum = try get(derived: .surface(.relativehumidity_2m), time: time).data
                 let radiation = try get(raw: .surface(.shortwave_radiation), time: time).data
                 return DataAndUnit(Meteorology.apparentTemperature(temperature_2m: temperature, relativehumidity_2m: relhum, windspeed_10m: windspeed, shortware_radiation: radiation), .celsius)
             case .evapotranspiration:
@@ -442,7 +447,7 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 return DataAndUnit(evapotranspiration, .millimeter)
             case .vapor_pressure_deficit:
                 let temperature = try get(raw: .surface(.temperature_2m), time: time).data
-                let rh = try get(raw: .surface(.relativehumidity_2m), time: time).data
+                let rh = try get(derived: .surface(.relativehumidity_2m), time: time).data
                 let dewpoint = zip(temperature,rh).map(Meteorology.dewpoint)
                 return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kiloPascal)
             case .et0_fao_evapotranspiration:
@@ -450,7 +455,7 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 let swrad = try get(raw: .surface(.shortwave_radiation), time: time).data
                 let temperature = try get(raw: .surface(.temperature_2m), time: time).data
                 let windspeed = try get(derived: .surface(.windspeed_10m), time: time).data
-                let rh = try get(raw: .surface(.relativehumidity_2m), time: time).data
+                let rh = try get(derived: .surface(.relativehumidity_2m), time: time).data
                 let dewpoint = zip(temperature,rh).map(Meteorology.dewpoint)
                 
                 let et0 = swrad.indices.map { i in
@@ -472,7 +477,7 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 })
                 return DataAndUnit(rain, .millimeter)
             case .relativehumitidy_2m:
-                return try get(raw: .surface(.relativehumidity_2m), time: time)
+                return try get(derived: .surface(.relativehumidity_2m), time: time)
             case .pressure_msl:
                 let temperature = try get(raw: .surface(.temperature_2m), time: time).data
                 let pressure_surface = try get(raw: .surface(.surface_pressure), time: time)
@@ -487,7 +492,7 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 return DataAndUnit(solar, .wattPerSquareMeter)
             case .dewpoint_2m:
                 let temperature = try get(raw: .surface(.temperature_2m), time: time)
-                let rh = try get(raw: .surface(.relativehumidity_2m), time: time)
+                let rh = try get(derived: .surface(.relativehumidity_2m), time: time)
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
             case .shortwave_radiation_instant:
                 let sw = try get(raw: .surface(.shortwave_radiation), time: time)
@@ -533,6 +538,11 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                     visibilityMeters: visibility,
                     modelDtHours: time.dtSeconds / 3600), .wmoCode
                 )
+            case .relativehumidity_2m:
+                let temperature = try get(raw: .surface(.temperature_2m), time: time)
+                let pressure = try get(raw: .surface(.surface_pressure), time: time)
+                let q = try get(raw: .surface(.specific_humidity_2m), time: time)
+                return DataAndUnit(Meteorology.specificToRelativeHumidity(specificHumidity: q.data, temperature: temperature.data, pressure: pressure.data), .percent)
             }
         case .pressure(let v):
             switch v.variable {
@@ -657,7 +667,7 @@ extension GfsMixer {
                 try prefetchData(raw: .temperature_2m, time: time)
                 try prefetchData(raw: .wind_u_component_10m, time: time)
                 try prefetchData(raw: .wind_v_component_10m, time: time)
-                try prefetchData(raw: .relativehumidity_2m, time: time)
+                try prefetchData(variable: .derived(.surface(.relativehumidity_2m)), time: time)
                 try prefetchData(raw: .shortwave_radiation, time: time)
             case .precipitation_sum:
                 try prefetchData(raw: .precipitation, time: time)
@@ -682,7 +692,7 @@ extension GfsMixer {
             case .et0_fao_evapotranspiration:
                 try prefetchData(raw: .shortwave_radiation, time: time)
                 try prefetchData(raw: .temperature_2m, time: time)
-                try prefetchData(raw: .relativehumidity_2m, time: time)
+                try prefetchData(variable: .derived(.surface(.relativehumidity_2m)), time: time)
                 try prefetchData(raw: .wind_u_component_10m, time: time)
                 try prefetchData(raw: .wind_v_component_10m, time: time)
             case .snowfall_sum:

--- a/Sources/App/Gfs/GfsController.swift
+++ b/Sources/App/Gfs/GfsController.swift
@@ -212,7 +212,7 @@ enum GfsVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case vapor_pressure_deficit
     case snowfall
     case rain
-    case surface_pressure
+    case pressure_msl
     case terrestrial_radiation
     case terrestrial_radiation_instant
     case weathercode
@@ -359,8 +359,8 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
             case .snowfall:
                 try prefetchData(raw: .surface(.frozen_precipitation_percent), time: time)
                 try prefetchData(raw: .surface(.precipitation), time: time)
-            case .surface_pressure:
-                try prefetchData(raw: .surface(.pressure_msl), time: time)
+            case .pressure_msl:
+                try prefetchData(raw: .surface(.surface_pressure), time: time)
                 try prefetchData(raw: .surface(.temperature_2m), time: time)
             case .terrestrial_radiation:
                 break
@@ -473,10 +473,10 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 return DataAndUnit(rain, .millimeter)
             case .relativehumitidy_2m:
                 return try get(raw: .surface(.relativehumidity_2m), time: time)
-            case .surface_pressure:
+            case .pressure_msl:
                 let temperature = try get(raw: .surface(.temperature_2m), time: time).data
-                let pressure = try get(raw: .surface(.pressure_msl), time: time)
-                return DataAndUnit(Meteorology.surfacePressure(temperature: temperature, pressure: pressure.data, elevation: reader.targetElevation), pressure.unit)
+                let pressure_surface = try get(raw: .surface(.surface_pressure), time: time)
+                return DataAndUnit(Meteorology.sealevelPressure(temperature: temperature, pressure: pressure_surface.data, elevation: reader.targetElevation), pressure_surface.unit)
             case .terrestrial_radiation:
                 /// Use center averaged
                 let solar = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)

--- a/Sources/App/Gfs/GfsDomain.swift
+++ b/Sources/App/Gfs/GfsDomain.swift
@@ -377,7 +377,7 @@ enum GfsPressureVariableType: String, CaseIterable {
     case geopotential_height
     case cloudcover
     case relativehumidity
-    //case vertical_velocity
+    case vertical_velocity
 }
 
 
@@ -413,6 +413,9 @@ struct GfsPressureVariable: PressureVariableRespresentable, GenericVariable, Has
             return (0.2..<1).interpolated(atFraction: (0..<800).fraction(of: Float(level)))
         case .relativehumidity:
             return (0.2..<1).interpolated(atFraction: (0..<800).fraction(of: Float(level)))
+        case .vertical_velocity:
+            // Use scalefactor 3 for levels higher than 500 hPa.
+            return (3..<10).interpolated(atFraction: (500..<1000).fraction(of: Float(level)))
         }
     }
     
@@ -436,6 +439,8 @@ struct GfsPressureVariable: PressureVariableRespresentable, GenericVariable, Has
             return .percent
         case .relativehumidity:
             return .percent
+        case .vertical_velocity:
+            return .ms_not_unit_converted
         }
     }
     

--- a/Sources/App/Gfs/GfsDomain.swift
+++ b/Sources/App/Gfs/GfsDomain.swift
@@ -3,7 +3,8 @@ import SwiftPFor2D
 
 
 /**
- GFS inventory: https://www.nco.ncep.noaa.gov/pmb/products/gfs/gfs.t00z.pgrb2.0p25.f003.shtml
+ GFS025 inventory: https://www.nco.ncep.noaa.gov/pmb/products/gfs/gfs.t00z.pgrb2.0p25.f003.shtml
+ GFS013 inventory: https://www.nco.ncep.noaa.gov/pmb/products/gfs/gfs.t00z.sfluxgrbf001.grib2.shtml
  NAM inventory: https://www.nco.ncep.noaa.gov/pmb/products/nam/nam.t00z.conusnest.hiresf06.tm00.grib2.shtml
  HRR inventory: https://www.nco.ncep.noaa.gov/pmb/products/hrrr/hrrr.t00z.wrfprsf02.grib2.shtml
  
@@ -232,12 +233,6 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
     /// CSNOW categorical snow as percent (0-100)
     case frozen_precipitation_percent
     
-    /// CFRZR
-    case categorical_freezing_rain
-    
-    /// CICEP
-    case categorical_ice_pellets
-    
     //case rain
     //case snowfall_convective_water_equivalent
     //case snowfall_water_equivalent
@@ -305,8 +300,6 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .pressure_msl: return 10
         case .shortwave_radiation: return 1
         case .frozen_precipitation_percent: return 1
-        case .categorical_freezing_rain: return 1
-        case .categorical_ice_pellets: return 1
         case .cape: return 0.1
         case .lifted_index: return 10
         case .visibility: return 0.05 // 50 meter
@@ -358,8 +351,6 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .pressure_msl: return .hectoPascal
         case .shortwave_radiation: return .wattPerSquareMeter
         case .frozen_precipitation_percent: return .percent
-        case .categorical_freezing_rain: return .percent
-        case .categorical_ice_pellets: return .percent
         case .cape: return .joulesPerKilogram
         case .lifted_index: return .dimensionless
         case .visibility: return .meter

--- a/Sources/App/Gfs/GfsDomain.swift
+++ b/Sources/App/Gfs/GfsDomain.swift
@@ -414,8 +414,7 @@ struct GfsPressureVariable: PressureVariableRespresentable, GenericVariable, Has
         case .relativehumidity:
             return (0.2..<1).interpolated(atFraction: (0..<800).fraction(of: Float(level)))
         case .vertical_velocity:
-            // Use scalefactor 3 for levels higher than 500 hPa.
-            return (3..<10).interpolated(atFraction: (500..<1000).fraction(of: Float(level)))
+            return (10..<20).interpolated(atFraction: (0..<500).fraction(of: Float(level)))
         }
     }
     

--- a/Sources/App/Gfs/GfsDomain.swift
+++ b/Sources/App/Gfs/GfsDomain.swift
@@ -201,7 +201,7 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
     case cloudcover_low
     case cloudcover_mid
     case cloudcover_high
-    case pressure_msl
+    case surface_pressure
     case relativehumidity_2m
     
     /// accumulated since forecast start
@@ -297,7 +297,7 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .windgusts_10m: return 10
         case .freezinglevel_height:  return 0.1 // zero height 10 meter resolution
         case .showers: return 10
-        case .pressure_msl: return 10
+        case .surface_pressure: return 10
         case .shortwave_radiation: return 1
         case .frozen_precipitation_percent: return 1
         case .cape: return 0.1
@@ -348,7 +348,7 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .showers: return .millimeter
         case .windgusts_10m: return .ms
         case .freezinglevel_height: return .meter
-        case .pressure_msl: return .hectoPascal
+        case .surface_pressure: return .hectoPascal
         case .shortwave_radiation: return .wattPerSquareMeter
         case .frozen_precipitation_percent: return .percent
         case .cape: return .joulesPerKilogram

--- a/Sources/App/Gfs/GfsDomain.swift
+++ b/Sources/App/Gfs/GfsDomain.swift
@@ -203,7 +203,7 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
     case cloudcover_high
     case surface_pressure
     
-    case specific_humidity_2m
+    case relativehumidity_2m
     
     /// accumulated since forecast start
     case precipitation
@@ -278,7 +278,7 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .cloudcover_low: return 1
         case .cloudcover_mid: return 1
         case .cloudcover_high: return 1
-        case .specific_humidity_2m: return 5
+        case .relativehumidity_2m: return 1
         case .precipitation: return 10
         case .wind_v_component_10m: return 10
         case .wind_u_component_10m: return 10
@@ -329,7 +329,7 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .cloudcover_low: return .percent
         case .cloudcover_mid: return .percent
         case .cloudcover_high: return .percent
-        case .specific_humidity_2m: return .gramPerKilogram
+        case .relativehumidity_2m: return .percent
         case .precipitation: return .millimeter
         case .wind_v_component_10m: return .ms
         case .wind_u_component_10m: return .ms
@@ -377,6 +377,7 @@ enum GfsPressureVariableType: String, CaseIterable {
     case geopotential_height
     case cloudcover
     case relativehumidity
+    //case vertical_velocity
 }
 
 

--- a/Sources/App/Gfs/GfsDomain.swift
+++ b/Sources/App/Gfs/GfsDomain.swift
@@ -414,7 +414,7 @@ struct GfsPressureVariable: PressureVariableRespresentable, GenericVariable, Has
         case .relativehumidity:
             return (0.2..<1).interpolated(atFraction: (0..<800).fraction(of: Float(level)))
         case .vertical_velocity:
-            return (10..<20).interpolated(atFraction: (0..<500).fraction(of: Float(level)))
+            return (20..<100).interpolated(atFraction: (0..<500).fraction(of: Float(level)))
         }
     }
     

--- a/Sources/App/Gfs/GfsDomain.swift
+++ b/Sources/App/Gfs/GfsDomain.swift
@@ -202,7 +202,8 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
     case cloudcover_mid
     case cloudcover_high
     case surface_pressure
-    case relativehumidity_2m
+    
+    case specific_humidity_2m
     
     /// accumulated since forecast start
     case precipitation
@@ -277,7 +278,7 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .cloudcover_low: return 1
         case .cloudcover_mid: return 1
         case .cloudcover_high: return 1
-        case .relativehumidity_2m: return 1
+        case .specific_humidity_2m: return 5
         case .precipitation: return 10
         case .wind_v_component_10m: return 10
         case .wind_u_component_10m: return 10
@@ -328,7 +329,7 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .cloudcover_low: return .percent
         case .cloudcover_mid: return .percent
         case .cloudcover_high: return .percent
-        case .relativehumidity_2m: return .percent
+        case .specific_humidity_2m: return .gramPerKilogram
         case .precipitation: return .millimeter
         case .wind_v_component_10m: return .ms
         case .wind_u_component_10m: return .ms

--- a/Sources/App/Gfs/GfsDownload.swift
+++ b/Sources/App/Gfs/GfsDownload.swift
@@ -201,7 +201,7 @@ struct GfsDownload: AsyncCommandFix {
                     fatalError("stepType=acc not supported")
                 }
                 
-                //try data.writeNetcdf(filename: "\(domain.downloadDirectory)\(variable.omFileName)_\(forecastHour).nc")
+                //try grib2d.array.writeNetcdf(filename: "\(domain.downloadDirectory)\(variable.variable.rawValue)_\(forecastHour).nc")
                 let file = "\(domain.downloadDirectory)\(variable.variable.omFileName)_\(forecastHour)\(prefix).fpg"
                 try FileManager.default.removeItemIfExists(at: file)
                 

--- a/Sources/App/Gfs/GfsDownload.swift
+++ b/Sources/App/Gfs/GfsDownload.swift
@@ -192,7 +192,7 @@ struct GfsDownload: AsyncCommandFix {
                         let deltaHours = Float(currentStep - startStep)
                         let deltaHoursPrevious = Float(previous.step - startStep)
                         for l in previous.data.indices {
-                            grib2d.array.data[l] = grib2d.array.data[l] * deltaHours - previous.data[l] * deltaHoursPrevious
+                            grib2d.array.data[l] = (grib2d.array.data[l] * deltaHours - previous.data[l] * deltaHoursPrevious) / (deltaHours - deltaHoursPrevious)
                         }
                     }
                 }

--- a/Sources/App/Gfs/GfsVariableDownloadable.swift
+++ b/Sources/App/Gfs/GfsVariableDownloadable.swift
@@ -284,6 +284,20 @@ extension GfsPressureVariable: GfsVariableDownloadable {
             return ":TCDC:\(level) mb:"
         case .relativehumidity:
             return ":RH:\(level) mb:"
+        case .vertical_velocity:
+            switch domain {
+            case .gfs013:
+                return nil
+            case .gfs025:
+                // Vertical Velocity (Geometric) [m/s]
+                return ":DZDT:\(level) mb:"
+            case .hrrr_conus:
+                // Vertical Velocity (Pressure) [Pa/s]
+                // Converted later while downlading
+                return ":VVEL:\(level) mb:"
+            case .gfs025_ensemble:
+                return nil
+            }
         }
     }
     

--- a/Sources/App/Gfs/GfsVariableDownloadable.swift
+++ b/Sources/App/Gfs/GfsVariableDownloadable.swift
@@ -59,8 +59,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
                 fallthrough
             case .soil_temperature_100_to_200cm:
                 return nil
-            case .surface_pressure:
-                return nil
             case .uv_index:
                 return nil
             case .uv_index_clear_sky:

--- a/Sources/App/Gfs/GfsVariableDownloadable.swift
+++ b/Sources/App/Gfs/GfsVariableDownloadable.swift
@@ -95,8 +95,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
                 return nil
             case .visibility:
                 return nil
-            case .snow_depth:
-                return nil // somehow only NaNs in gfs013
             default: break
             }
         }

--- a/Sources/App/Gfs/GfsVariableDownloadable.swift
+++ b/Sources/App/Gfs/GfsVariableDownloadable.swift
@@ -69,6 +69,9 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         
         if domain == .gfs013 {
             switch self {
+            case .relativehumidity_2m:
+                // Download specific humidity and convert it later
+                return ":SPFH:2 m above ground:"
             case .wind_u_component_80m:
                 return nil
             case .wind_v_component_80m:
@@ -107,8 +110,8 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
             return ":HCDC:high cloud layer:"
         case .surface_pressure:
             return ":PRES:surface:"
-        case .specific_humidity_2m:
-            return ":SPFH:2 m above ground:"
+        case .relativehumidity_2m:
+            return ":RH:2 m above ground:"
         case .precipitation:
             // PRATE:surface:6-7 hour ave fcst:
             return ":PRATE:surface:"
@@ -195,7 +198,7 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         case .cloudcover_low: return .hermite(bounds: 0...100)
         case .cloudcover_mid: return .hermite(bounds: 0...100)
         case .cloudcover_high: return .hermite(bounds: 0...100)
-        case .specific_humidity_2m: return .hermite(bounds: 0...1000)
+        case .relativehumidity_2m: return .hermite(bounds: 0...100)
         case .precipitation: return .nearest
         case .wind_v_component_10m: return .hermite(bounds: nil)
         case .wind_u_component_10m: return .hermite(bounds: nil)
@@ -242,8 +245,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
             return (1, -273.15)
         case .soil_temperature_100_to_200cm:
             return (1, -273.15)
-        case .specific_humidity_2m:
-            return (1000, 0) // kg/kg to g/kg
         case .showers:
             return (3600, 0)
         case .precipitation:

--- a/Sources/App/Gfs/GfsVariableDownloadable.swift
+++ b/Sources/App/Gfs/GfsVariableDownloadable.swift
@@ -71,8 +71,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         
         if domain == .gfs013 {
             switch self {
-            case .relativehumidity_2m: // only specific humidity
-                return nil
             case .wind_u_component_80m:
                 return nil
             case .wind_v_component_80m:
@@ -111,8 +109,8 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
             return ":HCDC:high cloud layer:"
         case .surface_pressure:
             return ":PRES:surface:"
-        case .relativehumidity_2m:
-            return ":RH:2 m above ground:"
+        case .specific_humidity_2m:
+            return ":SPFH:2 m above ground:"
         case .precipitation:
             // PRATE:surface:6-7 hour ave fcst:
             return ":PRATE:surface:"
@@ -199,7 +197,7 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         case .cloudcover_low: return .hermite(bounds: 0...100)
         case .cloudcover_mid: return .hermite(bounds: 0...100)
         case .cloudcover_high: return .hermite(bounds: 0...100)
-        case .relativehumidity_2m: return .hermite(bounds: 0...100)
+        case .specific_humidity_2m: return .hermite(bounds: 0...1000)
         case .precipitation: return .nearest
         case .wind_v_component_10m: return .hermite(bounds: nil)
         case .wind_u_component_10m: return .hermite(bounds: nil)
@@ -246,6 +244,8 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
             return (1, -273.15)
         case .soil_temperature_100_to_200cm:
             return (1, -273.15)
+        case .specific_humidity_2m:
+            return (1000, 0) // kg/kg to g/kg
         case .showers:
             return (3600, 0)
         case .precipitation:

--- a/Sources/App/Gfs/GfsVariableDownloadable.swift
+++ b/Sources/App/Gfs/GfsVariableDownloadable.swift
@@ -59,7 +59,7 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
                 fallthrough
             case .soil_temperature_100_to_200cm:
                 return nil
-            case .pressure_msl:
+            case .surface_pressure:
                 return nil
             case .uv_index:
                 return nil
@@ -71,9 +71,7 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         
         if domain == .gfs013 {
             switch self {
-            case .pressure_msl:
-                return nil // only specific humidity
-            case .relativehumidity_2m:
+            case .relativehumidity_2m: // only specific humidity
                 return nil
             case .wind_u_component_80m:
                 return nil
@@ -111,8 +109,8 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
             return ":MCDC:middle cloud layer:"
         case .cloudcover_high:
             return ":HCDC:high cloud layer:"
-        case .pressure_msl:
-            return ":PRMSL:mean sea level:"
+        case .surface_pressure:
+            return ":PRES:surface:"
         case .relativehumidity_2m:
             return ":RH:2 m above ground:"
         case .precipitation:
@@ -224,7 +222,7 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         case .wind_v_component_80m: return .hermite(bounds: nil)
         case .wind_u_component_80m: return .hermite(bounds: nil)
         case .showers: return .nearest
-        case .pressure_msl: return .hermite(bounds: nil)
+        case .surface_pressure: return .hermite(bounds: nil)
         case .frozen_precipitation_percent: return .nearest
         case .diffuse_radiation: return .solar_backwards_averaged
         case .cape: return .hermite(bounds: 0...1e9)
@@ -238,7 +236,7 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         switch self {
         case .temperature_2m:
             return (1, -273.15)
-        case .pressure_msl:
+        case .surface_pressure:
             return (1/100, 0)
         case .soil_temperature_0_to_10cm:
             return (1, -273.15)

--- a/Sources/App/Gfs/GfsVariableDownloadable.swift
+++ b/Sources/App/Gfs/GfsVariableDownloadable.swift
@@ -4,13 +4,11 @@ protocol GfsVariableDownloadable: GenericVariable {
     func skipHour0(for domain: GfsDomain) -> Bool
     var interpolationType: Interpolation2StepType { get }
     var multiplyAdd: (multiply: Float, add: Float)? { get }
-    var isAveragedOverForecastTime: Bool { get }
-    var isAccumulatedSinceModelStart: Bool { get }
 }
 
 extension GfsSurfaceVariable: GfsVariableDownloadable {
     func gribIndexName(for domain: GfsDomain) -> String? {
-        // NAM has eoms different definitons
+        // NAM has different definitons
         /*if domain == .nam_conus {
             switch variable {
             case .lifted_index:
@@ -77,10 +75,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
                 return nil // only specific humidity
             case .relativehumidity_2m:
                 return nil
-            case .precipitation:
-                return nil // only PRATE grib code
-            case .showers:
-                return nil
             case .wind_u_component_80m:
                 return nil
             case .wind_v_component_80m:
@@ -139,7 +133,8 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         case .relativehumidity_2m:
             return ":RH:2 m above ground:"
         case .precipitation:
-            return ":APCP:surface:0-"
+            // PRATE:surface:6-7 hour ave fcst:
+            return ":PRATE:surface:"
         case .wind_v_component_10m:
             return ":VGRD:10 m above ground:"
         case .wind_u_component_10m:
@@ -171,7 +166,7 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         case .latent_heatflux:
             return ":LHTFL:surface:"
         case .showers:
-            return ":ACPCP:surface:0-"
+            return ":CPRAT:surface:"
         case .windgusts_10m:
             return ":GUST:surface:"
         case .freezinglevel_height:
@@ -228,7 +223,7 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         case .cloudcover_mid: return .hermite(bounds: 0...100)
         case .cloudcover_high: return .hermite(bounds: 0...100)
         case .relativehumidity_2m: return .hermite(bounds: 0...100)
-        case .precipitation: return .linear
+        case .precipitation: return .nearest
         case .wind_v_component_10m: return .hermite(bounds: nil)
         case .wind_u_component_10m: return .hermite(bounds: nil)
         case .snow_depth: return .linear
@@ -249,7 +244,7 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         case .soil_moisture_100_to_200cm: return .hermite(bounds: nil)
         case .wind_v_component_80m: return .hermite(bounds: nil)
         case .wind_u_component_80m: return .hermite(bounds: nil)
-        case .showers: return .linear
+        case .showers: return .nearest
         case .pressure_msl: return .hermite(bounds: nil)
         case .frozen_precipitation_percent: return .nearest
         case .categorical_ice_pellets: return .nearest
@@ -282,6 +277,10 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
             return (100, 0)
         case .categorical_ice_pellets:
             return (100, 0)
+        case .showers:
+            return (3600, 0)
+        case .precipitation:
+            return (3600, 0)
         case .uv_index:
             fallthrough
         case .uv_index_clear_sky:
@@ -291,28 +290,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
             return (18.9 * 0.025, 0)
         default:
             return nil
-        }
-    }
-    
-    var isAveragedOverForecastTime: Bool {
-        switch self {
-        case .shortwave_radiation: return true
-        case .diffuse_radiation: return true
-        case .sensible_heatflux: return true
-        case .latent_heatflux: return true
-        case .uv_index:
-            return true
-        case .uv_index_clear_sky:
-            return true
-        default: return false
-        }
-    }
-    
-    var isAccumulatedSinceModelStart: Bool {
-        switch self {
-        case .precipitation: fallthrough
-        case .showers: return true
-        default: return false
         }
     }
 }
@@ -361,13 +338,5 @@ extension GfsPressureVariable: GfsVariableDownloadable {
         default:
             return nil
         }
-    }
-    
-    var isAveragedOverForecastTime: Bool {
-        return false
-    }
-    
-    var isAccumulatedSinceModelStart: Bool {
-        return false
     }
 }

--- a/Sources/App/Gfs/GfsVariableDownloadable.swift
+++ b/Sources/App/Gfs/GfsVariableDownloadable.swift
@@ -83,12 +83,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
                 return nil
             case .freezinglevel_height:
                 return nil
-            case .frozen_precipitation_percent:
-                return nil
-            case .categorical_ice_pellets:
-                return nil
-            case .categorical_freezing_rain:
-                return nil
             case .cape:
                 return nil
             case .lifted_index:
@@ -104,15 +98,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
             if self.gribIndexName(for: .gfs013) != nil {
                 return nil
             }
-            /*switch self {
-            case .uv_index:
-                return nil
-            case .uv_index_clear_sky:
-                return nil
-            case .diffuse_radiation:
-                return nil
-            default: break
-            }*/
         }
         
         switch self {
@@ -172,11 +157,7 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         case .shortwave_radiation:
             return ":DSWRF:surface:"
         case .frozen_precipitation_percent:
-            return ":CSNOW:surface:"
-        case .categorical_freezing_rain:
-            return ":CFRZR:surface:"
-        case .categorical_ice_pellets:
-            return ":CICEP:surface:"
+            return ":CPOFP:surface"
         case .cape:
             return ":CAPE:surface:"
         case .lifted_index:
@@ -245,8 +226,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
         case .showers: return .nearest
         case .pressure_msl: return .hermite(bounds: nil)
         case .frozen_precipitation_percent: return .nearest
-        case .categorical_ice_pellets: return .nearest
-        case .categorical_freezing_rain: return .nearest
         case .diffuse_radiation: return .solar_backwards_averaged
         case .cape: return .hermite(bounds: 0...1e9)
         case .lifted_index: return .hermite(bounds: 0...1e9)
@@ -269,12 +248,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
             return (1, -273.15)
         case .soil_temperature_100_to_200cm:
             return (1, -273.15)
-        case .frozen_precipitation_percent:
-            return (100, 0)
-        case .categorical_freezing_rain:
-            return (100, 0)
-        case .categorical_ice_pellets:
-            return (100, 0)
         case .showers:
             return (3600, 0)
         case .precipitation:

--- a/Sources/App/Helper/Array2DInterpolation.swift
+++ b/Sources/App/Helper/Array2DInterpolation.swift
@@ -4,7 +4,7 @@ import Foundation
 enum Interpolation2StepType {
     // Simple linear interpolation
     case linear
-    // Just copy the next value
+    // Just copy the next value. Which means it is backwards filled. n+1 = n
     case nearest
     // Use solar radiation interpolation
     case solar_backwards_averaged

--- a/Sources/App/Helper/Meteorology.swift
+++ b/Sources/App/Helper/Meteorology.swift
@@ -201,6 +201,23 @@ struct Meteorology {
         }
     }
     
+    /// Convert pressure vertical velocity `omega` (Pa/s) to geometric vertical velocity `w` (m/s)
+    /// See https://www.ncl.ucar.edu/Document/Functions/Contributed/omega_to_w.shtml
+    /// Temperature in Celsius
+    /// PressureLevel in hPa e.g. 1000
+    public static func verticalVelocityPressureToGeometric(omega: [Float], temperature: [Float], pressureLevel: Float) -> [Float] {
+        
+        let p = pressureLevel * 100
+        let rgas: Float = 287.058 // J/(kg-K) => m2/(s2 K)
+        let g: Float    = 9.80665            // m/s2
+        return zip(omega, temperature).map { (omega, temperature) in
+            let t = temperature + 273.15
+            let  rho  = p/(rgas*t)         // density => kg/m3
+            let w    = -omega/(rho*g)     // array operation
+            return w
+        }
+    }
+    
     /// Calculate upper level clouds from relative humidity using Sundqvist et al. (1989):
     /// See https://www.ecmwf.int/sites/default/files/elibrary/2005/16958-parametrization-cloud-cover.pdf
     /// https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2018MS001400  chapter 3.1

--- a/Sources/App/Helper/Meteorology.swift
+++ b/Sources/App/Helper/Meteorology.swift
@@ -52,7 +52,7 @@ struct Meteorology {
         return -1 * speed * cos(directionDegree.degreesToRadians)
     }
     
-    /// Calculate mea nsea level pressure, corrected by temperature.
+    /// Calculate mean sea level pressure, corrected by temperature.
     static func sealevelPressure(temperature: [Float], pressure: [Float], elevation: Float) -> [Float] {
         precondition(temperature.count == pressure.count)
         

--- a/Sources/App/Helper/Time/Time.swift
+++ b/Sources/App/Helper/Time/Time.swift
@@ -75,7 +75,7 @@ public struct Timestamp: Hashable {
         if str.count < 10 {
             return Timestamp(year, month, day)
         }
-        guard let hour = Int(str[8..<10]), hour >= 0, day <= 23 else {
+        guard let hour = Int(str[8..<10]), hour >= 0, hour <= 23 else {
             throw TimeError.InvalidDate
         }
         if str.count < 12 {

--- a/Sources/App/Icon/Icon.swift
+++ b/Sources/App/Icon/Icon.swift
@@ -451,7 +451,7 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
         case .snowfall_height:
             return 0.1
         case .updraft:
-            return 20
+            return 100
         }
     }
     

--- a/Sources/App/Icon/Icon.swift
+++ b/Sources/App/Icon/Icon.swift
@@ -622,7 +622,7 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
         case .direct_radiation:
             return .solar_backwards_averaged
         case .updraft:
-            return .hermite(bounds: 0...200)
+            return .hermite(bounds: nil)
         }
     }
     

--- a/Sources/App/Icon/Icon.swift
+++ b/Sources/App/Icon/Icon.swift
@@ -451,7 +451,7 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
         case .snowfall_height:
             return 0.1
         case .updraft:
-            return 10
+            return 20
         }
     }
     

--- a/Sources/App/Icon/IconVariableDownloadable.swift
+++ b/Sources/App/Icon/IconVariableDownloadable.swift
@@ -97,7 +97,7 @@ extension IconSurfaceVariable: IconVariableDownloadable {
         case .snowfall_height:
             return .hermite(bounds: nil)
         case .updraft:
-            return .hermite(bounds: 0...200)
+            return .hermite(bounds: nil)
         }
     }
     

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -27,6 +27,7 @@ extension Application {
         }
         // try again with very high timeouts, so only the curl internal timers are used
         let configuration = HTTPClient.Configuration(
+            redirectConfiguration: .follow(max: 5, allowCycles: false),
             timeout: .init(connect: .seconds(30), read: .minutes(5)),
             connectionPool: .init(idleTimeout: .minutes(10)))
         

--- a/Sources/CTurboPFor/src/vsimple.c
+++ b/Sources/CTurboPFor/src/vsimple.c
@@ -38,6 +38,7 @@
 
 #include "conf.h"
 #include "vsimple.h"
+#include <string.h>
 
   #ifdef __ARM_NEON
 #define PREFETCH(_ip_,_rw_)


### PR DESCRIPTION
This PR uses more surface variables from GFS013 instead of GFS025:
- Precipitation, showers and snow fall
- Surface level pressure -> pressure mean sea level is now calculated on demand in the API code
- Relative humidity calculated from specific humidity
- Vertical velocity (geometric) in m/s

Memory consumption of the GFS013 downloader code will be increased by 50 MB to keep temporary results in memory

see #259