### PR TITLE
allow --run to accept YYMMDD,RR where RR==run number

### DIFF
--- a/Sources/App/JMA/JmaDownloader.swift
+++ b/Sources/App/JMA/JmaDownloader.swift
@@ -603,6 +603,14 @@ enum JmaDomain: String, GenericDomain, CaseIterable {
 extension Timestamp {
     /// Interprete the run parameter as either a simple hour or a fully specified date
     static func fromRunHourOrYYYYMMDD(_ str: String) throws -> Timestamp {
+        if str.contains(",") {
+            let parts = str.split(separator: ",").map(String.init)
+            let year = parts[0]
+            guard let hr = Int(parts[1]) else {
+                throw TimeError.InvalidDateFromat
+            }
+            return try Timestamp.from(yyyymmdd: year).with(hour: hr)
+        }
         if str.count > 2 {
             return try Timestamp.from(yyyymmdd: str)
         }


### PR DESCRIPTION
useful for times when you want to download a run for a specific day without reference to the current wall clock time.  i.e. to reload the HRRR's last 18z run (to get all 48 hours) when the wallclock is from 19z-23z, for example.