### PR TITLE
Update getting-started.md for Ubuntu prebuild

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,6 +47,7 @@ They can be installed via APT:
 curl -L https://apt.open-meteo.com/public.key | sudo gpg --dearmour -o /etc/apt/trusted.gpg.d/openmeteo.gpg
 echo "deb [arch=amd64] https://apt.open-meteo.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/openmeteo-api.list
 sudo apt update
+sudo apt install cdo
 sudo apt install openmeteo-api
 
 # Download ECMWF


### PR DESCRIPTION
Prebuilt Ubuntu jammy packages missing cdo and icon model will failed to convert.