### PR TITLE
Optimise ensemble model storage

### DIFF
--- a/Sources/App/Cams/CamsDomain.swift
+++ b/Sources/App/Cams/CamsDomain.swift
@@ -83,8 +83,8 @@ enum CamsVariable: String, CaseIterable, GenericVariable, GenericVariableMixable
     case olive_pollen
     case ragweed_pollen
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var interpolation: ReaderInterpolation {

--- a/Sources/App/Cmip6/CmipDownloader.swift
+++ b/Sources/App/Cmip6/CmipDownloader.swift
@@ -349,8 +349,8 @@ enum Cmip6Variable: String, CaseIterable, GenericVariable, GenericVariableMixabl
         return false
     }
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var interpolation: ReaderInterpolation {

--- a/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
+++ b/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
@@ -139,7 +139,7 @@ struct DownloadEcmwfCommand: AsyncCommandFix {
             logger.info("Downloading hour \(hour)")
             
             let variables = variables.filter { variable in
-                let file = "\(downloadDirectory)\(variable.omFileName)_\(hour).om"
+                let file = "\(downloadDirectory)\(variable.omFileName.file)_\(hour).om"
                 return !skipFilesIfExisting || FileManager.default.fileExists(atPath: file)
             }
             if variables.isEmpty {
@@ -190,7 +190,7 @@ struct DownloadEcmwfCommand: AsyncCommandFix {
                 }
                 
                 let memberStr = member > 0 ? "_\(member)" : ""
-                let file = "\(downloadDirectory)\(variable.omFileName)_\(hour)\(memberStr).om"
+                let file = "\(downloadDirectory)\(variable.omFileName.file)_\(hour)\(memberStr).om"
                 try FileManager.default.removeItemIfExists(at: file)
                 
                 let compression = variable.isAccumulatedSinceModelStart ? CompressionType.fpxdec32 : .p4nzdec256
@@ -225,7 +225,7 @@ struct DownloadEcmwfCommand: AsyncCommandFix {
             for member in 0..<members {
                 let memberStr = member > 0 ? "_\(member)" : ""
                 let readers: [(hour: Int, reader: OmFileReader<MmapFile>)] = try forecastSteps.compactMap({ hour in
-                    let reader = try OmFileReader(file: "\(downloadDirectory)\(variable.omFileName)_\(hour)\(memberStr).om")
+                    let reader = try OmFileReader(file: "\(downloadDirectory)\(variable.omFileName.file)_\(hour)\(memberStr).om")
                     try reader.willNeed()
                     return (hour, reader)
                 })
@@ -237,7 +237,7 @@ struct DownloadEcmwfCommand: AsyncCommandFix {
                     return hour
                 }
                 
-                try om.updateFromTimeOrientedStreaming(variable: "\(variable.omFileName)\(memberStr)", indexTime: time.toIndexTime(), skipFirst: skip, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { d0offset in
+                try om.updateFromTimeOrientedStreaming(variable: "\(variable.omFileName.file)\(memberStr)", indexTime: time.toIndexTime(), skipFirst: skip, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { d0offset in
                     
                     let locationRange = d0offset ..< min(d0offset+nLocationsPerChunk, nLocations)
                     data2d.data.fillWithNaNs()

--- a/Sources/App/Ecmwf/EcmwfDomain.swift
+++ b/Sources/App/Ecmwf/EcmwfDomain.swift
@@ -70,7 +70,7 @@ enum EcmwfDomain: String, GenericDomain {
         return RegularGrid(nx: 900, ny: 451, latMin: -90, lonMin: -180, dx: 360/900, dy: 180/450)
     }
     
-    var ensembleMembers: Int? {
+    var ensembleMembers: Int {
         switch self {
         case .ifs04:
             return 1

--- a/Sources/App/Ecmwf/EcmwfVariable.swift
+++ b/Sources/App/Ecmwf/EcmwfVariable.swift
@@ -91,8 +91,8 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
     
     static let pressure_levels = [1000, 925, 850, 700, 500, 300, 250, 200, 50]
     
-    var omFileName: String {
-        return nameInFiles
+    var omFileName: (file: String, level: Int) {
+        return (nameInFiles, 0)
     }
     
     var nameInFiles: String {

--- a/Sources/App/Era5/CerraDomain.swift
+++ b/Sources/App/Era5/CerraDomain.swift
@@ -265,8 +265,8 @@ enum CerraVariable: String, CaseIterable, GenericVariable {
         return self == .temperature_2m
     }
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var interpolation: ReaderInterpolation {

--- a/Sources/App/Era5/DownloadEra5Command.swift
+++ b/Sources/App/Era5/DownloadEra5Command.swift
@@ -871,7 +871,7 @@ struct DownloadEra5Command: AsyncCommandFix {
             }
             
             // chunk 6 locations and 21 days of data
-            try om.updateFromTimeOrientedStreaming(variable: variable.omFileName, indexTime: indexTime, skipFirst: 0, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { dim0 in
+            try om.updateFromTimeOrientedStreaming(variable: variable.omFileName.file, indexTime: indexTime, skipFirst: 0, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { dim0 in
                 /// Process around 20 MB memory at once
                 let locationRange = dim0..<min(dim0+Self.nLocationsPerChunk, domain.grid.count)
                 

--- a/Sources/App/Era5/Era5Domain.swift
+++ b/Sources/App/Era5/Era5Domain.swift
@@ -31,8 +31,8 @@ enum Era5Variable: String, CaseIterable, GenericVariable {
         return self == .temperature_2m || self == .dewpoint_2m
     }
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var requiresOffsetCorrectionForMixing: Bool {

--- a/Sources/App/Gem/GemDownloader.swift
+++ b/Sources/App/Gem/GemDownloader.swift
@@ -166,7 +166,7 @@ struct GemDownload: AsyncCommandFix {
                 if !variable.includedFor(hour: hour, domain: domain) {
                     continue
                 }
-                let filenameDest = "\(downloadDirectory)\(variable.omFileName)_\(h3).om"
+                let filenameDest = "\(downloadDirectory)\(variable.omFileName.file)_\(h3).om"
                 if skipFilesIfExisting && FileManager.default.fileExists(atPath: filenameDest) {
                     continue
                 }
@@ -176,7 +176,7 @@ struct GemDownload: AsyncCommandFix {
                 for message in try await curl.downloadGrib(url: url, bzip2Decode: false) {
                     let member = message.get(attribute: "perturbationNumber").flatMap(Int.init) ?? 0
                     let memberStr = member > 0 ? "_\(member)" : ""
-                    let filenameDest = "\(downloadDirectory)\(variable.omFileName)_\(h3)\(memberStr).om"
+                    let filenameDest = "\(downloadDirectory)\(variable.omFileName.file)_\(h3)\(memberStr).om"
                     //try message.debugGrid(grid: domain.grid, flipLatidude: false, shift180Longitude: true)
                     //fatalError()
                     try grib2d.load(message: message)
@@ -191,7 +191,7 @@ struct GemDownload: AsyncCommandFix {
                         grib2d.array.data.multiplyAdd(multiply: fma.multiply, add: fma.add)
                     }
                     
-                    //try grib2d.array.writeNetcdf(filename: "\(domain.downloadDirectory)\(variable.omFileName)_\(h3)\(memberStr).nc")
+                    //try grib2d.array.writeNetcdf(filename: "\(domain.downloadDirectory)\(variable.omFileName.file)_\(h3)\(memberStr).nc")
                     let compression = variable.isAccumulatedSinceModelStart ? CompressionType.fpxdec32 : .p4nzdec256
                     try writer.write(file: filenameDest, compressionType: compression, scalefactor: variable.scalefactor, all: grib2d.array.data)
                 }
@@ -234,12 +234,12 @@ struct GemDownload: AsyncCommandFix {
                         return nil
                     }
                     let h3 = hour.zeroPadded(len: 3)
-                    let reader = try OmFileReader(file: "\(downloadDirectory)\(variable.omFileName)_\(h3)\(memberStr).om")
+                    let reader = try OmFileReader(file: "\(downloadDirectory)\(variable.omFileName.file)_\(h3)\(memberStr).om")
                     try reader.willNeed()
                     return (hour, reader)
                 })
                 
-                try om.updateFromTimeOrientedStreaming(variable: "\(variable.omFileName)\(memberStr)", indexTime: time.toIndexTime(), skipFirst: skip, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { d0offset in
+                try om.updateFromTimeOrientedStreaming(variable: "\(variable.omFileName.file)\(memberStr)", indexTime: time.toIndexTime(), skipFirst: skip, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { d0offset in
                     
                     let locationRange = d0offset ..< min(d0offset+nLocationsPerChunk, nLocations)
                     data2d.data.fillWithNaNs()

--- a/Sources/App/Gem/GemVariable.swift
+++ b/Sources/App/Gem/GemVariable.swift
@@ -242,8 +242,8 @@ enum GemSurfaceVariable: String, CaseIterable, GemVariableDownloadable, GenericV
         }
     }
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var scalefactor: Float {
@@ -469,8 +469,8 @@ struct GemPressureVariable: PressureVariableRespresentable, GemVariableDownloada
         return false
     }
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     func gribName(domain: GemDomain) -> String? {
         let isbl = (domain == .gem_hrdps_continental || domain == .gem_global_ensemble) ? "ISBL_\(level.zeroPadded(len: 4))" : "ISBL_\(level)"

--- a/Sources/App/Gfs/GfsDownload.swift
+++ b/Sources/App/Gfs/GfsDownload.swift
@@ -380,7 +380,7 @@ struct GfsDownload: AsyncCommandFix {
 
                 
                 progress.add(locationRange.count * nMembers)
-                return data3d.data[0..<(locationRange.count * nMembers) * nTime]
+                return data3d.data[0..<locationRange.count * nMembers * nTime]
             }
             progress.finish()
         }

--- a/Sources/App/Gfs/GfsVariable.swift
+++ b/Sources/App/Gfs/GfsVariable.swift
@@ -85,8 +85,8 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         }
     }
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var scalefactor: Float {
@@ -298,8 +298,8 @@ struct GfsPressureVariable: PressureVariableRespresentable, GenericVariable, Has
         return false
     }
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var scalefactor: Float {

--- a/Sources/App/GloFas/GloFasDownloader.swift
+++ b/Sources/App/GloFas/GloFasDownloader.swift
@@ -514,8 +514,8 @@ enum GloFasDomain: String, GenericDomain, CaseIterable {
 enum GloFasVariable: String, GenericVariable {
     case river_discharge
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var scalefactor: Float {

--- a/Sources/App/Helper/Array2D.swift
+++ b/Sources/App/Helper/Array2D.swift
@@ -290,3 +290,81 @@ public struct Array2DFastTime {
         }
     }
 }
+
+public struct Array3DFastTime {
+    public var data: [Float]
+    public let nLocations: Int
+    public let nLevel: Int
+    public let nTime: Int
+    
+    public init(data: [Float], nLocations: Int, nLevel: Int, nTime: Int) {
+        if (data.count != nLocations * nTime * nLevel) {
+            fatalError("Wrong Array2DFastTime dimensions. nLocations=\(nLocations) nLevel=\(nLevel) nTime=\(nTime) count=\(data.count)")
+        }
+        self.data = data
+        self.nLocations = nLocations
+        self.nLevel = nLevel
+        self.nTime = nTime
+    }
+    
+    public init(nLocations: Int, nLevel: Int, nTime: Int) {
+        self.data = .init(repeating: .nan, count: nLocations * nTime * nLevel)
+        self.nLocations = nLocations
+        self.nTime = nTime
+        self.nLevel = nLevel
+    }
+    
+    @inlinable subscript(location: Int, level: Int, time: Int) -> Float {
+        get {
+            precondition(location < nLocations, "location subscript invalid: \(location) with nLocations=\(nLocations)")
+            precondition(level < nLevel, "level subscript invalid: \(level) with nLevel=\(nLevel)")
+            precondition(time < nTime, "time subscript invalid: \(time) with nTime=\(nTime)")
+            return data[location * nTime * nLevel + level * nTime + time]
+        }
+        set {
+            precondition(location < nLocations, "location subscript invalid: \(location) with nLocations=\(nLocations)")
+            precondition(level < nLevel, "level subscript invalid: \(level) with nLevel=\(nLevel)")
+            precondition(time < nTime, "time subscript invalid: \(time) with nTime=\(nTime)")
+            data[location * nTime * nLevel + level * nTime + time] = newValue
+        }
+    }
+    
+    @inlinable subscript(location: Int, level: Int, time: Range<Int>) -> ArraySlice<Float> {
+        get {
+            precondition(location < nLocations, "location subscript invalid: \(location) with nLocations=\(nLocations)")
+            precondition(level < nLevel, "level subscript invalid: \(level) with nLevel=\(nLevel)")
+            precondition(time.upperBound <= nTime, "time subscript invalid: \(time) with nTime=\(nTime)")
+            return data[time.add(location * nTime * nLevel + level * nTime)]
+        }
+        set {
+            precondition(location < nLocations, "location subscript invalid: \(location) with nLocations=\(nLocations)")
+            precondition(level < nLevel, "level subscript invalid: \(level) with nLevel=\(nLevel)")
+            precondition(time.upperBound <= nTime, "time subscript invalid: \(time) with nTime=\(nTime)")
+            data[time.add(location * nTime * nLevel + level * nTime)] = newValue
+        }
+    }
+    
+    /// One spatial field into time-series array
+    @inlinable subscript(location: Range<Int>, level: Int, time: Int) -> [Float] {
+        get {
+            precondition(location.upperBound <= nLocations, "location subscript invalid: \(location) with nLocations=\(nLocations)")
+            precondition(level < nLevel, "level subscript invalid: \(level) with nLevel=\(nLevel)")
+            precondition(time < nTime, "time subscript invalid: \(nTime) with nTime=\(nTime)")
+            var out = [Float]()
+            out.reserveCapacity(location.count)
+            for loc in location {
+                out.append(self[loc, level, time])
+            }
+            return out
+        }
+        set {
+            precondition(location.upperBound <= nLocations, "location subscript invalid: \(location) with nLocations=\(nLocations)")
+            precondition(level < nLevel, "level subscript invalid: \(level) with nLevel=\(nLevel)")
+            precondition(time < nTime, "time subscript invalid: \(nTime) with nTime=\(nTime)")
+            precondition(newValue.count == location.count, "Array and location count do not match")
+            for (loc, value) in zip(location, newValue) {
+                data[loc * nTime * nLevel + level * nTime + time] = value
+            }
+        }
+    }
+}

--- a/Sources/App/Helper/Array2DInterpolation.swift
+++ b/Sources/App/Helper/Array2DInterpolation.swift
@@ -26,6 +26,18 @@ extension Array3DFastTime {
         d2.interpolate1Step(interpolation: interpolation, interpolationHours: interpolationHours, width: width, time: time, grid: grid, locationRange: locationRange)
         data = d2.data
     }
+    
+    mutating func deaccumulateOverTime(slidingWidth: Int, slidingOffset: Int) {
+        var d2 = Array2DFastTime(data: data, nLocations: nLocations*nLevel, nTime: nTime)
+        d2.deaccumulateOverTime(slidingWidth: slidingWidth, slidingOffset: slidingOffset)
+        data = d2.data
+    }
+    
+    mutating func deavergeOverTime(slidingWidth: Int, slidingOffset: Int) {
+        var d2 = Array2DFastTime(data: data, nLocations: nLocations*nLevel, nTime: nTime)
+        d2.deavergeOverTime(slidingWidth: slidingWidth, slidingOffset: slidingOffset)
+        data = d2.data
+    }
 }
 
 

--- a/Sources/App/Helper/PressureVariableRespresentable.swift
+++ b/Sources/App/Helper/PressureVariableRespresentable.swift
@@ -91,7 +91,7 @@ extension SurfaceAndPressureVariable: GenericVariable where Surface: GenericVari
         }
     }
     
-    var omFileName: String {
+    var omFileName: (file: String, level: Int) {
         asGenericVariable.omFileName
     }
     

--- a/Sources/App/Helper/Reader/GenericDomain.swift
+++ b/Sources/App/Helper/Reader/GenericDomain.swift
@@ -38,8 +38,8 @@ extension GenericDomain {
  Generic variable for the reader implementation
  */
 protocol GenericVariable: GenericVariableMixable {
-    /// The filename of the variable. Typically just `temperature_2m`
-    var omFileName: String { get }
+    /// The filename of the variable. Typically just `temperature_2m`. Level is used to store mutliple levels or ensemble members in one file
+    var omFileName: (file: String, level: Int) { get }
     
     /// The scalefactor to compress data
     var scalefactor: Float { get }

--- a/Sources/App/Helper/Reader/GenericReader.swift
+++ b/Sources/App/Helper/Reader/GenericReader.swift
@@ -85,12 +85,12 @@ struct GenericReader<Domain: GenericDomain, Variable: GenericVariable>: GenericR
     
     /// Prefetch data asynchronously. At the time `read` is called, it might already by in the kernel page cache.
     func prefetchData(variable: Variable, time: TimerangeDt) throws {
-        try omFileSplitter.willNeed(variable: variable.omFileName, location: position..<position+1, time: time)
+        try omFileSplitter.willNeed(variable: variable.omFileName.file, location: position..<position+1, level: variable.omFileName.level, time: time)
     }
     
     /// Read and scale if required
     private func readAndScale(variable: Variable, time: TimerangeDt) throws -> DataAndUnit {
-        var data = try omFileSplitter.read(variable: variable.omFileName, location: position..<position+1, time: time)
+        var data = try omFileSplitter.read(variable: variable.omFileName.file, location: position..<position+1, level: variable.omFileName.level, time: time)
         
         /// Scale pascal to hecto pasal. Case in era5
         if variable.unit == .pascal {

--- a/Sources/App/Icon/DownloadIconCommand.swift
+++ b/Sources/App/Icon/DownloadIconCommand.swift
@@ -129,7 +129,7 @@ struct DownloadIconCommand: AsyncCommandFix {
                 
                 let url = "\(serverPrefix)\(v.variable)/\(filenameFrom)"
                 
-                let filenameDest = "single-level_\(h3)_\(variable.omFileName.uppercased()).fpg"
+                let filenameDest = "single-level_\(h3)_\(variable.omFileName.file.uppercased()).fpg"
                 if skipFilesIfExisting && FileManager.default.fileExists(atPath: "\(downloadDirectory)\(filenameDest)") {
                     continue
                 }
@@ -141,7 +141,7 @@ struct DownloadIconCommand: AsyncCommandFix {
                     try FileManager.default.createDirectory(atPath: downloadDirectory, withIntermediateDirectories: true)
                     for (i, message) in messages.enumerated() {
                         let h3 = (hour*4+i).zeroPadded(len: 3)
-                        let filenameDest = "single-level_\(h3)_\(variable.omFileName.uppercased()).fpg"
+                        let filenameDest = "single-level_\(h3)_\(variable.omFileName.file.uppercased()).fpg"
                         try grib2d.load(message: message)
                         var data = grib2d.array.data
                         try FileManager.default.removeItemIfExists(at: "\(downloadDirectory)\(filenameDest)")
@@ -158,7 +158,7 @@ struct DownloadIconCommand: AsyncCommandFix {
                 for (i, message) in messages.enumerated() {
                     try grib2d.load(message: message)
                     let memberStr = i > 0 ? "_\(i)" : ""
-                    let filenameDest = "single-level_\(h3)_\(variable.omFileName.uppercased())\(memberStr).fpg"
+                    let filenameDest = "single-level_\(h3)_\(variable.omFileName.file.uppercased())\(memberStr).fpg"
                     
                     // Write data as encoded floats to disk
                     try FileManager.default.removeItemIfExists(at: "\(downloadDirectory)\(filenameDest)")
@@ -210,7 +210,7 @@ struct DownloadIconCommand: AsyncCommandFix {
             guard variable.getVarAndLevel(domain: domain) != nil else {
                 continue
             }
-            let v = variable.omFileName.uppercased()
+            let v = variable.omFileName.file.uppercased()
             let skip = variable.skipHour(hour: 0, domain: domain, forDownload: false, run: run) ? 1 : 0
             
             // For ICON-EPS, `direct radiation` only contains 3-hourly data. Remove them from `forecastSteps` for interpolation
@@ -231,7 +231,7 @@ struct DownloadIconCommand: AsyncCommandFix {
                     return (hour, reader)
                 })
                 
-                try om.updateFromTimeOrientedStreaming(variable: "\(variable.omFileName)\(memberStr)", indexTime: time.toIndexTime(), skipFirst: skip, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { d0offset in
+                try om.updateFromTimeOrientedStreaming(variable: "\(variable.omFileName.file)\(memberStr)", indexTime: time.toIndexTime(), skipFirst: skip, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { d0offset in
                     
                     let locationRange = d0offset ..< min(d0offset+nLocationsPerChunk, nLocations)
                     data2d.data.fillWithNaNs()

--- a/Sources/App/Icon/IconVariable.swift
+++ b/Sources/App/Icon/IconVariable.swift
@@ -17,8 +17,8 @@ struct IconPressureVariable: PressureVariableRespresentable, Hashable, GenericVa
         return false
     }
     
-    var omFileName: String {
-        rawValue
+    var omFileName: (file: String, level: Int) {
+        (rawValue, 0)
     }
     
     var scalefactor: Float {
@@ -319,8 +319,8 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
     }
     
     /// Name in dwd filenames
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var interpolation: ReaderInterpolation {

--- a/Sources/App/IconWave/IconWaveDomain.swift
+++ b/Sources/App/IconWave/IconWaveDomain.swift
@@ -101,8 +101,8 @@ enum IconWaveVariable: String, CaseIterable, GenericVariable, GenericVariableMix
         return false
     }
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     /// Name used on the dwd open data server

--- a/Sources/App/IconWave/IconWaveDownload.swift
+++ b/Sources/App/IconWave/IconWaveDownload.swift
@@ -133,7 +133,7 @@ struct DownloadIconWaveCommand: AsyncCommandFix {
                 return (hour, reader)
             })
             
-            try om.updateFromTimeOrientedStreaming(variable: variable.omFileName, indexTime: time.toIndexTime(), skipFirst: skip, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { d0offset in
+            try om.updateFromTimeOrientedStreaming(variable: variable.omFileName.file, indexTime: time.toIndexTime(), skipFirst: skip, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { d0offset in
                 
                 let locationRange = d0offset ..< min(d0offset+nLocationsPerChunk, nLocations)
                 data2d.data.fillWithNaNs()

--- a/Sources/App/MetNo/MetNoDomain.swift
+++ b/Sources/App/MetNo/MetNoDomain.swift
@@ -77,8 +77,8 @@ enum MetNoVariable: String, CaseIterable, GenericVariable, GenericVariableMixabl
         return false
     }
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var scalefactor: Float {

--- a/Sources/App/MetNo/MetNoDownloader.swift
+++ b/Sources/App/MetNo/MetNoDownloader.swift
@@ -135,7 +135,7 @@ struct MetNoDownloader: AsyncCommandFix {
             
             /// Create chunked time-series arrays instead of transposing the entire array
             let progress = ProgressTracker(logger: logger, total: nLocations, label: "Convert \(variable.rawValue)")
-            try om.updateFromTimeOrientedStreaming(variable: variable.omFileName, indexTime: time.toIndexTime(), skipFirst: skip, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { d0offset in
+            try om.updateFromTimeOrientedStreaming(variable: variable.omFileName.file, indexTime: time.toIndexTime(), skipFirst: skip, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { d0offset in
                 
                 let locationRange = d0offset ..< min(d0offset+nLocationsPerChunk, nLocations)
                 var data2d = Array2DFastTime(nLocations: locationRange.count, nTime: nTime)
@@ -159,7 +159,7 @@ struct MetNoDownloader: AsyncCommandFix {
             progress.finish()
             
             if createNetcdf {
-                try spatial.writeNetcdf(filename: "\(domain.downloadDirectory)\(variable.omFileName).nc", nx: nx, ny: ny)
+                try spatial.writeNetcdf(filename: "\(domain.downloadDirectory)\(variable.omFileName.file).nc", nx: nx, ny: ny)
             }
         }
     }

--- a/Sources/App/MeteoFrance/MeteoFranceDomain.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDomain.swift
@@ -227,8 +227,8 @@ enum MeteoFranceSurfaceVariable: String, CaseIterable, GenericVariable, GenericV
         return false
     }
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var scalefactor: Float {
@@ -359,8 +359,8 @@ struct MeteoFrancePressureVariable: PressureVariableRespresentable, GenericVaria
         return false
     }
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var scalefactor: Float {

--- a/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
@@ -157,7 +157,7 @@ struct MeteoFranceDownload: AsyncCommandFix {
                         if h == 0 && variable.skipHour0(domain: domain) {
                             return []
                         }
-                        let file = "\(domain.downloadDirectory)\(variable.omFileName)_\(h).om"
+                        let file = "\(domain.downloadDirectory)\(variable.omFileName.file)_\(h).om"
                         if skipFilesIfExisting && FileManager.default.fileExists(atPath: file) {
                             return []
                         }
@@ -205,10 +205,10 @@ struct MeteoFranceDownload: AsyncCommandFix {
                     }
                     
                     //try data.writeNetcdf(filename: "\(domain.downloadDirectory)\(variable.variable.omFileName)_\(variable.hour).nc")
-                    let file = "\(domain.downloadDirectory)\(variable.variable.omFileName)_\(variable.hour).om"
+                    let file = "\(domain.downloadDirectory)\(variable.variable.omFileName.file)_\(variable.hour).om"
                     try FileManager.default.removeItemIfExists(at: file)
                     
-                    logger.info("Compressing and writing data to \(variable.variable.omFileName)_\(variable.hour).om")
+                    logger.info("Compressing and writing data to \(variable.variable.omFileName.file)_\(variable.hour).om")
                     let compression = variable.variable.isAveragedOverForecastTime || variable.variable.isAccumulatedSinceModelStart ? CompressionType.fpxdec32 : .p4nzdec256
                     try writer.write(file: file, compressionType: compression, scalefactor: variable.variable.scalefactor, all: grib2d.array.data)
                 }
@@ -245,12 +245,12 @@ struct MeteoFranceDownload: AsyncCommandFix {
                 if hour == 0 && skipHour0 {
                     return nil
                 }
-                let reader = try OmFileReader(file: "\(domain.downloadDirectory)\(variable.omFileName)_\(hour).om")
+                let reader = try OmFileReader(file: "\(domain.downloadDirectory)\(variable.omFileName.file)_\(hour).om")
                 try reader.willNeed()
                 return (hour, reader)
             })
             
-            try om.updateFromTimeOrientedStreaming(variable: variable.omFileName, indexTime: time.toIndexTime(), skipFirst: skip, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { d0offset in
+            try om.updateFromTimeOrientedStreaming(variable: variable.omFileName.file, indexTime: time.toIndexTime(), skipFirst: skip, smooth: 0, skipLast: 0, scalefactor: variable.scalefactor) { d0offset in
                 
                 let locationRange = d0offset ..< min(d0offset+nLocationsPerChunk, nLocations)
                 data2d.data.fillWithNaNs()

--- a/Sources/App/SeasonalForecast/SeasonalForecastController.swift
+++ b/Sources/App/SeasonalForecast/SeasonalForecastController.swift
@@ -11,8 +11,8 @@ struct VariableAndMember<Variable: GenericVariable>: GenericVariable {
         self.member = member
     }
     
-    var omFileName: String {
-        return "\(variable.omFileName)_\(member)"
+    var omFileName: (file: String, level: Int) {
+        return variable.omFileName
     }
     
     var scalefactor: Float {
@@ -36,7 +36,7 @@ struct VariableAndMember<Variable: GenericVariable>: GenericVariable {
     }
     
     var rawValue: String {
-        "\(variable.omFileName)_\(member)"
+        "\(variable.omFileName.file)_\(member)"
     }
     
     var requiresOffsetCorrectionForMixing: Bool {
@@ -97,11 +97,8 @@ extension VariableAndMemberAndControl: Hashable, Equatable where Variable: Hasha
 }
 
 extension VariableAndMemberAndControl: GenericVariable where Variable: GenericVariable {
-    var omFileName: String {
-        if member == 0 {
-            return variable.rawValue
-        }
-        return "\(variable.omFileName)_member\(member)"
+    var omFileName: (file: String, level: Int) {
+        return (variable.omFileName.file, member)
     }
     
     var scalefactor: Float {

--- a/Sources/App/SeasonalForecast/SeasonalForecastDomains.swift
+++ b/Sources/App/SeasonalForecast/SeasonalForecastDomains.swift
@@ -206,8 +206,8 @@ enum CfsVariable: String, CaseIterable, GenericVariable {
     case relativehumidity_2m
     case pressure_msl
     
-    var omFileName: String {
-        return rawValue
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
     }
     
     var interpolation: ReaderInterpolation {


### PR DESCRIPTION
Use 3-dimensional files to store multiple ensemble members in each file. This will reduce required IOPS to read ensemble data by factor 20 to 50.