### PR TITLE
MeteoFrance: Add 20, 50, 100, 150 and 200 m above ground wind and temperature

### DIFF
--- a/Sources/App/MeteoFrance/MeteoFranceController.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceController.swift
@@ -190,12 +190,28 @@ enum MeteoFranceVariableDerivedSurface: String, CaseIterable, GenericVariableMix
     case dewpoint_2m
     case windspeed_10m
     case winddirection_10m
-    //case windspeed_80m
-    //case winddirection_80m
-    /*case windspeed_120m
+    case windspeed_20m
+    case winddirection_20m
+    case windspeed_50m
+    case winddirection_50m
+    case windspeed_100m
+    case winddirection_100m
+    case windspeed_150m
+    case winddirection_150m
+    case windspeed_200m
+    case winddirection_200m
+    /// Is using 100m wind
+    case windspeed_80m
+    case winddirection_80m
+    /// Is using 150m wind
+    case windspeed_120m
     case winddirection_120m
+    /// Is using 200m wind
     case windspeed_180m
-    case winddirection_180m*/
+    case winddirection_180m
+    case temperature_80m
+    case temperature_120m
+    case temperature_180m
     case direct_normal_irradiance
     case direct_normal_irradiance_instant
     case direct_radiation
@@ -399,6 +415,49 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(variable: .windgusts_10m, time: time)
             case .is_day:
                 break
+            case .windspeed_20m:
+                fallthrough
+            case .winddirection_20m:
+                try prefetchData(variable: .wind_u_component_20m, time: time)
+                try prefetchData(variable: .wind_v_component_20m, time: time)
+            case .windspeed_50m:
+                fallthrough
+            case .winddirection_50m:
+                try prefetchData(variable: .wind_u_component_50m, time: time)
+                try prefetchData(variable: .wind_v_component_50m, time: time)
+            case .windspeed_80m:
+                fallthrough
+            case .winddirection_80m:
+                fallthrough
+            case .windspeed_100m:
+                fallthrough
+            case .winddirection_100m:
+                try prefetchData(variable: .wind_u_component_100m, time: time)
+                try prefetchData(variable: .wind_v_component_100m, time: time)
+            case .windspeed_120m:
+                fallthrough
+            case .winddirection_120m:
+                fallthrough
+            case .windspeed_150m:
+                fallthrough
+            case .winddirection_150m:
+                try prefetchData(variable: .wind_u_component_150m, time: time)
+                try prefetchData(variable: .wind_v_component_150m, time: time)
+            case .windspeed_180m:
+                fallthrough
+            case .winddirection_180m:
+                fallthrough
+            case .windspeed_200m:
+                fallthrough
+            case .winddirection_200m:
+                try prefetchData(variable: .wind_u_component_200m, time: time)
+                try prefetchData(variable: .wind_v_component_200m, time: time)
+            case .temperature_80m:
+                try prefetchData(variable: .temperature_100m, time: time)
+            case .temperature_120m:
+                try prefetchData(variable: .temperature_150m, time: time)
+            case .temperature_180m:
+                try prefetchData(variable: .temperature_200m, time: time)
             }
         case .pressure(let v):
             switch v.variable {
@@ -521,6 +580,74 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 )
             case .is_day:
                 return DataAndUnit(Zensun.calculateIsDay(timeRange: time, lat: reader.modelLat, lon: reader.modelLon), .dimensionless_integer)
+            case .windspeed_20m:
+                let u = try get(raw: .wind_u_component_20m, time: time).data
+                let v = try get(raw: .wind_v_component_20m, time: time).data
+                let speed = zip(u,v).map(Meteorology.windspeed)
+                return DataAndUnit(speed, .ms)
+            case .winddirection_20m:
+                let u = try get(raw: .wind_u_component_20m, time: time).data
+                let v = try get(raw: .wind_v_component_20m, time: time).data
+                let direction = Meteorology.windirectionFast(u: u, v: v)
+                return DataAndUnit(direction, .degreeDirection)
+            case .windspeed_50m:
+                let u = try get(raw: .wind_u_component_50m, time: time).data
+                let v = try get(raw: .wind_v_component_50m, time: time).data
+                let speed = zip(u,v).map(Meteorology.windspeed)
+                return DataAndUnit(speed, .ms)
+            case .winddirection_50m:
+                let u = try get(raw: .wind_u_component_50m, time: time).data
+                let v = try get(raw: .wind_v_component_50m, time: time).data
+                let direction = Meteorology.windirectionFast(u: u, v: v)
+                return DataAndUnit(direction, .degreeDirection)
+            case .windspeed_80m:
+                fallthrough
+            case .windspeed_100m:
+                let u = try get(raw: .wind_u_component_100m, time: time).data
+                let v = try get(raw: .wind_v_component_100m, time: time).data
+                let speed = zip(u,v).map(Meteorology.windspeed)
+                return DataAndUnit(speed, .ms)
+            case .winddirection_80m:
+                fallthrough
+            case .winddirection_100m:
+                let u = try get(raw: .wind_u_component_100m, time: time).data
+                let v = try get(raw: .wind_v_component_100m, time: time).data
+                let direction = Meteorology.windirectionFast(u: u, v: v)
+                return DataAndUnit(direction, .degreeDirection)
+            case .windspeed_120m:
+                fallthrough
+            case .windspeed_150m:
+                let u = try get(raw: .wind_u_component_150m, time: time).data
+                let v = try get(raw: .wind_v_component_150m, time: time).data
+                let speed = zip(u,v).map(Meteorology.windspeed)
+                return DataAndUnit(speed, .ms)
+            case .winddirection_120m:
+                fallthrough
+            case .winddirection_150m:
+                let u = try get(raw: .wind_u_component_150m, time: time).data
+                let v = try get(raw: .wind_v_component_150m, time: time).data
+                let direction = Meteorology.windirectionFast(u: u, v: v)
+                return DataAndUnit(direction, .degreeDirection)
+            case .windspeed_180m:
+                fallthrough
+            case .windspeed_200m:
+                let u = try get(raw: .wind_u_component_200m, time: time).data
+                let v = try get(raw: .wind_v_component_200m, time: time).data
+                let speed = zip(u,v).map(Meteorology.windspeed)
+                return DataAndUnit(speed, .ms)
+            case .winddirection_180m:
+                fallthrough
+            case .winddirection_200m:
+                let u = try get(raw: .wind_u_component_200m, time: time).data
+                let v = try get(raw: .wind_v_component_200m, time: time).data
+                let direction = Meteorology.windirectionFast(u: u, v: v)
+                return DataAndUnit(direction, .degreeDirection)
+            case .temperature_80m:
+                return try get(raw: .temperature_100m, time: time)
+            case .temperature_120m:
+                return try get(raw: .temperature_150m, time: time)
+            case .temperature_180m:
+                return try get(raw: .temperature_200m, time: time)
             }
         case .pressure(let v):
             switch v.variable {

--- a/Sources/App/MeteoFrance/MeteoFranceDomain.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDomain.swift
@@ -212,6 +212,29 @@ enum MeteoFranceSurfaceVariable: String, CaseIterable, GenericVariable, GenericV
     case wind_v_component_10m
     case wind_u_component_10m
     
+    /**
+     Avaibility of upper level variables (U. VGRD, RH, TMP):
+     - Arome HD, `HP1`, 20, 50 and 100 m (no TMP)
+     - Arome france `HP1`, 20, 35,  50, 75, 100, 150, 200, 250, 375, 500, 625, 750, 875, 1000, 1125, 1250, 1375, 1500, 2000, 2250, 2500, 2750, 3000
+     - Arpege, same as arome france
+     */
+    case wind_v_component_20m
+    case wind_u_component_20m
+    case wind_v_component_50m
+    case wind_u_component_50m
+    case wind_v_component_100m
+    case wind_u_component_100m
+    case wind_v_component_150m
+    case wind_u_component_150m
+    case wind_v_component_200m
+    case wind_u_component_200m
+    
+    case temperature_20m
+    case temperature_50m
+    case temperature_100m
+    case temperature_150m
+    case temperature_200m
+    
     /// accumulated since forecast start
     case precipitation
    
@@ -261,6 +284,36 @@ enum MeteoFranceSurfaceVariable: String, CaseIterable, GenericVariable, GenericV
             return 10
         case .wind_u_component_10m:
             return 10
+        case .wind_v_component_20m:
+            fallthrough
+        case .wind_u_component_20m:
+            fallthrough
+        case .wind_v_component_50m:
+            fallthrough
+        case .wind_u_component_50m:
+            fallthrough
+        case .wind_v_component_100m:
+            fallthrough
+        case .wind_u_component_100m:
+            fallthrough
+        case .wind_v_component_150m:
+            fallthrough
+        case .wind_u_component_150m:
+            fallthrough
+        case .wind_v_component_200m:
+            fallthrough
+        case .wind_u_component_200m:
+            return 10
+        case .temperature_20m:
+            fallthrough
+        case .temperature_50m:
+            fallthrough
+        case .temperature_100m:
+            fallthrough
+        case .temperature_150m:
+            fallthrough
+        case .temperature_200m:
+            return 20
         }
     }
     
@@ -294,6 +347,36 @@ enum MeteoFranceSurfaceVariable: String, CaseIterable, GenericVariable, GenericV
             return .solar_backwards_averaged
         case .cape:
             return .hermite(bounds: 0...10e9)
+        case .wind_v_component_20m:
+            fallthrough
+        case .wind_u_component_20m:
+            fallthrough
+        case .wind_v_component_50m:
+            fallthrough
+        case .wind_u_component_50m:
+            fallthrough
+        case .wind_v_component_100m:
+            fallthrough
+        case .wind_u_component_100m:
+            fallthrough
+        case .wind_v_component_150m:
+            fallthrough
+        case .wind_u_component_150m:
+            fallthrough
+        case .wind_v_component_200m:
+            fallthrough
+        case .wind_u_component_200m:
+            return .hermite(bounds: nil)
+        case .temperature_20m:
+            fallthrough
+        case .temperature_50m:
+            fallthrough
+        case .temperature_100m:
+            fallthrough
+        case .temperature_150m:
+            fallthrough
+        case .temperature_200m:
+            return .hermite(bounds: nil)
         }
     }
     
@@ -327,11 +410,56 @@ enum MeteoFranceSurfaceVariable: String, CaseIterable, GenericVariable, GenericV
             return .ms
         case .wind_u_component_10m:
             return .ms
+        case .wind_v_component_20m:
+            fallthrough
+        case .wind_u_component_20m:
+            fallthrough
+        case .wind_v_component_50m:
+            fallthrough
+        case .wind_u_component_50m:
+            fallthrough
+        case .wind_v_component_100m:
+            fallthrough
+        case .wind_u_component_100m:
+            fallthrough
+        case .wind_v_component_150m:
+            fallthrough
+        case .wind_u_component_150m:
+            fallthrough
+        case .wind_v_component_200m:
+            fallthrough
+        case .wind_u_component_200m:
+            return .ms
+        case .temperature_20m:
+            fallthrough
+        case .temperature_50m:
+            fallthrough
+        case .temperature_100m:
+            fallthrough
+        case .temperature_150m:
+            fallthrough
+        case .temperature_200m:
+            return .celsius
         }
     }
     
     var isElevationCorrectable: Bool {
-        return self == .temperature_2m
+        switch self {
+        case .temperature_2m:
+            fallthrough
+        case .temperature_20m:
+            fallthrough
+        case .temperature_50m:
+            fallthrough
+        case .temperature_100m:
+            fallthrough
+        case .temperature_150m:
+            fallthrough
+        case .temperature_200m:
+            return true
+        default:
+            return false
+        }
     }
 }
 

--- a/Sources/App/MeteoFrance/MeteoFranceVariableDownloadable.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceVariableDownloadable.swift
@@ -22,6 +22,7 @@ enum MfVariablePackages: String, CaseIterable {
     case IP1
     case IP2
     case IP3
+    case HP1
 }
 
 extension MeteoFranceSurfaceVariable: MeteoFranceVariableDownloadable {
@@ -37,6 +38,18 @@ extension MeteoFranceSurfaceVariable: MeteoFranceVariableDownloadable {
         case .wind_u_component_10m:
             fallthrough
         case .wind_v_component_10m:
+            return true
+        case .wind_u_component_20m:
+            fallthrough
+        case .wind_v_component_20m:
+            return true
+        case .wind_u_component_50m:
+            fallthrough
+        case .wind_v_component_50m:
+            return true
+        case .wind_u_component_100m:
+            fallthrough
+        case .wind_v_component_100m:
             return true
         case .windgusts_10m:
             return true
@@ -90,6 +103,36 @@ extension MeteoFranceSurfaceVariable: MeteoFranceVariableDownloadable {
             return .SP2
         case .shortwave_radiation:
             return .SP1
+        case .wind_v_component_20m:
+            fallthrough
+        case .wind_u_component_20m:
+            fallthrough
+        case .wind_v_component_50m:
+            fallthrough
+        case .wind_u_component_50m:
+            fallthrough
+        case .wind_v_component_100m:
+            fallthrough
+        case .wind_u_component_100m:
+            fallthrough
+        case .wind_v_component_150m:
+            fallthrough
+        case .wind_u_component_150m:
+            fallthrough
+        case .wind_v_component_200m:
+            fallthrough
+        case .wind_u_component_200m:
+            fallthrough
+        case .temperature_20m:
+            fallthrough
+        case .temperature_50m:
+            fallthrough
+        case .temperature_100m:
+            fallthrough
+        case .temperature_150m:
+            fallthrough
+        case .temperature_200m:
+            return .HP1
         }
     }
     
@@ -125,6 +168,36 @@ extension MeteoFranceSurfaceVariable: MeteoFranceVariableDownloadable {
             return ":DSWRF:surface:0-\(hourOrDay) acc fcst:"
         case .cape:
             return ":CAPE:surface - 3000 m above ground:\(hourStr):"
+        case .wind_v_component_20m:
+            return "VGRD:20 m above ground:\(hourStr):"
+        case .wind_u_component_20m:
+            return "UGRD:20 m above ground:\(hourStr):"
+        case .wind_v_component_50m:
+            return "VGRD:50 m above ground:\(hourStr):"
+        case .wind_u_component_50m:
+            return "UGRD:50 m above ground:\(hourStr):"
+        case .wind_v_component_100m:
+            return "VGRD:100 m above ground:\(hourStr):"
+        case .wind_u_component_100m:
+            return "UGRD:100 m above ground:\(hourStr):"
+        case .wind_v_component_150m:
+            return "VGRD:150 m above ground:\(hourStr):"
+        case .wind_u_component_150m:
+            return "UGRD:150 m above ground:\(hourStr):"
+        case .wind_v_component_200m:
+            return "VGRD:200 m above ground:\(hourStr):"
+        case .wind_u_component_200m:
+            return "UGRD:200 m above ground:\(hourStr):"
+        case .temperature_20m:
+            return ":TMP:20 m above ground:\(hourStr):"
+        case .temperature_50m:
+            return ":TMP:50 m above ground:\(hourStr):"
+        case .temperature_100m:
+            return ":TMP:100 m above ground:\(hourStr):"
+        case .temperature_150m:
+            return ":TMP:150 m above ground:\(hourStr):"
+        case .temperature_200m:
+            return ":TMP:200 m above ground:\(hourStr):"
         }
     }
     

--- a/Tests/AppTests/SwiftPFor2DTests.swift
+++ b/Tests/AppTests/SwiftPFor2DTests.swift
@@ -39,7 +39,7 @@ final class SwiftPFor2DTests: XCTestCase {
         let file = "writetest.om"
         try FileManager.default.removeItemIfExists(at: file)
         
-        XCTAssertThrowsError(try OmFileWriter(dim0: 5, dim1: 5, chunk0: 2, chunk1: 2).write(file: file, compressionType: .p4nzdec256, scalefactor: 1, supplyChunk: { dim0pos in
+        XCTAssertThrowsError(try OmFileWriter(dim0: 5, dim1: 5, chunk0: 2, chunk1: 2).write(file: file, compressionType: .p4nzdec256, scalefactor: 1, overwrite: false, supplyChunk: { dim0pos in
             if dim0pos == 0 {
                 return ArraySlice((0..<10).map({ Float($0) }))
             }
@@ -59,7 +59,7 @@ final class SwiftPFor2DTests: XCTestCase {
         let file = "writetest.om"
         try FileManager.default.removeItemIfExists(at: file)
         
-        try OmFileWriter(dim0: 5, dim1: 5, chunk0: 2, chunk1: 2).write(file: file, compressionType: .p4nzdec256, scalefactor: 1, supplyChunk: { dim0pos in
+        try OmFileWriter(dim0: 5, dim1: 5, chunk0: 2, chunk1: 2).write(file: file, compressionType: .p4nzdec256, scalefactor: 1, overwrite: false, supplyChunk: { dim0pos in
             
             if dim0pos == 0 {
                 return ArraySlice((0..<10).map({ Float($0) }))
@@ -146,7 +146,7 @@ final class SwiftPFor2DTests: XCTestCase {
         let file = "writetest.om"
         try FileManager.default.removeItemIfExists(at: file)
         
-        try OmFileWriter(dim0: 5, dim1: 5, chunk0: 2, chunk1: 2).write(file: file, compressionType: .fpxdec32, scalefactor: 1, supplyChunk: { dim0pos in
+        try OmFileWriter(dim0: 5, dim1: 5, chunk0: 2, chunk1: 2).write(file: file, compressionType: .fpxdec32, scalefactor: 1, overwrite: false, supplyChunk: { dim0pos in
             
             if dim0pos == 0 {
                 return ArraySlice((0..<10).map({ Float($0) }))


### PR DESCRIPTION
This PR adds support for 20, 50, 100, 150 and 200 m above ground wind and temperature for MeteoFrance Arome and Arpege models.

AromeHD only include wind forecasts for level 20, 50 and 100 meters