### PR TITLE
Use ICON-EU side runs with updates every 3 hours

### DIFF
--- a/Sources/App/Commands/CronjobCommand.swift
+++ b/Sources/App/Commands/CronjobCommand.swift
@@ -14,16 +14,16 @@ struct CronjobCommand: Command {
         print("""
         MAILTO=info@open-meteo.com
         37 2,8,14,20  * * * /usr/local/bin/openmeteo-api download icon --group surface > ~/log/icon.log 2>&1 || cat ~/log/icon.log
-        36 2,8,14,20  * * * /usr/local/bin/openmeteo-api download icon-eu --group surface > ~/log/icon-eu.log 2>&1 || cat ~/log/icon-eu.log
+        36 2,5,8,11,14,17,20,23  * * * /usr/local/bin/openmeteo-api download icon-eu --group surface > ~/log/icon-eu.log 2>&1 || cat ~/log/icon-eu.log
         44 0,3,6,9,12,15,18,21 * * * /usr/local/bin/openmeteo-api download icon-d2 --group surface > ~/log/icon-d2.log 2>&1 || cat ~/log/icon-d2.log
         
         37 2,8,14,20  * * * /usr/local/bin/openmeteo-api download icon --group pressureLevelGt500 > ~/log/icon_upper-levelgt500.log 2>&1 || cat ~/log/icon_upper-levelgt500.log
         37 2,8,14,20  * * * /usr/local/bin/openmeteo-api download icon --group pressureLevelLtE500 > ~/log/icon_upper-levellte500.log 2>&1 || cat ~/log/icon_upper-levellte500.log
-        36 2,8,14,20  * * * /usr/local/bin/openmeteo-api download icon-eu --group pressureLevel > ~/log/icon-eu_upper-level.log 2>&1 || cat ~/log/icon-eu_upper-level.log
+        36 2,5,8,11,14,17,20,23  * * * /usr/local/bin/openmeteo-api download icon-eu --group pressureLevel > ~/log/icon-eu_upper-level.log 2>&1 || cat ~/log/icon-eu_upper-level.log
         44 0,3,6,9,12,15,18,21 * * * /usr/local/bin/openmeteo-api download icon-d2 --group pressureLevel > ~/log/icon-d2_upper-level.log 2>&1 || cat ~/log/icon-d2_upper-level.log
         
         37 2,8,14,20  * * * /usr/local/bin/openmeteo-api download icon --group modelLevel > ~/log/icon_model-level.log 2>&1 || cat ~/log/icon_model-level.log
-        36 2,8,14,20  * * * /usr/local/bin/openmeteo-api download icon-eu --group modelLevel > ~/log/icon-eu_model-level.log 2>&1 || cat ~/log/icon-eu_model-level.log
+        36 2,5,8,11,14,17,20,23  * * * /usr/local/bin/openmeteo-api download icon-eu --group modelLevel > ~/log/icon-eu_model-level.log 2>&1 || cat ~/log/icon-eu_model-level.log
         44 0,3,6,9,12,15,18,21 * * * /usr/local/bin/openmeteo-api download icon-d2 --group modelLevel > ~/log/icon-d2_model-level.log 2>&1 || cat ~/log/icon-d2_model-level.log
         
         45  7,19 * * * /usr/local/bin/openmeteo-api download-ecmwf > ~/log/ecmwf.log 2>&1 || cat ~/log/ecmwf.log

--- a/Sources/App/Icon/DownloadIconCommand.swift
+++ b/Sources/App/Icon/DownloadIconCommand.swift
@@ -419,10 +419,12 @@ extension IconDomains {
     fileprivate var lastRun: Timestamp {
         let t = Timestamp.now()
         switch self {
-        case .icon: fallthrough
-        case .iconEu:
-            // Icon has a delay of 2-3 hours after initialisation
+        case .icon:
+            // Icon has a delay of 2-3 hours after initialisation  with 4 runs a day
             return t.with(hour: ((t.hour - 2 + 24) % 24) / 6 * 6)
+        case .iconEu:
+            // Icon-eu has a delay of 2:40 hours after initialisation with 8 runs a day
+            return t.with(hour: ((t.hour - 2 + 24) % 24) / 3 * 3)
         case .iconD2:
             // Icon d2 has a delay of 44 minutes and runs every 3 hours
             return t.with(hour: t.hour / 3 * 3)

--- a/Sources/App/Icon/Icon.swift
+++ b/Sources/App/Icon/Icon.swift
@@ -137,9 +137,18 @@ enum IconDomains: String, CaseIterable, GenericDomain {
             } else {
                 return 180+1
             }
-        case .iconEu: return 120+1
-        case .iconD2_15min: return 48*4
-        case .iconD2: return 48+1
+        case .iconEu:
+            if run % 6 == 0 {
+                // full runs
+                return 120+1
+            } else {
+                // ICON-EU sideruns at 3,9,15,21 have 31x 1-hourly values and 3x 6-hourly steps (6 hourly steps are ignored)
+                return 30+1
+            }
+        case .iconD2_15min:
+            return 48*4
+        case .iconD2:
+            return 48+1
         }
     }
     
@@ -155,9 +164,16 @@ enum IconDomains: String, CaseIterable, GenericDomain {
                 // full 180
                 return Array(0...78) + Array(stride(from: 81, through: 180, by: 3))
             }
-        case .iconEu: return Array(0...78) + Array(stride(from: 81, through: 120, by: 3))
-        case .iconD2_15min: return Array(0...48*4-1)
-        case .iconD2: return Array(0...48)
+        case .iconEu:
+            if run % 6 == 0 {
+                return Array(0...78) + Array(stride(from: 81, through: 120, by: 3))
+            }
+            // side runs
+            return Array(0...30)
+        case .iconD2_15min:
+            return Array(0...48*4-1)
+        case .iconD2:
+            return Array(0...48)
         }
     }
 


### PR DESCRIPTION
Use ICON-EU side runs with updates every 3 hours instead of 6 hourly updates. 6-hourly updates only offer 31 10-hourly values. 

Although 6 hourly time steps are available until +51 hours since initialisation, due to 6-hourly resolution they do not provide much benefit. Thus only 31 hours are used.

Using 3h sideburns, should improve current weather conditions as well as a better assimilated historical time-series. They will however make it more difficult for #206.