### PR TITLE
Change enum IconVariable and Awscli installation via APT - Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -163,6 +163,8 @@ A fast way is to use:
 sudo apt-get install awscli
 aws s3 sync --no-sign-request --exclude "*" --include "Copernicus_DSM_COG_30*/*_DEM.tif" s3://copernicus-dem-90m/ dem-90m
 ```
+For further installation instructions see, [Install or update the latest version of the AWS CLI
+](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 
 Requirements: Install gdal and make sure the command `gdal_translate` is available. Mac: `brew install gdal` Linux: `apt install gdal`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,7 +103,7 @@ As a minimum requirement, ICON global should be downloaded. To download the 00 r
 
 For the first run, the ICON downloader will download additional domain geometry information and prepare reproduction weights. It might take a while.
 
-A list of all ICON weather variables that can be downloaded is available here: [IconVariables](https://github.com/open-meteo/open-meteo/blob/main/Sources/App/Icon/IconVariableDownloadable.swift#L84). To save resource on the public DWD servers, please only downloaded required weather variables.
+A list of all ICON weather variables that can be downloaded is available here: [IconVariables](https://github.com/open-meteo/open-meteo/blob/82a73573e2cb4d3dbecb972f5ce3924030b3a37e/Sources/App/Icon/IconVariable.swift#L90). To save resource on the public DWD servers, please only downloaded required weather variables.
 
 The icon download command has the following arguments:
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,7 +103,7 @@ As a minimum requirement, ICON global should be downloaded. To download the 00 r
 
 For the first run, the ICON downloader will download additional domain geometry information and prepare reproduction weights. It might take a while.
 
-A list of all ICON weather variables that can be downloaded is available here: [enum IconVariable](https://github.com/open-meteo/open-meteo/blob/main/Sources/App/Icon/Icon.swift#L173). To save resource on the public DWD servers, please only downloaded required weather variables.
+A list of all ICON weather variables that can be downloaded is available here: [IconVariables](https://github.com/open-meteo/open-meteo/blob/main/Sources/App/Icon/IconVariableDownloadable.swift). To save resource on the public DWD servers, please only downloaded required weather variables.
 
 The icon download command has the following arguments:
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,7 +103,7 @@ As a minimum requirement, ICON global should be downloaded. To download the 00 r
 
 For the first run, the ICON downloader will download additional domain geometry information and prepare reproduction weights. It might take a while.
 
-A list of all ICON weather variables that can be downloaded is available here: [IconVariables](https://github.com/open-meteo/open-meteo/blob/main/Sources/App/Icon/IconVariableDownloadable.swift). To save resource on the public DWD servers, please only downloaded required weather variables.
+A list of all ICON weather variables that can be downloaded is available here: [IconVariables](https://github.com/open-meteo/open-meteo/blob/main/Sources/App/Icon/IconVariableDownloadable.swift#L84). To save resource on the public DWD servers, please only downloaded required weather variables.
 
 The icon download command has the following arguments:
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -158,7 +158,10 @@ Options:
 ### Digital elevation model
 To download the 90 meter elevation model for the Elevation API as well as improving weather forecast accuracy, you first have to download the Copernicus DEM: https://copernicus-dem-30m.s3.amazonaws.com/readme.html
 
-A fast way is to use `aws s3 sync --no-sign-request --exclude "*" --include "Copernicus_DSM_COG_30*/*_DEM.tif" s3://copernicus-dem-90m/ dem-90m`.
+A fast way is to use ```
+sudo apt-get install awscli
+aws s3 sync --no-sign-request --exclude "*" --include "Copernicus_DSM_COG_30*/*_DEM.tif" s3://copernicus-dem-90m/ dem-90m
+```
 
 Requirements: Install gdal and make sure the command `gdal_translate` is available. Mac: `brew install gdal` Linux: `apt install gdal`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -163,8 +163,7 @@ A fast way is to use:
 sudo apt-get install awscli
 aws s3 sync --no-sign-request --exclude "*" --include "Copernicus_DSM_COG_30*/*_DEM.tif" s3://copernicus-dem-90m/ dem-90m
 ```
-For further installation instructions see, [Install or update the latest version of the AWS CLI
-](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+For further installation instructions see, [Install or update the latest version of the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 
 Requirements: Install gdal and make sure the command `gdal_translate` is available. Mac: `brew install gdal` Linux: `apt install gdal`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -158,7 +158,8 @@ Options:
 ### Digital elevation model
 To download the 90 meter elevation model for the Elevation API as well as improving weather forecast accuracy, you first have to download the Copernicus DEM: https://copernicus-dem-30m.s3.amazonaws.com/readme.html
 
-A fast way is to use ```
+A fast way is to use:
+```
 sudo apt-get install awscli
 aws s3 sync --no-sign-request --exclude "*" --include "Copernicus_DSM_COG_30*/*_DEM.tif" s3://copernicus-dem-90m/ dem-90m
 ```


### PR DESCRIPTION
## Change enum IconVariable and Awscli installation via APT - Update getting-started.md

### Description
This pull requets updates the `docs/getting-started.md` file, in which the documentation for "deployment" lifes in.

### Changes
- Updated the link for ICON weather variables from [enum IconVariable](https://github.com/open-meteo/open-meteo/blob/main/Sources/App/Icon/Icon.swift#L173) to [IconVariables](https://github.com/open-meteo/open-meteo/blob/main/Sources/App/Icon/IconVariableDownloadable.swift#L84) in the `getting-started.md` file.
- Added installation command for the `awscli`, via `sudo apt-get install awscli`

### Context
The current link was leading to the wrong/ old file, causing confusion for users trying to access the list of ICON weather variables. This change ensures that the link accurately directs users to the correct location.
The Aws S3 Bucket Sync only works, if the `awscli` is installed.