### PR TITLE
Increase deadLineHours for GEM and GFS model downloader

### DIFF
--- a/Sources/App/Gem/GemDownloader.swift
+++ b/Sources/App/Gem/GemDownloader.swift
@@ -159,7 +159,7 @@ struct GemDownload: AsyncCommandFix {
     /// Download data and store as compressed files for each timestep
     func download(application: Application, domain: GemDomain, variables: [GemVariableDownloadable], run: Timestamp, skipFilesIfExisting: Bool, server: String?) async throws {
         let logger = application.logger
-        let curl = Curl(logger: logger, client: application.dedicatedHttpClient, deadLineHours: domain == .gem_global_ensemble ? 10 : 5)
+        let curl = Curl(logger: logger, client: application.dedicatedHttpClient, deadLineHours: (domain == .gem_global_ensemble || domain == .gem_global) ? 11 : 5) // 12 hours and 6 hours interval so we let 1 hour for data conversion
         let downloadDirectory = domain.downloadDirectory
         let nMembers = domain.ensembleMembers
         

--- a/Sources/App/Gfs/GfsDownload.swift
+++ b/Sources/App/Gfs/GfsDownload.swift
@@ -155,15 +155,15 @@ struct GfsDownload: AsyncCommandFix {
         let deadLineHours: Double
         switch domain {
         case .gfs013:
-            deadLineHours = 4
+            deadLineHours = 5 // 6 hours interval so we let 1 hour for data conversion
         case .gfs025:
-            deadLineHours = 4
+            deadLineHours = 5
         case .hrrr_conus:
             deadLineHours = 2
         case .gfs025_ensemble:
-            deadLineHours = 4
+            deadLineHours = 5
         case .gfs025_ens:
-            deadLineHours = 4
+            deadLineHours = 5
         case .gfs05_ens:
             deadLineHours = secondFlush ? 10 : 5
         }


### PR DESCRIPTION
Increase deadLineHours for GEM and GFS model downloader, fix #428