### PR TITLE
More efficient FlatBuffers encoding

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/open-meteo/sdk.git",
       "state" : {
         "branch" : "encode_as_lists",
-        "revision" : "8fde2d92fb61a68eaf4feb43a0a8ccebd9ccf9d8"
+        "revision" : "eebfe333125c2ae2e88ce2d5319b05781ad825a1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-meteo/sdk.git",
       "state" : {
-        "revision" : "ca7696ad7391c09fc5b111ed53ed8ceea755a814",
-        "version" : "1.0.10"
+        "branch" : "encode_as_lists",
+        "revision" : "8fde2d92fb61a68eaf4feb43a0a8ccebd9ccf9d8"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/open-meteo/sdk.git",
       "state" : {
         "branch" : "encode_as_lists",
-        "revision" : "eebfe333125c2ae2e88ce2d5319b05781ad825a1"
+        "revision" : "61f93255dcba4e095a1194353423834d99a6bbcf"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/open-meteo/sdk.git",
       "state" : {
         "branch" : "encode_as_lists",
-        "revision" : "61f93255dcba4e095a1194353423834d99a6bbcf"
+        "revision" : "86ebee8a51970801e02d1f9292695e9256caf33c"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-meteo/sdk.git",
       "state" : {
-        "branch" : "encode_as_lists",
-        "revision" : "e97aef99b14ecfda0e1cba4a2024962c2a2804ee"
+        "revision" : "eccba0d208c9e8fd6f6eb39ed2ad2cc78cae500f",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/open-meteo/sdk.git",
       "state" : {
         "branch" : "encode_as_lists",
-        "revision" : "86ebee8a51970801e02d1f9292695e9256caf33c"
+        "revision" : "e97aef99b14ecfda0e1cba4a2024962c2a2804ee"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.67.4"),
         .package(url: "https://github.com/google/flatbuffers.git", from: "23.3.3"),
-        .package(url: "https://github.com/open-meteo/sdk.git", from: "1.0.10"),
+        .package(url: "https://github.com/open-meteo/sdk.git", branch: "encode_as_lists"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftNetCDF.git", from: "1.0.0"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftTimeZoneLookup.git", from: "1.0.1"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftEccodes.git", from: "0.1.5"),

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.67.4"),
         .package(url: "https://github.com/google/flatbuffers.git", from: "23.3.3"),
-        .package(url: "https://github.com/open-meteo/sdk.git", branch: "encode_as_lists"),
+        .package(url: "https://github.com/open-meteo/sdk.git", from: "1.1.0"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftNetCDF.git", from: "1.0.0"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftTimeZoneLookup.git", from: "1.0.1"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftEccodes.git", from: "0.1.5"),

--- a/Sources/App/Cams/CamsController.swift
+++ b/Sources/App/Cams/CamsController.swift
@@ -91,6 +91,9 @@ enum CamsVariableDerived: String, GenericVariableMixable {
     case european_aqi_no2
     case european_aqi_o3
     case european_aqi_so2
+    case european_aqi_nitrogen_dioxide
+    case european_aqi_ozone
+    case european_aqi_sulphur_dioxide
     
     case us_aqi
     case us_aqi_pm2_5
@@ -99,6 +102,10 @@ enum CamsVariableDerived: String, GenericVariableMixable {
     case us_aqi_o3
     case us_aqi_so2
     case us_aqi_co
+    case us_aqi_nitrogen_dioxide
+    case us_aqi_ozone
+    case us_aqi_sulphur_dioxide
+    case us_aqi_carbon_monoxide
     
     case is_day
     
@@ -138,12 +145,18 @@ struct CamsReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let timeAhead = time.with(start: time.range.lowerBound.add(-24*3600))
             let pm10avg = try get(raw: .pm10, time: timeAhead).data.slidingAverageDroppingFirstDt(dt: 24)
             return DataAndUnit(pm10avg.map(EuropeanAirQuality.indexPm10), .europeanAirQualityIndex)
+        case .european_aqi_nitrogen_dioxide:
+            fallthrough
         case .european_aqi_no2:
             let no2 = try get(raw: .nitrogen_dioxide, time: time).data
             return DataAndUnit(no2.map(EuropeanAirQuality.indexNo2), .europeanAirQualityIndex)
+        case .european_aqi_ozone:
+            fallthrough
         case .european_aqi_o3:
             let o3 = try get(raw: .ozone, time: time).data
             return DataAndUnit(o3.map(EuropeanAirQuality.indexO3), .europeanAirQualityIndex)
+        case .european_aqi_sulphur_dioxide:
+            fallthrough
         case .european_aqi_so2:
             let so2 = try get(raw: .sulphur_dioxide, time: time).data
             return DataAndUnit(so2.map(EuropeanAirQuality.indexSo2), .europeanAirQualityIndex)
@@ -166,22 +179,30 @@ struct CamsReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let timeAhead = time.with(start: time.range.lowerBound.add(-24*3600))
             let pm10avg = try get(raw: .pm10, time: timeAhead).data.slidingAverageDroppingFirstDt(dt: 24)
             return DataAndUnit(pm10avg.map(UnitedStatesAirQuality.indexPm10), .usAirQualityIndex)
+        case .us_aqi_nitrogen_dioxide:
+            fallthrough
         case .us_aqi_no2:
             // need to convert from ugm3 to ppb
             let no2 = try get(raw: .nitrogen_dioxide, time: time).data
             return DataAndUnit(no2.map({UnitedStatesAirQuality.indexNo2(no2: $0 / 1.88) }), .usAirQualityIndex)
+        case .us_aqi_ozone:
+            fallthrough
         case .us_aqi_o3:
             // need to convert from ugm3 to ppb
             let timeAhead = time.with(start: time.range.lowerBound.add(-8*3600))
             let o3 = try get(raw: .ozone, time: timeAhead).data
             let o3avg = o3.slidingAverageDroppingFirstDt(dt: 8)
             return DataAndUnit(zip(o3.dropFirst(8), o3avg).map({UnitedStatesAirQuality.indexO3(o3: $0.0 / 1.96, o3_8h_mean: $0.1 / 1.96)}), .usAirQualityIndex)
+        case .us_aqi_sulphur_dioxide:
+            fallthrough
         case .us_aqi_so2:
             // need to convert from ugm3 to ppb
             let timeAhead = time.with(start: time.range.lowerBound.add(-24*3600))
             let so2 = try get(raw: .sulphur_dioxide, time: timeAhead).data
             let so2avg = so2.slidingAverageDroppingFirstDt(dt: 24)
             return DataAndUnit(zip(so2.dropFirst(24), so2avg).map({UnitedStatesAirQuality.indexSo2(so2: $0.0 / 2.62, so2_24h_mean: $0.1 / 2.62)}), .usAirQualityIndex)
+        case .us_aqi_carbon_monoxide:
+            fallthrough
         case .us_aqi_co:
             // need to convert from ugm3 to ppm
             let timeAhead = time.with(start: time.range.lowerBound.add(-8*3600))
@@ -204,10 +225,16 @@ struct CamsReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             try prefetchData(raw: .pm2_5, time: time.with(start: time.range.lowerBound.add(-24*3600)))
         case .european_aqi_pm10:
             try prefetchData(raw: .pm10, time: time.with(start: time.range.lowerBound.add(-24*3600)))
+        case .european_aqi_nitrogen_dioxide:
+            fallthrough
         case .european_aqi_no2:
             try prefetchData(raw: .nitrogen_dioxide, time: time)
+        case .european_aqi_ozone:
+            fallthrough
         case .european_aqi_o3:
             try prefetchData(raw: .ozone, time: time)
+        case .european_aqi_sulphur_dioxide:
+            fallthrough
         case .european_aqi_so2:
             try prefetchData(raw: .sulphur_dioxide, time: time)
         case .us_aqi:
@@ -221,12 +248,20 @@ struct CamsReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             try prefetchData(raw: .pm2_5, time: time.with(start: time.range.lowerBound.add(-24*3600)))
         case .us_aqi_pm10:
             try prefetchData(raw: .pm10, time: time.with(start: time.range.lowerBound.add(-24*3600)))
+        case .us_aqi_nitrogen_dioxide:
+            fallthrough
         case .us_aqi_no2:
             try prefetchData(raw: .nitrogen_dioxide, time: time)
+        case .us_aqi_ozone:
+            fallthrough
         case .us_aqi_o3:
             try prefetchData(raw: .ozone, time: time.with(start: time.range.lowerBound.add(-8*3600)))
+        case .us_aqi_sulphur_dioxide:
+            fallthrough
         case .us_aqi_so2:
             try prefetchData(raw: .ozone, time: time.with(start: time.range.lowerBound.add(-24*3600)))
+        case .us_aqi_carbon_monoxide:
+            fallthrough
         case .us_aqi_co:
             try prefetchData(raw: .ozone, time: time.with(start: time.range.lowerBound.add(-8*3600)))
         case .is_day:

--- a/Sources/App/Cams/CamsController.swift
+++ b/Sources/App/Cams/CamsController.swift
@@ -129,24 +129,24 @@ struct CamsReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let max = pm2_5.indices.map({ i -> Float in
                 return Swift.max(Swift.max(Swift.max(Swift.max(pm2_5[i], pm10[i]), no2[i]), o3[i]), so2[i])
             })
-            return DataAndUnit(max, .eaqi)
+            return DataAndUnit(max, .europeanAirQualityIndex)
         case .european_aqi_pm2_5:
             let timeAhead = time.with(start: time.range.lowerBound.add(-24*3600))
             let pm2_5 = try get(raw: .pm2_5, time: timeAhead).data.slidingAverageDroppingFirstDt(dt: 24)
-            return DataAndUnit(pm2_5.map(EuropeanAirQuality.indexPm2_5), .eaqi)
+            return DataAndUnit(pm2_5.map(EuropeanAirQuality.indexPm2_5), .europeanAirQualityIndex)
         case .european_aqi_pm10:
             let timeAhead = time.with(start: time.range.lowerBound.add(-24*3600))
             let pm10avg = try get(raw: .pm10, time: timeAhead).data.slidingAverageDroppingFirstDt(dt: 24)
-            return DataAndUnit(pm10avg.map(EuropeanAirQuality.indexPm10), .eaqi)
+            return DataAndUnit(pm10avg.map(EuropeanAirQuality.indexPm10), .europeanAirQualityIndex)
         case .european_aqi_no2:
             let no2 = try get(raw: .nitrogen_dioxide, time: time).data
-            return DataAndUnit(no2.map(EuropeanAirQuality.indexNo2), .eaqi)
+            return DataAndUnit(no2.map(EuropeanAirQuality.indexNo2), .europeanAirQualityIndex)
         case .european_aqi_o3:
             let o3 = try get(raw: .ozone, time: time).data
-            return DataAndUnit(o3.map(EuropeanAirQuality.indexO3), .eaqi)
+            return DataAndUnit(o3.map(EuropeanAirQuality.indexO3), .europeanAirQualityIndex)
         case .european_aqi_so2:
             let so2 = try get(raw: .sulphur_dioxide, time: time).data
-            return DataAndUnit(so2.map(EuropeanAirQuality.indexSo2), .eaqi)
+            return DataAndUnit(so2.map(EuropeanAirQuality.indexSo2), .europeanAirQualityIndex)
         case .us_aqi:
             let pm2_5 = try get(derived: .us_aqi_pm2_5, time: time).data
             let pm10 = try get(derived: .us_aqi_pm10, time: time).data
@@ -157,36 +157,36 @@ struct CamsReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let max = pm2_5.indices.map({ i -> Float in
                 return Swift.max(Swift.max(Swift.max(Swift.max(pm2_5[i], Swift.max(pm10[i], co[i])), no2[i]), o3[i]), so2[i])
             })
-            return DataAndUnit(max, .usaqi)
+            return DataAndUnit(max, .usAirQualityIndex)
         case .us_aqi_pm2_5:
             let timeAhead = time.with(start: time.range.lowerBound.add(-24*3600))
             let pm2_5 = try get(raw: .pm2_5, time: timeAhead).data.slidingAverageDroppingFirstDt(dt: 24)
-            return DataAndUnit(pm2_5.map(UnitedStatesAirQuality.indexPm2_5), .usaqi)
+            return DataAndUnit(pm2_5.map(UnitedStatesAirQuality.indexPm2_5), .usAirQualityIndex)
         case .us_aqi_pm10:
             let timeAhead = time.with(start: time.range.lowerBound.add(-24*3600))
             let pm10avg = try get(raw: .pm10, time: timeAhead).data.slidingAverageDroppingFirstDt(dt: 24)
-            return DataAndUnit(pm10avg.map(UnitedStatesAirQuality.indexPm10), .usaqi)
+            return DataAndUnit(pm10avg.map(UnitedStatesAirQuality.indexPm10), .usAirQualityIndex)
         case .us_aqi_no2:
             // need to convert from ugm3 to ppb
             let no2 = try get(raw: .nitrogen_dioxide, time: time).data
-            return DataAndUnit(no2.map({UnitedStatesAirQuality.indexNo2(no2: $0 / 1.88) }), .usaqi)
+            return DataAndUnit(no2.map({UnitedStatesAirQuality.indexNo2(no2: $0 / 1.88) }), .usAirQualityIndex)
         case .us_aqi_o3:
             // need to convert from ugm3 to ppb
             let timeAhead = time.with(start: time.range.lowerBound.add(-8*3600))
             let o3 = try get(raw: .ozone, time: timeAhead).data
             let o3avg = o3.slidingAverageDroppingFirstDt(dt: 8)
-            return DataAndUnit(zip(o3.dropFirst(8), o3avg).map({UnitedStatesAirQuality.indexO3(o3: $0.0 / 1.96, o3_8h_mean: $0.1 / 1.96)}), .usaqi)
+            return DataAndUnit(zip(o3.dropFirst(8), o3avg).map({UnitedStatesAirQuality.indexO3(o3: $0.0 / 1.96, o3_8h_mean: $0.1 / 1.96)}), .usAirQualityIndex)
         case .us_aqi_so2:
             // need to convert from ugm3 to ppb
             let timeAhead = time.with(start: time.range.lowerBound.add(-24*3600))
             let so2 = try get(raw: .sulphur_dioxide, time: timeAhead).data
             let so2avg = so2.slidingAverageDroppingFirstDt(dt: 24)
-            return DataAndUnit(zip(so2.dropFirst(24), so2avg).map({UnitedStatesAirQuality.indexSo2(so2: $0.0 / 2.62, so2_24h_mean: $0.1 / 2.62)}), .usaqi)
+            return DataAndUnit(zip(so2.dropFirst(24), so2avg).map({UnitedStatesAirQuality.indexSo2(so2: $0.0 / 2.62, so2_24h_mean: $0.1 / 2.62)}), .usAirQualityIndex)
         case .us_aqi_co:
             // need to convert from ugm3 to ppm
             let timeAhead = time.with(start: time.range.lowerBound.add(-8*3600))
             let co = try get(raw: .carbon_monoxide, time: timeAhead).data.slidingAverageDroppingFirstDt(dt: 8)
-            return DataAndUnit(co.map({UnitedStatesAirQuality.indexCo(co_8h_mean: $0 / 1.15 / 1000)}), .usaqi)
+            return DataAndUnit(co.map({UnitedStatesAirQuality.indexCo(co_8h_mean: $0 / 1.15 / 1000)}), .usAirQualityIndex)
         case .is_day:
             return DataAndUnit(Zensun.calculateIsDay(timeRange: time, lat: reader.modelLat, lon: reader.modelLon), .dimensionlessInteger)
         }

--- a/Sources/App/Cams/CamsController.swift
+++ b/Sources/App/Cams/CamsController.swift
@@ -76,7 +76,7 @@ struct CamsController {
             guard !readers.isEmpty else {
                 throw ForecastapiError.noDataAvilableForThisLocation
             }
-            return .init(timezone: timezone, time: time, results: readers)
+            return .init(timezone: timezone, time: time, locationId: coordinates.locationId, results: readers)
         }
         let result = ForecastapiResult<CamsQuery.Domain>(timeformat: params.timeformatOrDefault, results: locations)
         req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))

--- a/Sources/App/Cams/CamsDomain.swift
+++ b/Sources/App/Cams/CamsDomain.swift
@@ -102,39 +102,39 @@ enum CamsVariable: String, CaseIterable, GenericVariable, GenericVariableMixable
     var unit: SiUnit {
         switch self {
         case .pm10:
-            return .microgramsPerQuibicMeter
+            return .microgramsPerCubicMetre
         case .pm2_5:
-            return .microgramsPerQuibicMeter
+            return .microgramsPerCubicMetre
         case .dust:
-            return .microgramsPerQuibicMeter
+            return .microgramsPerCubicMetre
         case .aerosol_optical_depth:
             return .dimensionless
         case .carbon_monoxide:
-            return .microgramsPerQuibicMeter
+            return .microgramsPerCubicMetre
         case .nitrogen_dioxide:
-            return .microgramsPerQuibicMeter
+            return .microgramsPerCubicMetre
         case .ammonia:
-            return .microgramsPerQuibicMeter
+            return .microgramsPerCubicMetre
         case .ozone:
-            return .microgramsPerQuibicMeter
+            return .microgramsPerCubicMetre
         case .sulphur_dioxide:
-            return .microgramsPerQuibicMeter
+            return .microgramsPerCubicMetre
         case .uv_index:
             return .dimensionless
         case .uv_index_clear_sky:
             return .dimensionless
         case .alder_pollen:
-            return .grainsPerQuibicMeter
+            return .grainsPerCubicMetre
         case .birch_pollen:
-            return .grainsPerQuibicMeter
+            return .grainsPerCubicMetre
         case .grass_pollen:
-            return .grainsPerQuibicMeter
+            return .grainsPerCubicMetre
         case .mugwort_pollen:
-            return .grainsPerQuibicMeter
+            return .grainsPerCubicMetre
         case .olive_pollen:
-            return .grainsPerQuibicMeter
+            return .grainsPerCubicMetre
         case .ragweed_pollen:
-            return .grainsPerQuibicMeter
+            return .grainsPerCubicMetre
         }
     }
     

--- a/Sources/App/Cmip6/CmipController.swift
+++ b/Sources/App/Cmip6/CmipController.swift
@@ -66,7 +66,7 @@ struct CmipController {
             guard !readers.isEmpty else {
                 throw ForecastapiError.noDataAvilableForThisLocation
             }
-            return .init(timezone: timezone, time: time, results: readers)
+            return .init(timezone: timezone, time: time, locationId: coordinates.locationId, results: readers)
         }
         let result = ForecastapiResult<Cmip6Domain>(timeformat: params.timeformatOrDefault, results: locations)
         req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))

--- a/Sources/App/Cmip6/CmipController.swift
+++ b/Sources/App/Cmip6/CmipController.swift
@@ -529,7 +529,7 @@ struct Cmip6ReaderPostBiasCorrected<ReaderNext: GenericReaderProtocol>: GenericR
         case .snowfall_sum:
             let snowwater = try get(raw: .raw(.snowfall_water_equivalent_sum), time: time).data
             let snowfall = snowwater.map { $0 * 0.7 }
-            return DataAndUnit(snowfall, .centimeter)
+            return DataAndUnit(snowfall, .centimetre)
         case .rain_sum:
             let snowwater = try get(raw: .raw(.snowfall_water_equivalent_sum), time: time)
             let precip = try get(raw: .raw(.precipitation_sum), time: time)
@@ -581,7 +581,7 @@ struct Cmip6ReaderPostBiasCorrected<ReaderNext: GenericReaderProtocol>: GenericR
             return DataAndUnit(type.calculateSoilMoistureIndex(soilMoisture.data), .fraction)
         case .daylight_duration:
             // note: time should aldign to UTC 0 midnight
-            return DataAndUnit(Zensun.calculateDaylightDuration(utcMidnight: time.range, lat: modelLat, lon: modelLon), .second)
+            return DataAndUnit(Zensun.calculateDaylightDuration(utcMidnight: time.range, lat: modelLat, lon: modelLon), .seconds)
         case .windspeed_2m_max:
             let wind = try get(raw: .raw(.windspeed_10m_max), time: time)
             let scale = Meteorology.scaleWindFactor(from: 10, to: 2)
@@ -673,7 +673,7 @@ struct Cmip6ReaderPreBiasCorrection<ReaderNext: GenericReaderProtocol>: GenericR
                     extraTerrestrialRadiationSum: exrad[i] * 0.0036,
                     relativeHumidity: rh))
             }
-            return DataAndUnit(et0, .millimeter)
+            return DataAndUnit(et0, .millimetre)
         case .vapor_pressure_deficit_max:
             let tempmax = try get(raw: .temperature_2m_max, time: time).data
             let tempmin = try get(raw: .temperature_2m_min, time: time).data
@@ -695,7 +695,7 @@ struct Cmip6ReaderPreBiasCorrection<ReaderNext: GenericReaderProtocol>: GenericR
                     temperature2mCelsiusDailyMin: tempmin[i],
                     relativeHumidity: rh))
             }
-            return DataAndUnit(vpd, .kiloPascal)
+            return DataAndUnit(vpd, .kilopascal)
         case .leaf_wetness_probability_mean:
             let tempmax = try get(raw: .temperature_2m_max, time: time).data
             let tempmin = try get(raw: .temperature_2m_min, time: time).data
@@ -715,7 +715,7 @@ struct Cmip6ReaderPreBiasCorrection<ReaderNext: GenericReaderProtocol>: GenericR
                 }
                 leafWetness.append(Meteorology.leafwetnessPorbabilityDaily(temperature2mCelsiusDaily: (max: tempmax[i], min: tempmin[i]), relativeHumidity: rh, precipitation: preciptitation[i]))
             }
-            return DataAndUnit(leafWetness, .percent)
+            return DataAndUnit(leafWetness, .percentage)
         case .soil_moisture_0_to_100cm_mean:
             // estimate soil moisture in 0-100 by a moving average over 0-10 cm moisture
             let sm0_10 = try get(raw: .soil_moisture_0_to_10cm_mean, time: time)

--- a/Sources/App/Cmip6/CmipController.swift
+++ b/Sources/App/Cmip6/CmipController.swift
@@ -115,8 +115,11 @@ enum Cmip6VariableDerivedBiasCorrected: String, GenericVariableMixable, CaseIter
     case soil_temperature_7_to_28cm_mean
     case soil_temperature_28_to_100cm_mean
     case vapor_pressure_deficit_max
+    case vapour_pressure_deficit_max
     case windgusts_10m_mean
     case windgusts_10m_max
+    case wind_gusts_10m_mean
+    case wind_gusts_10m_max
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false
@@ -126,6 +129,8 @@ enum Cmip6VariableDerivedBiasCorrected: String, GenericVariableMixable, CaseIter
         switch self {
         case .et0_fao_evapotranspiration_sum:
             return .relativeChange(maximum: nil)
+        case .vapour_pressure_deficit_max:
+            fallthrough
         case .vapor_pressure_deficit_max:
             return .relativeChange(maximum: nil)
         case .leaf_wetness_probability_mean:
@@ -146,8 +151,12 @@ enum Cmip6VariableDerivedBiasCorrected: String, GenericVariableMixable, CaseIter
             return .absoluteChage(bounds: nil)
         case .soil_temperature_28_to_100cm_mean:
             return .absoluteChage(bounds: nil)
+        case .wind_gusts_10m_mean:
+            fallthrough
         case .windgusts_10m_mean:
             return .relativeChange(maximum: nil)
+        case .wind_gusts_10m_max:
+            fallthrough
         case .windgusts_10m_max:
             return .relativeChange(maximum: nil)
         }
@@ -674,6 +683,8 @@ struct Cmip6ReaderPreBiasCorrection<ReaderNext: GenericReaderProtocol>: GenericR
                     relativeHumidity: rh))
             }
             return DataAndUnit(et0, .millimetre)
+        case .vapour_pressure_deficit_max:
+            fallthrough
         case .vapor_pressure_deficit_max:
             let tempmax = try get(raw: .temperature_2m_max, time: time).data
             let tempmin = try get(raw: .temperature_2m_min, time: time).data
@@ -760,8 +771,12 @@ struct Cmip6ReaderPreBiasCorrection<ReaderNext: GenericReaderProtocol>: GenericR
             let st7_28 = st0_7.indices.map { return st0_7[max(0, $0-5) ..< $0+1].mean() }
             let st28_100 = st7_28.indices.map { return st7_28[max(0, $0-51) ..< $0+1].mean() }
             return DataAndUnit(st28_100, t2m.unit)
+        case .wind_gusts_10m_mean:
+            fallthrough
         case .windgusts_10m_mean:
             return try get(raw: .windspeed_10m_mean, time: time)
+        case .wind_gusts_10m_max:
+            fallthrough
         case .windgusts_10m_max:
             return try get(raw: .windspeed_10m_max, time: time)
         }
@@ -782,6 +797,8 @@ struct Cmip6ReaderPreBiasCorrection<ReaderNext: GenericReaderProtocol>: GenericR
             } else {
                 try prefetchData(raw: .relative_humidity_2m_mean, time: time)
             }
+        case .vapour_pressure_deficit_max:
+            fallthrough
         case .vapor_pressure_deficit_max:
             try prefetchData(raw: .temperature_2m_max, time: time)
             try prefetchData(raw: .temperature_2m_min, time: time)
@@ -819,8 +836,12 @@ struct Cmip6ReaderPreBiasCorrection<ReaderNext: GenericReaderProtocol>: GenericR
             try prefetchData(raw: .temperature_2m_max, time: time)
         case .soil_temperature_28_to_100cm_mean:
             try prefetchData(raw: .temperature_2m_max, time: time)
+        case .wind_gusts_10m_mean:
+            fallthrough
         case .windgusts_10m_mean:
             try prefetchData(raw: .windspeed_10m_mean, time: time)
+        case .wind_gusts_10m_max:
+            fallthrough
         case .windgusts_10m_max:
             try prefetchData(raw: .windspeed_10m_max, time: time)
         }

--- a/Sources/App/Cmip6/CmipDownloader.swift
+++ b/Sources/App/Cmip6/CmipDownloader.swift
@@ -391,7 +391,7 @@ enum Cmip6Variable: String, CaseIterable, GenericVariable, GenericVariableMixabl
     var unit: SiUnit {
         switch self {
         case .pressure_msl_mean:
-            return .hectoPascal
+            return .hectopascal
         case .temperature_2m_min:
             return .celsius
         case .temperature_2m_max:
@@ -399,27 +399,27 @@ enum Cmip6Variable: String, CaseIterable, GenericVariable, GenericVariableMixabl
         case .temperature_2m_mean:
             return .celsius
         case .cloudcover_mean:
-            return .percent
+            return .percentage
         case .precipitation_sum:
-            return .millimeter
+            return .millimetre
         //case .runoff_sum:
-        //    return .millimeter
+        //    return .millimetre
         case .snowfall_water_equivalent_sum:
-            return .millimeter
+            return .millimetre
         case .relative_humidity_2m_min:
-            return .percent
+            return .percentage
         case .relative_humidity_2m_max:
-            return .percent
+            return .percentage
         case .relative_humidity_2m_mean:
-            return .percent
+            return .percentage
         case .windspeed_10m_mean:
-            return .ms
+            return .metrePerSecond
         case .windspeed_10m_max:
-            return .ms
+            return .metrePerSecond
         case .soil_moisture_0_to_10cm_mean:
-            return .qubicMeterPerQubicMeter
+            return .cubicMetrePerCubicMetre
         case .shortwave_radiation_sum:
-            return .megaJoulesPerSquareMeter
+            return .megajoulePerSquareMetre
         }
     }
     

--- a/Sources/App/Commands/ExportCommand.swift
+++ b/Sources/App/Commands/ExportCommand.swift
@@ -34,7 +34,7 @@ final class BufferedParquetFileWriter {
                 ("latitude", .float),
                 ("longitude", .float),
                 ("elevation", .float),
-                ("time", .timestamp(unit: .second))
+                ("time", .timestamp(unit: .seconds))
             ] + zip(variables, data).map{("\($0.0)_\($0.1.unit)", ArrowDataType.float)}
             
             let schema = try ArrowSchema(columns)
@@ -74,7 +74,7 @@ final class BufferedParquetFileWriter {
             try ArrowArray(float: latitudes),
             try ArrowArray(float: longitudes),
             try ArrowArray(float: elevations),
-            try ArrowArray(timestamp: times, unit: .second)
+            try ArrowArray(timestamp: times, unit: .seconds)
         ] + data.map( {try ArrowArray(float: $0)}))
         try writer.write(table: table, chunkSize: locations.count)
         

--- a/Sources/App/Controllers/EnsembleController.swift
+++ b/Sources/App/Controllers/EnsembleController.swift
@@ -167,17 +167,22 @@ enum EnsembleMultiDomains: String, RawRepresentableString, CaseIterable, MultiDo
 /// Define all available surface weather variables
 enum EnsembleSurfaceVariable: String, GenericVariableMixable, Equatable, RawRepresentableString {
     case weathercode
+    case weather_code
     case temperature_2m
     case temperature_80m
     case temperature_120m
     case cloudcover
+    case cloud_cover
     case pressure_msl
     case relativehumidity_2m
+    case relative_humidity_2m
     case precipitation
     //case showers
     case rain
     case windgusts_10m
+    case wind_gusts_10m
     case dewpoint_2m
+    case dew_point_2m
     case diffuse_radiation
     case direct_radiation
     case apparent_temperature
@@ -187,15 +192,20 @@ enum EnsembleSurfaceVariable: String, GenericVariableMixable, Equatable, RawRepr
     case winddirection_80m
     case windspeed_120m
     case winddirection_120m
+    case wind_speed_10m
+    case wind_direction_10m
+    case wind_speed_80m
+    case wind_direction_80m
+    case wind_speed_120m
+    case wind_direction_120m
     case direct_normal_irradiance
     case et0_fao_evapotranspiration
+    case vapour_pressure_deficit
     case vapor_pressure_deficit
     case shortwave_radiation
     case snowfall
     case snow_depth
     case surface_pressure
-    //case terrestrial_radiation
-    //case terrestrial_radiation_instant
     case shortwave_radiation_instant
     case diffuse_radiation_instant
     case direct_radiation_instant
@@ -203,6 +213,7 @@ enum EnsembleSurfaceVariable: String, GenericVariableMixable, Equatable, RawRepr
     case is_day
     case visibility
     case freezinglevel_height
+    case freezing_level_height
     case uv_index
     case uv_index_clear_sky
     case cape
@@ -221,7 +232,12 @@ enum EnsembleSurfaceVariable: String, GenericVariableMixable, Equatable, RawRepr
     /// Soil moisture or snow depth are cumulative processes and have offests if mutliple models are mixed
     var requiresOffsetCorrectionForMixing: Bool {
         switch self {
-        default: return false
+        case .soil_moisture_0_to_10cm, .soil_moisture_10_to_40cm, .soil_moisture_40_to_100cm, .soil_moisture_100_to_200cm:
+            return true
+        case .snow_depth:
+            return true
+        default:
+            return false
         }
     }
 }
@@ -231,10 +247,15 @@ enum EnsemblePressureVariableType: String, GenericVariableMixable {
     case temperature
     case geopotential_height
     case relativehumidity
+    case relative_humidity
     case windspeed
+    case wind_speed
     case winddirection
+    case wind_direction
     case dewpoint
+    case dew_point
     case cloudcover
+    case cloud_cover
     case vertical_velocity
     
     var requiresOffsetCorrectionForMixing: Bool {

--- a/Sources/App/Controllers/EnsembleController.swift
+++ b/Sources/App/Controllers/EnsembleController.swift
@@ -74,7 +74,7 @@ public struct EnsembleApiController {
             guard !readers.isEmpty else {
                 throw ForecastapiError.noDataAvilableForThisLocation
             }
-            return .init(timezone: timezone, time: time, results: readers)
+            return .init(timezone: timezone, time: time, locationId: coordinates.locationId, results: readers)
         }
         let result = ForecastapiResult<EnsembleMultiDomains>(timeformat: params.timeformatOrDefault, results: locations)
         req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -452,7 +452,12 @@ enum ForecastSurfaceVariable: String, GenericVariableMixable {
     case cloudcover_high
     case cloudcover_low
     case cloudcover_mid
+    case cloud_cover
+    case cloud_cover_high
+    case cloud_cover_low
+    case cloud_cover_mid
     case dewpoint_2m
+    case dew_point_2m
     case diffuse_radiation
     case diffuse_radiation_instant
     case direct_normal_irradiance
@@ -462,9 +467,11 @@ enum ForecastSurfaceVariable: String, GenericVariableMixable {
     case et0_fao_evapotranspiration
     case evapotranspiration
     case freezinglevel_height
+    case freezing_level_height
     case growing_degree_days_base_0_limit_50
     case is_day
     case latent_heatflux
+    case latent_heat_flux
     case lifted_index
     case leaf_wetness_probability
     case lightning_potential
@@ -473,8 +480,10 @@ enum ForecastSurfaceVariable: String, GenericVariableMixable {
     case pressure_msl
     case rain
     case relativehumidity_2m
+    case relative_humidity_2m
     case runoff
     case sensible_heatflux
+    case sensible_heat_flux
     case shortwave_radiation
     case shortwave_radiation_instant
     case showers
@@ -541,8 +550,10 @@ enum ForecastSurfaceVariable: String, GenericVariableMixable {
     case uv_index
     case uv_index_clear_sky
     case vapor_pressure_deficit
+    case vapour_pressure_deficit
     case visibility
     case weathercode
+    case weather_code
     case winddirection_100m
     case winddirection_10m
     case winddirection_120m
@@ -564,6 +575,27 @@ enum ForecastSurfaceVariable: String, GenericVariableMixable {
     case windspeed_40m
     case windspeed_50m
     case windspeed_80m
+    case wind_direction_100m
+    case wind_direction_10m
+    case wind_direction_120m
+    case wind_direction_150m
+    case wind_direction_180m
+    case wind_direction_200m
+    case wind_direction_20m
+    case wind_direction_40m
+    case wind_direction_50m
+    case wind_direction_80m
+    case wind_gusts_10m
+    case wind_speed_100m
+    case wind_speed_10m
+    case wind_speed_120m
+    case wind_speed_150m
+    case wind_speed_180m
+    case wind_speed_200m
+    case wind_speed_20m
+    case wind_speed_40m
+    case wind_speed_50m
+    case wind_speed_80m
     
     /// Some variables are kept for backwards compatibility
     var remapped: Self {
@@ -610,20 +642,16 @@ enum ForecastPressureVariableType: String, GenericVariableMixable {
     case temperature
     case geopotential_height
     case relativehumidity
-    case windspeed
-    case winddirection
-    case dewpoint
-    case cloudcover
-    case vertical_velocity
     case relative_humidity
-    
-    /// Some variables are kept for backwards compatibility
-    var remapped: Self {
-        switch self {
-        case .relative_humidity: return .relativehumidity
-        default: return self
-        }
-    }
+    case windspeed
+    case wind_speed
+    case winddirection
+    case wind_direction
+    case dewpoint
+    case dew_point
+    case cloudcover
+    case cloud_cover
+    case vertical_velocity
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false
@@ -647,8 +675,8 @@ extension ForecastVariable {
         switch self {
         case .surface(let surface):
             return .surface(surface.remapped)
-        case .pressure(let pressure):
-            return .pressure(ForecastPressureVariable(variable: pressure.variable.remapped, level: pressure.level))
+        case .pressure(_):
+            return self
         }
     }
 }
@@ -664,9 +692,15 @@ enum ForecastVariableDaily: String, DailyVariableCalculatable, RawRepresentableS
     case cloudcover_max
     case cloudcover_mean
     case cloudcover_min
+    case cloud_cover_max
+    case cloud_cover_mean
+    case cloud_cover_min
     case dewpoint_2m_max
     case dewpoint_2m_mean
     case dewpoint_2m_min
+    case dew_point_2m_max
+    case dew_point_2m_mean
+    case dew_point_2m_min
     case et0_fao_evapotranspiration
     case et0_fao_evapotranspiration_sum
     case growing_degree_days_base_0_limit_50
@@ -713,10 +747,12 @@ enum ForecastVariableDaily: String, DailyVariableCalculatable, RawRepresentableS
     case uv_index_clear_sky_max
     case uv_index_max
     case vapor_pressure_deficit_max
+    case vapour_pressure_deficit_max
     case visibility_max
     case visibility_mean
     case visibility_min
     case weathercode
+    case weather_code
     case winddirection_10m_dominant
     case windgusts_10m_max
     case windgusts_10m_mean
@@ -724,6 +760,13 @@ enum ForecastVariableDaily: String, DailyVariableCalculatable, RawRepresentableS
     case windspeed_10m_max
     case windspeed_10m_mean
     case windspeed_10m_min
+    case wind_direction_10m_dominant
+    case wind_gusts_10m_max
+    case wind_gusts_10m_mean
+    case wind_gusts_10m_min
+    case wind_speed_10m_max
+    case wind_speed_10m_mean
+    case wind_speed_10m_min
     case wet_bulb_temperature_2m_max
     case wet_bulb_temperature_2m_mean
     case wet_bulb_temperature_2m_min
@@ -751,23 +794,23 @@ enum ForecastVariableDaily: String, DailyVariableCalculatable, RawRepresentableS
             return .sum(.surface(.rain))
         case .showers_sum:
             return .sum(.surface(.showers))
-        case .weathercode:
+        case .weathercode, .weather_code:
             return .max(.surface(.weathercode))
         case .shortwave_radiation_sum:
             return .radiationSum(.surface(.shortwave_radiation))
-        case .windspeed_10m_max:
+        case .windspeed_10m_max, .wind_speed_10m_max:
             return .max(.surface(.windspeed_10m))
-        case .windspeed_10m_min:
+        case .windspeed_10m_min, .wind_speed_10m_min:
             return .min(.surface(.windspeed_10m))
-        case .windspeed_10m_mean:
+        case .windspeed_10m_mean, .wind_speed_10m_mean:
             return .mean(.surface(.windspeed_10m))
-        case .windgusts_10m_max:
+        case .windgusts_10m_max, .wind_gusts_10m_max:
             return .max(.surface(.windgusts_10m))
-        case .windgusts_10m_min:
+        case .windgusts_10m_min, .wind_gusts_10m_min:
             return .min(.surface(.windgusts_10m))
-        case .windgusts_10m_mean:
+        case .windgusts_10m_mean, .wind_gusts_10m_mean:
             return .mean(.surface(.windgusts_10m))
-        case .winddirection_10m_dominant:
+        case .winddirection_10m_dominant, .wind_direction_10m_dominant:
             return .dominantDirection(velocity: .surface(.windspeed_10m), direction: .surface(.winddirection_10m))
         case .precipitation_hours:
             return .precipitationHours(.surface(.precipitation))
@@ -801,11 +844,11 @@ enum ForecastVariableDaily: String, DailyVariableCalculatable, RawRepresentableS
             return .min(.surface(.cape))
         case .cape_mean:
             return .mean(.surface(.cape))
-        case .cloudcover_max:
+        case .cloudcover_max, .cloud_cover_max:
             return .max(.surface(.cloudcover))
-        case .cloudcover_min:
+        case .cloudcover_min, .cloud_cover_min:
             return .min(.surface(.cloudcover))
-        case .cloudcover_mean:
+        case .cloudcover_mean, .cloud_cover_mean:
             return .mean(.surface(.cloudcover))
         case .uv_index_max:
             return .max(.surface(.uv_index))
@@ -817,11 +860,11 @@ enum ForecastVariableDaily: String, DailyVariableCalculatable, RawRepresentableS
             return .max(.surface(.precipitation_probability))
         case .precipitation_probability_mean:
             return .max(.surface(.precipitation_probability))
-        case .dewpoint_2m_max:
+        case .dewpoint_2m_max, .dew_point_2m_max:
             return .max(.surface(.dewpoint_2m))
-        case .dewpoint_2m_mean:
+        case .dewpoint_2m_mean, .dew_point_2m_mean:
             return .mean(.surface(.dewpoint_2m))
-        case .dewpoint_2m_min:
+        case .dewpoint_2m_min, .dew_point_2m_min:
             return .min(.surface(.dewpoint_2m))
         case .et0_fao_evapotranspiration_sum:
             return .sum(.surface(.et0_fao_evapotranspiration))
@@ -867,7 +910,7 @@ enum ForecastVariableDaily: String, DailyVariableCalculatable, RawRepresentableS
             return .mean(.surface(.soil_temperature_7_to_28cm))
         case .updraft_max:
             return .max(.surface(.updraft))
-        case .vapor_pressure_deficit_max:
+        case .vapor_pressure_deficit_max, .vapour_pressure_deficit_max:
             return .max(.surface(.vapor_pressure_deficit))
         case .wet_bulb_temperature_2m_max:
             return .max(.surface(.wet_bulb_temperature_2m))

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -209,7 +209,7 @@ struct WeatherApiController {
             guard !readers.isEmpty else {
                 throw ForecastapiError.noDataAvilableForThisLocation
             }
-            return .init(timezone: timezone, time: time, results: readers)
+            return .init(timezone: timezone, time: time, locationId: coordinates.locationId, results: readers)
         }
         let result = ForecastapiResult<MultiDomains>(timeformat: params.timeformatOrDefault, results: locations)
         req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))

--- a/Sources/App/Ecmwf/EcmwfReader.swift
+++ b/Sources/App/Ecmwf/EcmwfReader.swift
@@ -34,101 +34,141 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
     func get(derived: Derived, time: TimerangeDt) throws -> DataAndUnit {
         let member = derived.member
         switch derived.variable {
+        case .wind_speed_10m:
+            fallthrough
         case .windspeed_10m:
             let v = try get(raw: .init(.northward_wind_10m, member), time: time)
             let u = try get(raw: .init(.eastward_wind_10m, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
+        case .wind_direction_10m:
+            fallthrough
         case .winddirection_10m:
             let v = try get(raw: .init(.northward_wind_10m, member), time: time)
             let u = try get(raw: .init(.eastward_wind_10m, member), time: time)
             let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
             return DataAndUnit(direction, .degreeDirection)
+        case .wind_speed_1000hPa:
+            fallthrough
         case .windspeed_1000hPa:
             let v = try get(raw: .init(.northward_wind_1000hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_1000hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
+        case .wind_speed_925hPa:
+            fallthrough
         case .windspeed_925hPa:
             let v = try get(raw: .init(.northward_wind_925hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_925hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
+        case .wind_speed_850hPa:
+            fallthrough
         case .windspeed_850hPa:
             let v = try get(raw: .init(.northward_wind_850hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_850hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
+        case .wind_speed_700hPa:
+            fallthrough
         case .windspeed_700hPa:
             let v = try get(raw: .init(.northward_wind_700hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_700hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
+        case .wind_speed_500hPa:
+            fallthrough
         case .windspeed_500hPa:
             let v = try get(raw: .init(.northward_wind_500hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_500hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
+        case .wind_speed_300hPa:
+            fallthrough
         case .windspeed_300hPa:
             let v = try get(raw: .init(.northward_wind_300hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_300hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
+        case .wind_speed_250hPa:
+            fallthrough
         case .windspeed_250hPa:
             let v = try get(raw: .init(.northward_wind_250hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_250hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
+        case .wind_speed_200hPa:
+            fallthrough
         case .windspeed_200hPa:
             let v = try get(raw: .init(.northward_wind_200hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_200hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
+        case .wind_speed_50hPa:
+            fallthrough
         case .windspeed_50hPa:
             let v = try get(raw: .init(.northward_wind_50hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_50hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
+        case .wind_direction_1000hPa:
+            fallthrough
         case .winddirection_1000hPa:
             let v = try get(raw: .init(.northward_wind_1000hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_1000hPa, member), time: time)
             let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
             return DataAndUnit(direction, .degreeDirection)
+        case .wind_direction_925hPa:
+            fallthrough
         case .winddirection_925hPa:
             let v = try get(raw: .init(.northward_wind_925hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_925hPa, member), time: time)
             let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
             return DataAndUnit(direction, .degreeDirection)
+        case .wind_direction_850hPa:
+            fallthrough
         case .winddirection_850hPa:
             let v = try get(raw: .init(.northward_wind_850hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_850hPa, member), time: time)
             let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
             return DataAndUnit(direction, .degreeDirection)
+        case .wind_direction_700hPa:
+            fallthrough
         case .winddirection_700hPa:
             let v = try get(raw: .init(.northward_wind_700hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_700hPa, member), time: time)
             let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
             return DataAndUnit(direction, .degreeDirection)
+        case .wind_direction_500hPa:
+            fallthrough
         case .winddirection_500hPa:
             let v = try get(raw: .init(.northward_wind_500hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_500hPa, member), time: time)
             let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
             return DataAndUnit(direction, .degreeDirection)
+        case .wind_direction_300hPa:
+            fallthrough
         case .winddirection_300hPa:
             let v = try get(raw: .init(.northward_wind_300hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_300hPa, member), time: time)
             let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
             return DataAndUnit(direction, .degreeDirection)
+        case .wind_direction_250hPa:
+            fallthrough
         case .winddirection_250hPa:
             let v = try get(raw: .init(.northward_wind_250hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_250hPa, member), time: time)
             let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
             return DataAndUnit(direction, .degreeDirection)
+        case .wind_direction_200hPa:
+            fallthrough
         case .winddirection_200hPa:
             let v = try get(raw: .init(.northward_wind_200hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_200hPa, member), time: time)
             let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
             return DataAndUnit(direction, .degreeDirection)
+        case .wind_direction_50hPa:
+            fallthrough
         case .winddirection_50hPa:
             let v = try get(raw: .init(.northward_wind_50hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_50hPa, member), time: time)
@@ -140,6 +180,8 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             fallthrough
         case .soil_temperature_0_7cm:
             return try get(raw: .init(.soil_temperature_0_to_7cm, member), time: time)
+        case .weather_code:
+            fallthrough
         case .weathercode:
             let cloudcover = try get(raw: .init(.cloudcover, member), time: time).data
             let precipitation = try get(raw: .init(.precipitation, member), time: time).data
@@ -156,31 +198,49 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
                 categoricalFreezingRain: nil,
                 modelDtSeconds: time.dtSeconds), .wmoCode
             )
+        case .cloud_cover_1000hPa:
+            fallthrough
         case .cloudcover_1000hPa:
             let rh = try get(raw: .init(.relative_humidity_1000hPa, member), time: time)
             return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 1000)}), .percentage)
+        case .cloud_cover_925hPa:
+            fallthrough
         case .cloudcover_925hPa:
             let rh = try get(raw: .init(.relative_humidity_925hPa, member), time: time)
             return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 925)}), .percentage)
+        case .cloud_cover_850hPa:
+            fallthrough
         case .cloudcover_850hPa:
             let rh = try get(raw: .init(.relative_humidity_850hPa, member), time: time)
             return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 850)}), .percentage)
+        case .cloud_cover_700hPa:
+            fallthrough
         case .cloudcover_700hPa:
             let rh = try get(raw: .init(.relative_humidity_700hPa, member), time: time)
             return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 700)}), .percentage)
+        case .cloud_cover_500hPa:
+            fallthrough
         case .cloudcover_500hPa:
             let rh = try get(raw: .init(.relative_humidity_500hPa, member), time: time)
             return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 500)}), .percentage)
+        case .cloud_cover_300hPa:
+            fallthrough
         case .cloudcover_300hPa:
             let rh = try get(raw: .init(.relative_humidity_300hPa, member), time: time)
             return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 300)}), .percentage)
+        case .cloud_cover_250hPa:
+            fallthrough
         case .cloudcover_250hPa:
             let rh = try get(raw: .init(.relative_humidity_250hPa, member), time: time)
             return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 250)}), .percentage)
+        case .cloud_cover_200hPa:
+            fallthrough
         case .cloudcover_200hPa:
             let rh = try get(raw: .init(.relative_humidity_200hPa, member), time: time)
             return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 200)}), .percentage)
         case .cloudcover_50hPa:
+            fallthrough
+        case .cloud_cover_50hPa:
             let rh = try get(raw: .init(.relative_humidity_50hPa, member), time: time)
             return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 50)}), .percentage)
         case .snowfall:
@@ -211,38 +271,56 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             return try get(raw: .init(.relative_humidity_200hPa, member), time: time)
         case .relativehumidity_50hPa:
             return try get(raw: .init(.relative_humidity_50hPa, member), time: time)
+        case .dew_point_1000hPa:
+            fallthrough
         case .dewpoint_1000hPa:
             let temperature = try get(raw: .init(.temperature_1000hPa, member), time: time)
             let rh = try get(raw: .init(.relative_humidity_1000hPa, member), time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+        case .dew_point_925hPa:
+            fallthrough
         case .dewpoint_925hPa:
             let temperature = try get(raw: .init(.temperature_925hPa, member), time: time)
             let rh = try get(raw: .init(.relative_humidity_925hPa, member), time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+        case .dew_point_850hPa:
+            fallthrough
         case .dewpoint_850hPa:
             let temperature = try get(raw: .init(.temperature_850hPa, member), time: time)
             let rh = try get(raw: .init(.relative_humidity_850hPa, member), time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+        case .dew_point_700hPa:
+            fallthrough
         case .dewpoint_700hPa:
             let temperature = try get(raw: .init(.temperature_700hPa, member), time: time)
             let rh = try get(raw: .init(.relative_humidity_700hPa, member), time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+        case .dew_point_500hPa:
+            fallthrough
         case .dewpoint_500hPa:
             let temperature = try get(raw: .init(.temperature_500hPa, member), time: time)
             let rh = try get(raw: .init(.relative_humidity_500hPa, member), time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+        case .dew_point_300hPa:
+            fallthrough
         case .dewpoint_300hPa:
             let temperature = try get(raw: .init(.temperature_300hPa, member), time: time)
             let rh = try get(raw: .init(.relative_humidity_300hPa, member), time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+        case .dew_point_250hPa:
+            fallthrough
         case .dewpoint_250hPa:
             let temperature = try get(raw: .init(.temperature_250hPa, member), time: time)
             let rh = try get(raw: .init(.relative_humidity_250hPa, member), time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+        case .dew_point_200hPa:
+            fallthrough
         case .dewpoint_200hPa:
             let temperature = try get(raw: .init(.temperature_200hPa, member), time: time)
             let rh = try get(raw: .init(.relative_humidity_200hPa, member), time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+        case .dew_point_50hPa:
+            fallthrough
         case .dewpoint_50hPa:
             let temperature = try get(raw: .init(.temperature_50hPa, member), time: time)
             let rh = try get(raw: .init(.relative_humidity_50hPa, member), time: time)
@@ -253,8 +331,12 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             return try get(raw: .init(.skin_temperature, member), time: time)
         case .surface_pressure:
             return try get(raw: .init(.surface_air_pressure, member), time: time)
+        case .relative_humidity_2m:
+            fallthrough
         case .relativehumidity_2m:
             return try get(raw: .init(.relative_humidity_1000hPa, member), time: time)
+        case .dew_point_2m:
+            fallthrough
         case .dewpoint_2m:
             let temperature = try get(raw: .init(.temperature_2m, member), time: time)
             let rh = try get(derived: .init(.relativehumidity_2m, member), time: time)
@@ -264,6 +346,8 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             let temperature = try get(raw: .init(.temperature_2m, member), time: time).data
             let relhum = try get(derived: .init(.relativehumidity_2m, member), time: time).data
             return DataAndUnit(Meteorology.apparentTemperature(temperature_2m: temperature, relativehumidity_2m: relhum, windspeed_10m: windspeed, shortware_radiation: nil), .celsius)
+        case .vapour_pressure_deficit:
+            fallthrough
         case .vapor_pressure_deficit:
             let temperature = try get(raw: .init(.temperature_2m, member), time: time).data
             let rh = try get(derived: .init(.relativehumidity_2m, member), time: time).data
@@ -273,69 +357,117 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             let temperature = try get(raw: .init(.temperature_2m, member), time: time)
             let rh = try get(derived: .init(.relativehumidity_2m, member), time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.wetBulbTemperature), temperature.unit)
+        case .cloud_cover:
+            return try get(raw: .init(.cloudcover, member), time: time)
+        case .cloud_cover_low:
+            return try get(raw: .init(.cloudcover_low, member), time: time)
+        case .cloud_cover_mid:
+            return try get(raw: .init(.cloudcover_mid, member), time: time)
+        case .cloud_cover_high:
+            return try get(raw: .init(.cloudcover_high, member), time: time)
         }
     }
     
     func prefetchData(derived: Derived, time: TimerangeDt) throws {
         let member = derived.member
         switch derived.variable {
+        case .wind_speed_10m:
+            fallthrough
         case .windspeed_10m:
             try prefetchData(raw: .init(.northward_wind_10m, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_10m, member), time: time)
+        case .wind_speed_1000hPa:
+            fallthrough
         case .windspeed_1000hPa:
             try prefetchData(raw: .init(.northward_wind_1000hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_1000hPa, member), time: time)
+        case .wind_speed_925hPa:
+            fallthrough
         case .windspeed_925hPa:
             try prefetchData(raw: .init(.northward_wind_925hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_925hPa, member), time: time)
+        case .wind_speed_850hPa:
+            fallthrough
         case .windspeed_850hPa:
             try prefetchData(raw: .init(.northward_wind_850hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_850hPa, member), time: time)
+        case .wind_speed_700hPa:
+            fallthrough
         case .windspeed_700hPa:
             try prefetchData(raw: .init(.northward_wind_700hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_700hPa, member), time: time)
+        case .wind_speed_500hPa:
+            fallthrough
         case .windspeed_500hPa:
             try prefetchData(raw: .init(.northward_wind_500hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_500hPa, member), time: time)
+        case .wind_speed_300hPa:
+            fallthrough
         case .windspeed_300hPa:
             try prefetchData(raw: .init(.northward_wind_300hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_300hPa, member), time: time)
+        case .wind_speed_250hPa:
+            fallthrough
         case .windspeed_250hPa:
             try prefetchData(raw: .init(.northward_wind_250hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_250hPa, member), time: time)
+        case .wind_speed_200hPa:
+            fallthrough
         case .windspeed_200hPa:
             try prefetchData(raw: .init(.northward_wind_200hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_200hPa, member), time: time)
+        case .wind_speed_50hPa:
+            fallthrough
         case .windspeed_50hPa:
             try prefetchData(raw: .init(.northward_wind_50hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_50hPa, member), time: time)
+        case .wind_direction_10m:
+            fallthrough
         case .winddirection_10m:
             try prefetchData(raw: .init(.northward_wind_10m, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_10m, member), time: time)
+        case .wind_direction_1000hPa:
+            fallthrough
         case .winddirection_1000hPa:
             try prefetchData(raw: .init(.northward_wind_1000hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_1000hPa, member), time: time)
+        case .wind_direction_925hPa:
+            fallthrough
         case .winddirection_925hPa:
             try prefetchData(raw: .init(.northward_wind_925hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_925hPa, member), time: time)
+        case .wind_direction_850hPa:
+            fallthrough
         case .winddirection_850hPa:
             try prefetchData(raw: .init(.northward_wind_850hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_850hPa, member), time: time)
+        case .wind_direction_700hPa:
+            fallthrough
         case .winddirection_700hPa:
             try prefetchData(raw: .init(.northward_wind_700hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_700hPa, member), time: time)
+        case .wind_direction_500hPa:
+            fallthrough
         case .winddirection_500hPa:
             try prefetchData(raw: .init(.northward_wind_500hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_500hPa, member), time: time)
+        case .wind_direction_300hPa:
+            fallthrough
         case .winddirection_300hPa:
             try prefetchData(raw: .init(.northward_wind_300hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_300hPa, member), time: time)
+        case .wind_direction_250hPa:
+            fallthrough
         case .winddirection_250hPa:
             try prefetchData(raw: .init(.northward_wind_250hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_250hPa, member), time: time)
+        case .wind_direction_200hPa:
+            fallthrough
         case .winddirection_200hPa:
             try prefetchData(raw: .init(.northward_wind_200hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_200hPa, member), time: time)
+        case .wind_direction_50hPa:
+            fallthrough
         case .winddirection_50hPa:
             try prefetchData(raw: .init(.northward_wind_50hPa, member), time: time)
             try prefetchData(raw: .init(.eastward_wind_50hPa, member), time: time)
@@ -345,24 +477,44 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             fallthrough
         case .soil_temperature_0_7cm:
             try prefetchData(raw: .init(.soil_temperature_0_to_7cm, member), time: time)
+        case .cloud_cover_1000hPa:
+            fallthrough
         case .cloudcover_1000hPa:
             try prefetchData(raw: .init(.relative_humidity_1000hPa, member), time: time)
+        case .cloud_cover_925hPa:
+            fallthrough
         case .cloudcover_925hPa:
             try prefetchData(raw: .init(.relative_humidity_925hPa, member), time: time)
+        case .cloud_cover_850hPa:
+            fallthrough
         case .cloudcover_850hPa:
             try prefetchData(raw: .init(.relative_humidity_850hPa, member), time: time)
+        case .cloud_cover_700hPa:
+            fallthrough
         case .cloudcover_700hPa:
             try prefetchData(raw: .init(.relative_humidity_700hPa, member), time: time)
+        case .cloud_cover_500hPa:
+            fallthrough
         case .cloudcover_500hPa:
             try prefetchData(raw: .init(.relative_humidity_500hPa, member), time: time)
+        case .cloud_cover_300hPa:
+            fallthrough
         case .cloudcover_300hPa:
             try prefetchData(raw: .init(.relative_humidity_300hPa, member), time: time)
+        case .cloud_cover_250hPa:
+            fallthrough
         case .cloudcover_250hPa:
             try prefetchData(raw: .init(.relative_humidity_250hPa, member), time: time)
+        case .cloud_cover_200hPa:
+            fallthrough
         case .cloudcover_200hPa:
             try prefetchData(raw: .init(.relative_humidity_200hPa, member), time: time)
+        case .cloud_cover_50hPa:
+            fallthrough
         case .cloudcover_50hPa:
             try prefetchData(raw: .init(.relative_humidity_50hPa, member), time: time)
+        case .weather_code:
+            fallthrough
         case .weathercode:
             try prefetchData(raw: .init(.cloudcover, member), time: time)
             try prefetchData(derived: .init(.snowfall, member), time: time)
@@ -392,30 +544,48 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             try prefetchData(raw: .init(.relative_humidity_200hPa, member), time: time)
         case .relativehumidity_50hPa:
             try prefetchData(raw: .init(.relative_humidity_50hPa, member), time: time)
+        case .dew_point_1000hPa:
+            fallthrough
         case .dewpoint_1000hPa:
             try prefetchData(raw: .init(.temperature_1000hPa, member), time: time)
             try prefetchData(raw: .init(.relative_humidity_1000hPa, member), time: time)
+        case .dew_point_925hPa:
+            fallthrough
         case .dewpoint_925hPa:
             try prefetchData(raw: .init(.temperature_925hPa, member), time: time)
             try prefetchData(raw: .init(.relative_humidity_925hPa, member), time: time)
+        case .dew_point_850hPa:
+            fallthrough
         case .dewpoint_850hPa:
             try prefetchData(raw: .init(.temperature_850hPa, member), time: time)
             try prefetchData(raw: .init(.relative_humidity_850hPa, member), time: time)
+        case .dew_point_700hPa:
+            fallthrough
         case .dewpoint_700hPa:
             try prefetchData(raw: .init(.temperature_700hPa, member), time: time)
             try prefetchData(raw: .init(.relative_humidity_700hPa, member), time: time)
+        case .dew_point_500hPa:
+            fallthrough
         case .dewpoint_500hPa:
             try prefetchData(raw: .init(.temperature_500hPa, member), time: time)
             try prefetchData(raw: .init(.relative_humidity_500hPa, member), time: time)
+        case .dew_point_300hPa:
+            fallthrough
         case .dewpoint_300hPa:
             try prefetchData(raw: .init(.temperature_300hPa, member), time: time)
             try prefetchData(raw: .init(.relative_humidity_300hPa, member), time: time)
+        case .dew_point_250hPa:
+            fallthrough
         case .dewpoint_250hPa:
             try prefetchData(raw: .init(.temperature_250hPa, member), time: time)
             try prefetchData(raw: .init(.relative_humidity_250hPa, member), time: time)
+        case .dew_point_200hPa:
+            fallthrough
         case .dewpoint_200hPa:
             try prefetchData(raw: .init(.temperature_200hPa, member), time: time)
             try prefetchData(raw: .init(.relative_humidity_200hPa, member), time: time)
+        case .dew_point_50hPa:
+            fallthrough
         case .dewpoint_50hPa:
             try prefetchData(raw: .init(.temperature_50hPa, member), time: time)
             try prefetchData(raw: .init(.relative_humidity_50hPa, member), time: time)
@@ -425,8 +595,12 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             try prefetchData(raw: .init(.skin_temperature, member), time: time)
         case .surface_pressure:
             try prefetchData(raw: .init(.surface_air_pressure, member), time: time)
+        case .relative_humidity_2m:
+            fallthrough
         case .relativehumidity_2m:
             try prefetchData(raw: .init(.relative_humidity_1000hPa, member), time: time)
+        case .dew_point_2m:
+            fallthrough
         case .dewpoint_2m:
             try prefetchData(raw: .init(.relative_humidity_1000hPa, member), time: time)
             try prefetchData(raw: .init(.temperature_2m, member), time: time)
@@ -434,12 +608,22 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             try prefetchData(derived: .init(.relativehumidity_2m, member), time: time)
             try prefetchData(raw: .init(.temperature_2m, member), time: time)
             try prefetchData(derived: .init(.windspeed_10m, member), time: time)
+        case .vapour_pressure_deficit:
+            fallthrough
         case .vapor_pressure_deficit:
             try prefetchData(derived: .init(.relativehumidity_2m, member), time: time)
             try prefetchData(raw: .init(.temperature_2m, member), time: time)
         case .wet_bulb_temperature_2m:
             try prefetchData(raw: .init(.relative_humidity_1000hPa, member), time: time)
             try prefetchData(raw: .init(.temperature_2m, member), time: time)
+        case .cloud_cover:
+            try prefetchData(raw: .init(.cloudcover, member), time: time)
+        case .cloud_cover_low:
+            try prefetchData(raw: .init(.cloudcover_low, member), time: time)
+        case .cloud_cover_mid:
+            try prefetchData(raw: .init(.cloudcover_mid, member), time: time)
+        case .cloud_cover_high:
+            try prefetchData(raw: .init(.cloudcover_high, member), time: time)
         }
     }
 }

--- a/Sources/App/Ecmwf/EcmwfReader.swift
+++ b/Sources/App/Ecmwf/EcmwfReader.swift
@@ -38,7 +38,7 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             let v = try get(raw: .init(.northward_wind_10m, member), time: time)
             let u = try get(raw: .init(.eastward_wind_10m, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .winddirection_10m:
             let v = try get(raw: .init(.northward_wind_10m, member), time: time)
             let u = try get(raw: .init(.eastward_wind_10m, member), time: time)
@@ -48,47 +48,47 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             let v = try get(raw: .init(.northward_wind_1000hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_1000hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .windspeed_925hPa:
             let v = try get(raw: .init(.northward_wind_925hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_925hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .windspeed_850hPa:
             let v = try get(raw: .init(.northward_wind_850hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_850hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .windspeed_700hPa:
             let v = try get(raw: .init(.northward_wind_700hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_700hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .windspeed_500hPa:
             let v = try get(raw: .init(.northward_wind_500hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_500hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .windspeed_300hPa:
             let v = try get(raw: .init(.northward_wind_300hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_300hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .windspeed_250hPa:
             let v = try get(raw: .init(.northward_wind_250hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_250hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .windspeed_200hPa:
             let v = try get(raw: .init(.northward_wind_200hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_200hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .windspeed_50hPa:
             let v = try get(raw: .init(.northward_wind_50hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_50hPa, member), time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .winddirection_1000hPa:
             let v = try get(raw: .init(.northward_wind_1000hPa, member), time: time)
             let u = try get(raw: .init(.eastward_wind_1000hPa, member), time: time)
@@ -158,39 +158,39 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             )
         case .cloudcover_1000hPa:
             let rh = try get(raw: .init(.relative_humidity_1000hPa, member), time: time)
-            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 1000)}), .percent)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 1000)}), .percentage)
         case .cloudcover_925hPa:
             let rh = try get(raw: .init(.relative_humidity_925hPa, member), time: time)
-            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 925)}), .percent)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 925)}), .percentage)
         case .cloudcover_850hPa:
             let rh = try get(raw: .init(.relative_humidity_850hPa, member), time: time)
-            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 850)}), .percent)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 850)}), .percentage)
         case .cloudcover_700hPa:
             let rh = try get(raw: .init(.relative_humidity_700hPa, member), time: time)
-            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 700)}), .percent)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 700)}), .percentage)
         case .cloudcover_500hPa:
             let rh = try get(raw: .init(.relative_humidity_500hPa, member), time: time)
-            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 500)}), .percent)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 500)}), .percentage)
         case .cloudcover_300hPa:
             let rh = try get(raw: .init(.relative_humidity_300hPa, member), time: time)
-            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 300)}), .percent)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 300)}), .percentage)
         case .cloudcover_250hPa:
             let rh = try get(raw: .init(.relative_humidity_250hPa, member), time: time)
-            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 250)}), .percent)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 250)}), .percentage)
         case .cloudcover_200hPa:
             let rh = try get(raw: .init(.relative_humidity_200hPa, member), time: time)
-            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 200)}), .percent)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 200)}), .percentage)
         case .cloudcover_50hPa:
             let rh = try get(raw: .init(.relative_humidity_50hPa, member), time: time)
-            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 50)}), .percent)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 50)}), .percentage)
         case .snowfall:
             let temperature = try get(raw: .init(.temperature_2m, member), time: time)
             let precipitation = try get(raw: .init(.precipitation, member), time: time)
-            return DataAndUnit(zip(temperature.data, precipitation.data).map({ $1 * ($0 >= 0 ? 0 : 0.7) }), .centimeter)
+            return DataAndUnit(zip(temperature.data, precipitation.data).map({ $1 * ($0 >= 0 ? 0 : 0.7) }), .centimetre)
         case .rain:
             let temperature = try get(raw: .init(.temperature_2m, member), time: time)
             let precipitation = try get(raw: .init(.precipitation, member), time: time)
-            return DataAndUnit(zip(temperature.data, precipitation.data).map({ $0 >= 0 ? $1 : 0 }), .millimeter)
+            return DataAndUnit(zip(temperature.data, precipitation.data).map({ $0 >= 0 ? $1 : 0 }), .millimetre)
         case .is_day:
             return DataAndUnit(Zensun.calculateIsDay(timeRange: time, lat: reader.modelLat, lon: reader.modelLon), .dimensionlessInteger)
         case .relativehumidity_1000hPa:
@@ -268,7 +268,7 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             let temperature = try get(raw: .init(.temperature_2m, member), time: time).data
             let rh = try get(derived: .init(.relativehumidity_2m, member), time: time).data
             let dewpoint = zip(temperature,rh).map(Meteorology.dewpoint)
-            return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kiloPascal)
+            return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kilopascal)
         case .wet_bulb_temperature_2m:
             let temperature = try get(raw: .init(.temperature_2m, member), time: time)
             let rh = try get(derived: .init(.relativehumidity_2m, member), time: time)

--- a/Sources/App/Ecmwf/EcmwfVariable.swift
+++ b/Sources/App/Ecmwf/EcmwfVariable.swift
@@ -167,7 +167,7 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
     var unit: SiUnit {
         switch self {
         case .precipitation: fallthrough
-        case .runoff: return .millimeter
+        case .runoff: return .millimetre
         case .soil_temperature_0_to_7cm: fallthrough
         case .skin_temperature: return .celsius
         case .geopotential_height_1000hPa: fallthrough
@@ -178,7 +178,7 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .geopotential_height_300hPa: fallthrough
         case .geopotential_height_250hPa: fallthrough
         case .geopotential_height_200hPa: fallthrough
-        case .geopotential_height_50hPa: return .meter
+        case .geopotential_height_50hPa: return .metre
         case .northward_wind_1000hPa: fallthrough
         case .northward_wind_925hPa: fallthrough
         case .northward_wind_850hPa: fallthrough
@@ -196,7 +196,7 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .eastward_wind_300hPa: fallthrough
         case .eastward_wind_250hPa: fallthrough
         case .eastward_wind_200hPa: fallthrough
-        case .eastward_wind_50hPa: return .ms
+        case .eastward_wind_50hPa: return .metrePerSecond
         case .temperature_1000hPa: fallthrough
         case .temperature_925hPa: fallthrough
         case .temperature_850hPa: fallthrough
@@ -214,12 +214,12 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .relative_humidity_300hPa: fallthrough
         case .relative_humidity_250hPa: fallthrough
         case .relative_humidity_200hPa: fallthrough
-        case .relative_humidity_50hPa: return .percent
-        case .surface_air_pressure: return .hectoPascal
-        case .pressure_msl: return .hectoPascal
-        case .total_column_integrated_water_vapour: return .kilogramPerSquareMeter
-        case .northward_wind_10m: return .ms
-        case .eastward_wind_10m: return .ms
+        case .relative_humidity_50hPa: return .percentage
+        case .surface_air_pressure: return .hectopascal
+        case .pressure_msl: return .hectopascal
+        case .total_column_integrated_water_vapour: return .kilogramPerSquareMetre
+        case .northward_wind_10m: return .metrePerSecond
+        case .eastward_wind_10m: return .metrePerSecond
         case .specific_humidity_1000hPa: fallthrough
         case .specific_humidity_925hPa: fallthrough
         case .specific_humidity_850hPa: fallthrough
@@ -249,13 +249,13 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .divergence_of_wind_200hPa: fallthrough
         case .divergence_of_wind_50hPa: return .perSecond
         case .cloudcover:
-            return .percent
+            return .percentage
         case .cloudcover_low:
-            return .percent
+            return .percentage
         case .cloudcover_mid:
-            return .percent
+            return .percentage
         case .cloudcover_high:
-            return .percent
+            return .percentage
         }
     }
     

--- a/Sources/App/Ecmwf/EcmwfVariable.swift
+++ b/Sources/App/Ecmwf/EcmwfVariable.swift
@@ -615,9 +615,12 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
 
 enum EcmwfVariableDerived: String, GenericVariableMixable {
     case relativehumidity_2m
+    case relative_humidity_2m
     case dewpoint_2m
+    case dew_point_2m
     case apparent_temperature
     case vapor_pressure_deficit
+    case vapour_pressure_deficit
     case windspeed_10m
     case windspeed_1000hPa
     case windspeed_925hPa
@@ -628,6 +631,16 @@ enum EcmwfVariableDerived: String, GenericVariableMixable {
     case windspeed_250hPa
     case windspeed_200hPa
     case windspeed_50hPa
+    case wind_speed_10m
+    case wind_speed_1000hPa
+    case wind_speed_925hPa
+    case wind_speed_850hPa
+    case wind_speed_700hPa
+    case wind_speed_500hPa
+    case wind_speed_300hPa
+    case wind_speed_250hPa
+    case wind_speed_200hPa
+    case wind_speed_50hPa
     case winddirection_10m
     case winddirection_1000hPa
     case winddirection_925hPa
@@ -638,6 +651,16 @@ enum EcmwfVariableDerived: String, GenericVariableMixable {
     case winddirection_250hPa
     case winddirection_200hPa
     case winddirection_50hPa
+    case wind_direction_10m
+    case wind_direction_1000hPa
+    case wind_direction_925hPa
+    case wind_direction_850hPa
+    case wind_direction_700hPa
+    case wind_direction_500hPa
+    case wind_direction_300hPa
+    case wind_direction_250hPa
+    case wind_direction_200hPa
+    case wind_direction_50hPa
     case cloudcover_1000hPa
     case cloudcover_925hPa
     case cloudcover_850hPa
@@ -647,6 +670,15 @@ enum EcmwfVariableDerived: String, GenericVariableMixable {
     case cloudcover_250hPa
     case cloudcover_200hPa
     case cloudcover_50hPa
+    case cloud_cover_1000hPa
+    case cloud_cover_925hPa
+    case cloud_cover_850hPa
+    case cloud_cover_700hPa
+    case cloud_cover_500hPa
+    case cloud_cover_300hPa
+    case cloud_cover_250hPa
+    case cloud_cover_200hPa
+    case cloud_cover_50hPa
     case relativehumidity_1000hPa
     case relativehumidity_925hPa
     case relativehumidity_850hPa
@@ -665,10 +697,20 @@ enum EcmwfVariableDerived: String, GenericVariableMixable {
     case dewpoint_250hPa
     case dewpoint_200hPa
     case dewpoint_50hPa
+    case dew_point_1000hPa
+    case dew_point_925hPa
+    case dew_point_850hPa
+    case dew_point_700hPa
+    case dew_point_500hPa
+    case dew_point_300hPa
+    case dew_point_250hPa
+    case dew_point_200hPa
+    case dew_point_50hPa
     case soil_temperature_0_7cm
     case soil_temperature_0_10cm
     case soil_temperature_0_to_10cm
     case weathercode
+    case weather_code
     case snowfall
     case is_day
     case surface_pressure
@@ -676,6 +718,11 @@ enum EcmwfVariableDerived: String, GenericVariableMixable {
     case soil_temperature_0cm
     case rain
     case wet_bulb_temperature_2m
+    
+    case cloud_cover
+    case cloud_cover_low
+    case cloud_cover_mid
+    case cloud_cover_high
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false

--- a/Sources/App/Era5/CerraDomain.swift
+++ b/Sources/App/Era5/CerraDomain.swift
@@ -9,20 +9,19 @@ typealias CerraHourlyVariable = VariableOrDerived<CerraVariable, CerraVariableDe
 enum CerraVariableDerived: String, RawRepresentableString, GenericVariableMixable {
     case apparent_temperature
     case dewpoint_2m
-    //case relativehumidity_2m
-    //case windspeed_10m
-    //case winddirection_10m
-    //case windspeed_100m
-    //case winddirection_100m
+    case dew_point_2m
     case vapor_pressure_deficit
+    case vapour_pressure_deficit
     case diffuse_radiation
     case surface_pressure
     case snowfall
     case rain
     case et0_fao_evapotranspiration
     case cloudcover
+    case cloud_cover
     case direct_normal_irradiance
     case weathercode
+    case weather_code
     case is_day
     case terrestrial_radiation
     case terrestrial_radiation_instant
@@ -31,6 +30,15 @@ enum CerraVariableDerived: String, RawRepresentableString, GenericVariableMixabl
     case direct_radiation_instant
     case direct_normal_irradiance_instant
     case wet_bulb_temperature_2m
+    case wind_speed_10m
+    case wind_direction_10m
+    case wind_speed_100m
+    case wind_direction_100m
+    case wind_gusts_10m
+    case relative_humidity_2m
+    case cloud_cover_low
+    case cloud_cover_mid
+    case cloud_cover_high
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false
@@ -66,30 +74,19 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
     
     func prefetchData(derived: CerraVariableDerived, time: TimerangeDt) throws {
         switch derived {
-        //case .windspeed_10m:
-        //    try prefetchData(variable: .wind_u_component_10m, time: time)
-        //    try prefetchData(variable: .wind_v_component_10m, time: time)
         case .apparent_temperature:
             try prefetchData(raw: .temperature_2m, time: time)
             try prefetchData(raw: .windspeed_10m, time: time)
             try prefetchData(raw: .relativehumidity_2m, time: time)
             try prefetchData(raw: .direct_radiation, time: time)
             try prefetchData(raw: .shortwave_radiation, time: time)
+        case .dew_point_2m:
+            fallthrough
         case .dewpoint_2m:
             try prefetchData(raw: .temperature_2m, time: time)
             try prefetchData(raw: .relativehumidity_2m, time: time)
-            /*case .relativehumidity_2m:
-            try prefetchData(variable: .temperature_2m, time: time)
-            try prefetchData(variable: .dewpoint_2m, time: time)
-        case .winddirection_10m:
-            try prefetchData(variable: .wind_u_component_10m, time: time)
-            try prefetchData(variable: .wind_v_component_10m, time: time)
-        case .windspeed_100m:
-            try prefetchData(variable: .wind_u_component_100m, time: time)
-            try prefetchData(variable: .wind_v_component_100m, time: time)
-        case .winddirection_100m:
-            try prefetchData(variable: .wind_u_component_100m, time: time)
-            try prefetchData(variable: .wind_v_component_100m, time: time)*/
+        case .vapour_pressure_deficit:
+            fallthrough
         case .vapor_pressure_deficit:
             try prefetchData(raw: .temperature_2m, time: time)
             try prefetchData(raw: .relativehumidity_2m, time: time)
@@ -106,6 +103,8 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             try prefetchData(raw: .pressure_msl, time: time)
         case .snowfall:
             try prefetchData(raw: .snowfall_water_equivalent, time: time)
+        case .cloud_cover:
+            fallthrough
         case .cloudcover:
             try prefetchData(raw: .cloudcover_low, time: time)
             try prefetchData(raw: .cloudcover_mid, time: time)
@@ -115,6 +114,8 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
         case .rain:
             try prefetchData(raw: .precipitation, time: time)
             try prefetchData(raw: .snowfall_water_equivalent, time: time)
+        case .weather_code:
+            fallthrough
         case .weathercode:
             try prefetchData(derived: .cloudcover, time: time)
             try prefetchData(raw: .precipitation, time: time)
@@ -136,6 +137,24 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
         case .wet_bulb_temperature_2m:
             try prefetchData(raw: .temperature_2m, time: time)
             try prefetchData(raw: .relativehumidity_2m, time: time)
+        case .wind_speed_10m:
+            try prefetchData(raw: .windspeed_10m, time: time)
+        case .wind_direction_10m:
+            try prefetchData(raw: .winddirection_10m, time: time)
+        case .wind_gusts_10m:
+            try prefetchData(raw: .windgusts_10m, time: time)
+        case .relative_humidity_2m:
+            try prefetchData(raw: .relativehumidity_2m, time: time)
+        case .cloud_cover_low:
+            try prefetchData(raw: .cloudcover_low, time: time)
+        case .cloud_cover_mid:
+            try prefetchData(raw: .cloudcover_mid, time: time)
+        case .cloud_cover_high:
+            try prefetchData(raw: .cloudcover_high, time: time)
+        case .wind_speed_100m:
+            try prefetchData(raw: .windspeed_100m, time: time)
+        case .wind_direction_100m:
+            try prefetchData(raw: .windspeed_100m, time: time)
         }
     }
     
@@ -151,11 +170,8 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
     
     func get(derived: CerraVariableDerived, time: TimerangeDt) throws -> DataAndUnit {
         switch derived {
-        /*case .windspeed_10m:
-            let u = try get(variable: .wind_u_component_10m, time: time)
-            let v = try get(variable: .wind_v_component_10m, time: time)
-            let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .metrePerSecond)*/
+        case .dew_point_2m:
+            fallthrough
         case .dewpoint_2m:
             let relhum = try get(raw: .relativehumidity_2m, time: time)
             let temperature = try get(raw: .temperature_2m, time: time)
@@ -166,26 +182,8 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let relhum = try get(raw: .relativehumidity_2m, time: time).data
             let radiation = try get(raw: .shortwave_radiation, time: time).data
             return DataAndUnit(Meteorology.apparentTemperature(temperature_2m: temperature, relativehumidity_2m: relhum, windspeed_10m: windspeed, shortware_radiation: radiation), .celsius)
-            /*case .relativehumidity_2m:
-            let temperature = try get(variable: .temperature_2m, time: time).data
-            let dew = try get(variable: .dewpoint_2m, time: time).data
-            let relativeHumidity = zip(temperature, dew).map(Meteorology.relativeHumidity)
-            return DataAndUnit(relativeHumidity, .percentage)
-        case .winddirection_10m:
-            let u = try get(variable: .wind_u_component_10m, time: time).data
-            let v = try get(variable: .wind_v_component_10m, time: time).data
-            let direction = Meteorology.windirectionFast(u: u, v: v)
-            return DataAndUnit(direction, .degreeDirection)
-        case .windspeed_100m:
-            let u = try get(variable: .wind_u_component_100m, time: time)
-            let v = try get(variable: .wind_v_component_100m, time: time)
-            let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .metrePerSecond)
-        case .winddirection_100m:
-            let u = try get(variable: .wind_u_component_100m, time: time).data
-            let v = try get(variable: .wind_v_component_100m, time: time).data
-            let direction = Meteorology.windirectionFast(u: u, v: v)
-            return DataAndUnit(direction, .degreeDirection)*/
+        case .vapour_pressure_deficit:
+            fallthrough
         case .vapor_pressure_deficit:
             let temperature = try get(raw: .temperature_2m, time: time).data
             let dewpoint = try get(derived: .dewpoint_2m, time: time).data
@@ -210,6 +208,8 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let temperature = try get(raw: .temperature_2m, time: time).data
             let pressure = try get(raw: .pressure_msl, time: time)
             return DataAndUnit(Meteorology.surfacePressure(temperature: temperature, pressure: pressure.data, elevation: targetElevation), pressure.unit)
+        case .cloud_cover:
+            fallthrough
         case .cloudcover:
             let low = try get(raw: .cloudcover_low, time: time).data
             let mid = try get(raw: .cloudcover_mid, time: time).data
@@ -230,6 +230,8 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 return max($0.0-$0.1, 0)
             })
             return DataAndUnit(rain, precip.unit)
+        case .weather_code:
+            fallthrough
         case .weathercode:
             let cloudcover = try get(derived: .cloudcover, time: time).data
             let precipitation = try get(raw: .precipitation, time: time).data
@@ -274,6 +276,24 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let relhum = try get(raw: .relativehumidity_2m, time: time)
             let temperature = try get(raw: .temperature_2m, time: time)
             return DataAndUnit(zip(temperature.data,relhum.data).map(Meteorology.wetBulbTemperature), temperature.unit)
+        case .wind_speed_10m:
+            return try get(raw: .windspeed_10m, time: time)
+        case .wind_direction_10m:
+            return try get(raw: .winddirection_10m, time: time)
+        case .wind_speed_100m:
+            return try get(raw: .windspeed_10m, time: time)
+        case .wind_direction_100m:
+            return try get(raw: .winddirection_100m, time: time)
+        case .wind_gusts_10m:
+            return try get(raw: .windgusts_10m, time: time)
+        case .relative_humidity_2m:
+            return try get(raw: .relativehumidity_2m, time: time)
+        case .cloud_cover_low:
+            return try get(raw: .cloudcover_low, time: time)
+        case .cloud_cover_mid:
+            return try get(raw: .cloudcover_mid, time: time)
+        case .cloud_cover_high:
+            return try get(raw: .cloudcover_high, time: time)
         }
     }
 }

--- a/Sources/App/Era5/CerraDomain.swift
+++ b/Sources/App/Era5/CerraDomain.swift
@@ -155,7 +155,7 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let u = try get(variable: .wind_u_component_10m, time: time)
             let v = try get(variable: .wind_v_component_10m, time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)*/
+            return DataAndUnit(speed, .metrePerSecond)*/
         case .dewpoint_2m:
             let relhum = try get(raw: .relativehumidity_2m, time: time)
             let temperature = try get(raw: .temperature_2m, time: time)
@@ -170,7 +170,7 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let temperature = try get(variable: .temperature_2m, time: time).data
             let dew = try get(variable: .dewpoint_2m, time: time).data
             let relativeHumidity = zip(temperature, dew).map(Meteorology.relativeHumidity)
-            return DataAndUnit(relativeHumidity, .percent)
+            return DataAndUnit(relativeHumidity, .percentage)
         case .winddirection_10m:
             let u = try get(variable: .wind_u_component_10m, time: time).data
             let v = try get(variable: .wind_v_component_10m, time: time).data
@@ -180,7 +180,7 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let u = try get(variable: .wind_u_component_100m, time: time)
             let v = try get(variable: .wind_v_component_100m, time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .winddirection_100m:
             let u = try get(variable: .wind_u_component_100m, time: time).data
             let v = try get(variable: .wind_v_component_100m, time: time).data
@@ -189,7 +189,7 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
         case .vapor_pressure_deficit:
             let temperature = try get(raw: .temperature_2m, time: time).data
             let dewpoint = try get(derived: .dewpoint_2m, time: time).data
-            return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kiloPascal)
+            return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kilopascal)
         case .et0_fao_evapotranspiration:
             let exrad = Zensun.extraTerrestrialRadiationBackwards(latitude: modelLat, longitude: modelLon, timerange: time)
             let swrad = try get(raw: .shortwave_radiation, time: time).data
@@ -200,12 +200,12 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let et0 = swrad.indices.map { i in
                 return Meteorology.et0Evapotranspiration(temperature2mCelsius: temperature[i], windspeed10mMeterPerSecond: windspeed[i], dewpointCelsius: dewpoint[i], shortwaveRadiationWatts: swrad[i], elevation: self.modelElevation.numeric, extraTerrestrialRadiation: exrad[i], dtSeconds: 3600)
             }
-            return DataAndUnit(et0, .millimeter)
+            return DataAndUnit(et0, .millimetre)
         case .diffuse_radiation:
             let swrad = try get(raw: .shortwave_radiation, time: time).data
             let direct = try get(raw: .direct_radiation, time: time).data
             let diff = zip(swrad,direct).map(-)
-            return DataAndUnit(diff, .wattPerSquareMeter)
+            return DataAndUnit(diff, .wattPerSquareMetre)
         case .surface_pressure:
             let temperature = try get(raw: .temperature_2m, time: time).data
             let pressure = try get(raw: .pressure_msl, time: time)
@@ -214,15 +214,15 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let low = try get(raw: .cloudcover_low, time: time).data
             let mid = try get(raw: .cloudcover_mid, time: time).data
             let high = try get(raw: .cloudcover_high, time: time).data
-            return DataAndUnit(Meteorology.cloudCoverTotal(low: low, mid: mid, high: high), .percent)
+            return DataAndUnit(Meteorology.cloudCoverTotal(low: low, mid: mid, high: high), .percentage)
         case .snowfall:
             let snowwater = try get(raw: .snowfall_water_equivalent, time: time).data
             let snowfall = snowwater.map { $0 * 0.7 }
-            return DataAndUnit(snowfall, .centimeter)
+            return DataAndUnit(snowfall, .centimetre)
         case .direct_normal_irradiance:
             let dhi = try get(raw: .direct_radiation, time: time).data
             let dni = Zensun.calculateBackwardsDNI(directRadiation: dhi, latitude: modelLat, longitude: modelLon, timerange: time)
-            return DataAndUnit(dni, .wattPerSquareMeter)
+            return DataAndUnit(dni, .wattPerSquareMetre)
         case .rain:
             let snowwater = try get(raw: .snowfall_water_equivalent, time: time)
             let precip = try get(raw: .precipitation, time: time)
@@ -250,10 +250,10 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             return DataAndUnit(Zensun.calculateIsDay(timeRange: time, lat: reader.modelLat, lon: reader.modelLon), .dimensionlessInteger)
         case .terrestrial_radiation:
             let solar = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-            return DataAndUnit(solar, .wattPerSquareMeter)
+            return DataAndUnit(solar, .wattPerSquareMetre)
         case .terrestrial_radiation_instant:
             let solar = Zensun.extraTerrestrialRadiationInstant(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-            return DataAndUnit(solar, .wattPerSquareMeter)
+            return DataAndUnit(solar, .wattPerSquareMetre)
         case .shortwave_radiation_instant:
             let sw = try get(raw: .shortwave_radiation, time: time)
             let factor = Zensun.backwardsAveragedToInstantFactor(time: time, latitude: reader.modelLat, longitude: reader.modelLon)
@@ -425,19 +425,19 @@ enum CerraVariable: String, CaseIterable, GenericVariable {
         switch self {
         case .windspeed_10m: fallthrough
         case .windspeed_100m: fallthrough
-        case .windgusts_10m: return .ms
+        case .windgusts_10m: return .metrePerSecond
         case .winddirection_10m: return .degreeDirection
         case .winddirection_100m: return .degreeDirection
-        case .relativehumidity_2m: return .percent
+        case .relativehumidity_2m: return .percentage
         case .temperature_2m: return .celsius
-        case .cloudcover_low: return .percent
-        case .cloudcover_mid: return .percent
-        case .cloudcover_high: return .percent
+        case .cloudcover_low: return .percentage
+        case .cloudcover_mid: return .percentage
+        case .cloudcover_high: return .percentage
         case .pressure_msl: return .pascal
-        case .snowfall_water_equivalent: return .millimeter
-        case .shortwave_radiation: return .wattPerSquareMeter
-        case .precipitation: return .millimeter
-        case .direct_radiation: return .wattPerSquareMeter
+        case .snowfall_water_equivalent: return .millimetre
+        case .shortwave_radiation: return .wattPerSquareMetre
+        case .precipitation: return .millimetre
+        case .direct_radiation: return .wattPerSquareMetre
         }
     }
 }

--- a/Sources/App/Era5/DownloadEra5Command.swift
+++ b/Sources/App/Era5/DownloadEra5Command.swift
@@ -231,7 +231,7 @@ struct DownloadEra5Command: AsyncCommandFix {
         let binsPerYear = 6
         let nLocationChunks = 200
         let writer = OmFileWriter(dim0: domain.grid.count, dim1: binsPerYear, chunk0: nLocationChunks, chunk1: binsPerYear)
-        let units = ApiUnits(temperature_unit: .celsius, windspeed_unit: .ms, precipitation_unit: .mm, length_unit: .metric)
+        let units = ApiUnits(temperature_unit: .celsius, windspeed_unit: .ms, wind_speed_unit: nil, precipitation_unit: .mm, length_unit: .metric)
         let variables: [Cmip6VariableOrDerived] = Cmip6Variable.allCases.map{.raw($0)} + Cmip6VariableDerivedBiasCorrected.allCases.map{.derived($0)}
         let availableForEra5Land: [Cmip6VariableOrDerived] = [
             Cmip6Variable.temperature_2m_min,

--- a/Sources/App/Era5/Era5Controller.swift
+++ b/Sources/App/Era5/Era5Controller.swift
@@ -9,19 +9,30 @@ typealias Era5HourlyVariable = VariableOrDerived<Era5Variable, Era5VariableDeriv
 enum Era5VariableDerived: String, RawRepresentableString, GenericVariableMixable {
     case apparent_temperature
     case relativehumidity_2m
+    case relative_humidity_2m
     case windspeed_10m
+    case wind_speed_10m
     case winddirection_10m
+    case wind_direction_10m
     case windspeed_100m
+    case wind_speed_100m
     case winddirection_100m
+    case wind_direction_100m
     case vapor_pressure_deficit
+    case vapour_pressure_deficit
     case diffuse_radiation
     case surface_pressure
     case snowfall
     case rain
     case et0_fao_evapotranspiration
     case cloudcover
+    case cloud_cover
+    case cloud_cover_low
+    case cloud_cover_mid
+    case cloud_cover_high
     case direct_normal_irradiance
     case weathercode
+    case weather_code
     case soil_moisture_0_to_100cm
     case soil_temperature_0_to_100cm
     case growing_degree_days_base_0_limit_50
@@ -39,6 +50,8 @@ enum Era5VariableDerived: String, RawRepresentableString, GenericVariableMixable
     case direct_radiation_instant
     case direct_normal_irradiance_instant
     case wet_bulb_temperature_2m
+    case wind_gusts_10m
+    case dew_point_2m
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false

--- a/Sources/App/Era5/Era5Domain.swift
+++ b/Sources/App/Era5/Era5Domain.swift
@@ -346,6 +346,8 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
     
     func prefetchData(derived: Era5VariableDerived, time: TimerangeDt) throws {
         switch derived {
+        case .wind_speed_10m:
+            fallthrough
         case .windspeed_10m:
             try prefetchData(raw: .wind_u_component_10m, time: time)
             try prefetchData(raw: .wind_v_component_10m, time: time)
@@ -356,18 +358,28 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             try prefetchData(raw: .dewpoint_2m, time: time)
             try prefetchData(raw: .direct_radiation, time: time)
             try prefetchData(raw: .shortwave_radiation, time: time)
+        case .relative_humidity_2m:
+            fallthrough
         case .relativehumidity_2m:
             try prefetchData(raw: .temperature_2m, time: time)
             try prefetchData(raw: .dewpoint_2m, time: time)
+        case .wind_direction_10m:
+            fallthrough
         case .winddirection_10m:
             try prefetchData(raw: .wind_u_component_10m, time: time)
             try prefetchData(raw: .wind_v_component_10m, time: time)
+        case .wind_speed_100m:
+            fallthrough
         case .windspeed_100m:
             try prefetchData(raw: .wind_u_component_100m, time: time)
             try prefetchData(raw: .wind_v_component_100m, time: time)
+        case .wind_direction_100m:
+            fallthrough
         case .winddirection_100m:
             try prefetchData(raw: .wind_u_component_100m, time: time)
             try prefetchData(raw: .wind_v_component_100m, time: time)
+        case .vapour_pressure_deficit:
+            fallthrough
         case .vapor_pressure_deficit:
             try prefetchData(raw: .temperature_2m, time: time)
             try prefetchData(raw: .dewpoint_2m, time: time)
@@ -384,6 +396,8 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             try prefetchData(raw: .pressure_msl, time: time)
         case .snowfall:
             try prefetchData(raw: .snowfall_water_equivalent, time: time)
+        case .cloud_cover:
+            fallthrough
         case .cloudcover:
             try prefetchData(raw: .cloudcover_low, time: time)
             try prefetchData(raw: .cloudcover_mid, time: time)
@@ -393,6 +407,8 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
         case .rain:
             try prefetchData(raw: .precipitation, time: time)
             try prefetchData(raw: .snowfall_water_equivalent, time: time)
+        case .weather_code:
+            fallthrough
         case .weathercode:
             try prefetchData(derived: .cloudcover, time: time)
             try prefetchData(raw: .precipitation, time: time)
@@ -438,6 +454,16 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
         case .wet_bulb_temperature_2m:
             try prefetchData(raw: .dewpoint_2m, time: time)
             try prefetchData(raw: .temperature_2m, time: time)
+        case .cloud_cover_low:
+            try prefetchData(raw: .cloudcover_low, time: time)
+        case .cloud_cover_mid:
+            try prefetchData(raw: .cloudcover_mid, time: time)
+        case .cloud_cover_high:
+            try prefetchData(raw: .cloudcover_high, time: time)
+        case .wind_gusts_10m:
+            try prefetchData(raw: .windgusts_10m, time: time)
+        case .dew_point_2m:
+            try prefetchData(raw: .dewpoint_2m, time: time)
         }
     }
     
@@ -452,6 +478,8 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
     
     func get(derived: Era5VariableDerived, time: TimerangeDt) throws -> DataAndUnit {
         switch derived {
+        case .wind_speed_10m:
+            fallthrough
         case .windspeed_10m:
             let u = try get(raw: .wind_u_component_10m, time: time)
             let v = try get(raw: .wind_v_component_10m, time: time)
@@ -463,26 +491,36 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let relhum = try get(derived: .relativehumidity_2m, time: time).data
             let radiation = try get(raw: .shortwave_radiation, time: time).data
             return DataAndUnit(Meteorology.apparentTemperature(temperature_2m: temperature, relativehumidity_2m: relhum, windspeed_10m: windspeed, shortware_radiation: radiation), .celsius)
+        case .relative_humidity_2m:
+            fallthrough
         case .relativehumidity_2m:
             let temperature = try get(raw: .temperature_2m, time: time).data
             let dew = try get(raw: .dewpoint_2m, time: time).data
             let relativeHumidity = zip(temperature, dew).map(Meteorology.relativeHumidity)
             return DataAndUnit(relativeHumidity, .percentage)
+        case .wind_direction_10m:
+            fallthrough
         case .winddirection_10m:
             let u = try get(raw: .wind_u_component_10m, time: time).data
             let v = try get(raw: .wind_v_component_10m, time: time).data
             let direction = Meteorology.windirectionFast(u: u, v: v)
             return DataAndUnit(direction, .degreeDirection)
+        case .wind_speed_100m:
+            fallthrough
         case .windspeed_100m:
             let u = try get(raw: .wind_u_component_100m, time: time)
             let v = try get(raw: .wind_v_component_100m, time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
+        case .wind_direction_100m:
+            fallthrough
         case .winddirection_100m:
             let u = try get(raw: .wind_u_component_100m, time: time).data
             let v = try get(raw: .wind_v_component_100m, time: time).data
             let direction = Meteorology.windirectionFast(u: u, v: v)
             return DataAndUnit(direction, .degreeDirection)
+        case .vapour_pressure_deficit:
+            fallthrough
         case .vapor_pressure_deficit:
             let temperature = try get(raw: .temperature_2m, time: time).data
             let dewpoint = try get(raw: .dewpoint_2m, time: time).data
@@ -507,6 +545,8 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let temperature = try get(raw: .temperature_2m, time: time).data
             let pressure = try get(raw: .pressure_msl, time: time)
             return DataAndUnit(Meteorology.surfacePressure(temperature: temperature, pressure: pressure.data, elevation: targetElevation), pressure.unit)
+        case .cloud_cover:
+            fallthrough
         case .cloudcover:
             let low = try get(raw: .cloudcover_low, time: time).data
             let mid = try get(raw: .cloudcover_mid, time: time).data
@@ -527,6 +567,8 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
                 return max($0.0-$0.1, 0)
             })
             return DataAndUnit(rain, precip.unit)
+        case .weather_code:
+            fallthrough
         case .weathercode:
             let cloudcover = try get(derived: .cloudcover, time: time).data
             let precipitation = try get(raw: .precipitation, time: time).data
@@ -648,6 +690,16 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let dew = try get(raw: .dewpoint_2m, time: time).data
             let rh = zip(temperature.data, dew).map(Meteorology.relativeHumidity)
             return DataAndUnit(zip(temperature.data, rh).map(Meteorology.wetBulbTemperature), temperature.unit)
+        case .cloud_cover_low:
+            return try get(raw: .cloudcover_low, time: time)
+        case .cloud_cover_mid:
+            return try get(raw: .cloudcover_mid, time: time)
+        case .cloud_cover_high:
+            return try get(raw: .cloudcover_high, time: time)
+        case .wind_gusts_10m:
+            return try get(raw: .windgusts_10m, time: time)
+        case .dew_point_2m:
+            return try get(raw: .dewpoint_2m, time: time)
         }
     }
 }

--- a/Sources/App/Era5/Era5Domain.swift
+++ b/Sources/App/Era5/Era5Domain.swift
@@ -269,26 +269,26 @@ enum Era5Variable: String, CaseIterable, GenericVariable {
         case .wind_v_component_100m: fallthrough
         case .wind_u_component_10m: fallthrough
         case .wind_v_component_10m: fallthrough
-        case .windgusts_10m: return .ms
+        case .windgusts_10m: return .metrePerSecond
         case .dewpoint_2m: return .celsius
         case .temperature_2m: return .celsius
-        case .cloudcover_low: return .percent
-        case .cloudcover_mid: return .percent
-        case .cloudcover_high: return .percent
+        case .cloudcover_low: return .percentage
+        case .cloudcover_mid: return .percentage
+        case .cloudcover_high: return .percentage
         case .pressure_msl: return .pascal
-        case .snowfall_water_equivalent: return .millimeter
+        case .snowfall_water_equivalent: return .millimetre
         case .soil_temperature_0_to_7cm: return .celsius
         case .soil_temperature_7_to_28cm: return .celsius
         case .soil_temperature_28_to_100cm: return .celsius
         case .soil_temperature_100_to_255cm: return .celsius
-        case .shortwave_radiation: return .wattPerSquareMeter
-        case .precipitation: return .millimeter
-        case .direct_radiation: return .wattPerSquareMeter
-        case .soil_moisture_0_to_7cm: return .qubicMeterPerQubicMeter
-        case .soil_moisture_7_to_28cm: return .qubicMeterPerQubicMeter
-        case .soil_moisture_28_to_100cm: return .qubicMeterPerQubicMeter
-        case .soil_moisture_100_to_255cm: return .qubicMeterPerQubicMeter
-        case .snow_depth: return .meter
+        case .shortwave_radiation: return .wattPerSquareMetre
+        case .precipitation: return .millimetre
+        case .direct_radiation: return .wattPerSquareMetre
+        case .soil_moisture_0_to_7cm: return .cubicMetrePerCubicMetre
+        case .soil_moisture_7_to_28cm: return .cubicMetrePerCubicMetre
+        case .soil_moisture_28_to_100cm: return .cubicMetrePerCubicMetre
+        case .soil_moisture_100_to_255cm: return .cubicMetrePerCubicMetre
+        case .snow_depth: return .metre
         }
     }
 }
@@ -456,7 +456,7 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let u = try get(raw: .wind_u_component_10m, time: time)
             let v = try get(raw: .wind_v_component_10m, time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .apparent_temperature:
             let windspeed = try get(derived: .windspeed_10m, time: time).data
             let temperature = try get(raw: .temperature_2m, time: time).data
@@ -467,7 +467,7 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let temperature = try get(raw: .temperature_2m, time: time).data
             let dew = try get(raw: .dewpoint_2m, time: time).data
             let relativeHumidity = zip(temperature, dew).map(Meteorology.relativeHumidity)
-            return DataAndUnit(relativeHumidity, .percent)
+            return DataAndUnit(relativeHumidity, .percentage)
         case .winddirection_10m:
             let u = try get(raw: .wind_u_component_10m, time: time).data
             let v = try get(raw: .wind_v_component_10m, time: time).data
@@ -477,7 +477,7 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let u = try get(raw: .wind_u_component_100m, time: time)
             let v = try get(raw: .wind_v_component_100m, time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .ms)
+            return DataAndUnit(speed, .metrePerSecond)
         case .winddirection_100m:
             let u = try get(raw: .wind_u_component_100m, time: time).data
             let v = try get(raw: .wind_v_component_100m, time: time).data
@@ -486,7 +486,7 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
         case .vapor_pressure_deficit:
             let temperature = try get(raw: .temperature_2m, time: time).data
             let dewpoint = try get(raw: .dewpoint_2m, time: time).data
-            return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kiloPascal)
+            return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kilopascal)
         case .et0_fao_evapotranspiration:
             let exrad = Zensun.extraTerrestrialRadiationBackwards(latitude: modelLat, longitude: modelLon, timerange: time)
             let swrad = try get(raw: .shortwave_radiation, time: time).data
@@ -497,12 +497,12 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let et0 = swrad.indices.map { i in
                 return Meteorology.et0Evapotranspiration(temperature2mCelsius: temperature[i], windspeed10mMeterPerSecond: windspeed[i], dewpointCelsius: dewpoint[i], shortwaveRadiationWatts: swrad[i], elevation: self.modelElevation.numeric, extraTerrestrialRadiation: exrad[i], dtSeconds: 3600)
             }
-            return DataAndUnit(et0, .millimeter)
+            return DataAndUnit(et0, .millimetre)
         case .diffuse_radiation:
             let swrad = try get(raw: .shortwave_radiation, time: time).data
             let direct = try get(raw: .direct_radiation, time: time).data
             let diff = zip(swrad,direct).map(-)
-            return DataAndUnit(diff, .wattPerSquareMeter)
+            return DataAndUnit(diff, .wattPerSquareMetre)
         case .surface_pressure:
             let temperature = try get(raw: .temperature_2m, time: time).data
             let pressure = try get(raw: .pressure_msl, time: time)
@@ -511,15 +511,15 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let low = try get(raw: .cloudcover_low, time: time).data
             let mid = try get(raw: .cloudcover_mid, time: time).data
             let high = try get(raw: .cloudcover_high, time: time).data
-            return DataAndUnit(Meteorology.cloudCoverTotal(low: low, mid: mid, high: high), .percent)
+            return DataAndUnit(Meteorology.cloudCoverTotal(low: low, mid: mid, high: high), .percentage)
         case .snowfall:
             let snowwater = try get(raw: .snowfall_water_equivalent, time: time).data
             let snowfall = snowwater.map { $0 * 0.7 }
-            return DataAndUnit(snowfall, .centimeter)
+            return DataAndUnit(snowfall, .centimetre)
         case .direct_normal_irradiance:
             let dhi = try get(raw: .direct_radiation, time: time).data
             let dni = Zensun.calculateBackwardsDNI(directRadiation: dhi, latitude: modelLat, longitude: modelLon, timerange: time)
-            return DataAndUnit(dni, .wattPerSquareMeter)
+            return DataAndUnit(dni, .wattPerSquareMetre)
         case .rain:
             let snowwater = try get(raw: .snowfall_water_equivalent, time: time)
             let precip = try get(raw: .precipitation, time: time)
@@ -573,7 +573,7 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             return DataAndUnit(zip(zip(temperature, dewpoint), precipitation).map( {
                 let ((temperature, dewpoint), precipitation) = $0
                 return Meteorology.leafwetnessPorbability(temperature2mCelsius: temperature, dewpointCelsius: dewpoint, precipitation: precipitation)
-            }), .percent)
+            }), .percentage)
         case .soil_moisture_index_0_to_7cm:
             guard let soilType = try self.getStatic(type: .soilType) else {
                 throw ForecastapiError.generic(message: "Could not read ERA5 soil type")
@@ -623,10 +623,10 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             return DataAndUnit(Zensun.calculateIsDay(timeRange: time, lat: reader.modelLat, lon: reader.modelLon), .dimensionlessInteger)
         case .terrestrial_radiation:
             let solar = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-            return DataAndUnit(solar, .wattPerSquareMeter)
+            return DataAndUnit(solar, .wattPerSquareMetre)
         case .terrestrial_radiation_instant:
             let solar = Zensun.extraTerrestrialRadiationInstant(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-            return DataAndUnit(solar, .wattPerSquareMeter)
+            return DataAndUnit(solar, .wattPerSquareMetre)
         case .shortwave_radiation_instant:
             let sw = try get(raw: .shortwave_radiation, time: time)
             let factor = Zensun.backwardsAveragedToInstantFactor(time: time, latitude: reader.modelLat, longitude: reader.modelLon)

--- a/Sources/App/Gem/GemController.swift
+++ b/Sources/App/Gem/GemController.swift
@@ -5,9 +5,13 @@ import Vapor
 enum GemVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case apparent_temperature
     case dewpoint_2m
+    case dew_point_2m
     case cloudcover_low
     case cloudcover_mid
     case cloudcover_high
+    case cloud_cover_low
+    case cloud_cover_mid
+    case cloud_cover_high
     case direct_normal_irradiance
     case direct_normal_irradiance_instant
     case direct_radiation
@@ -17,14 +21,28 @@ enum GemVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case shortwave_radiation_instant
     case et0_fao_evapotranspiration
     case vapor_pressure_deficit
+    case vapour_pressure_deficit
     case surface_pressure
     case terrestrial_radiation
     case terrestrial_radiation_instant
     case snowfall
     case rain
     case weathercode
+    case weather_code
     case is_day
     case wet_bulb_temperature_2m
+    
+    case relative_humidity_2m
+    case cloud_cover
+    case wind_speed_10m
+    case wind_direction_10m
+    case wind_speed_40m
+    case wind_direction_40m
+    case wind_speed_80m
+    case wind_direction_80m
+    case wind_speed_120m
+    case wind_direction_120m
+    case wind_gusts_10m
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false
@@ -37,6 +55,11 @@ enum GemVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
 enum GemPressureVariableDerivedType: String, CaseIterable {
     case dewpoint
     case cloudcover
+    case dew_point
+    case cloud_cover
+    case wind_speed
+    case wind_direction
+    case relative_humidity
 }
 
 /**
@@ -83,9 +106,13 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 try prefetchData(raw: .init(.surface(.windspeed_10m), member), time: time)
                 try prefetchData(raw: .init(.surface(.relativehumidity_2m), member), time: time)
                 try prefetchData(raw: .init(.surface(.shortwave_radiation), member), time: time)
+            case .dew_point_2m:
+                fallthrough
             case .dewpoint_2m:
                 try prefetchData(raw: .init(.surface(.temperature_2m), member), time: time)
                 try prefetchData(raw: .init(.surface(.relativehumidity_2m), member), time: time)
+            case .vapour_pressure_deficit:
+                fallthrough
             case .vapor_pressure_deficit:
                 try prefetchData(raw: .init(.surface(.temperature_2m), member), time: time)
                 try prefetchData(raw: .init(.surface(.relativehumidity_2m), member), time: time)
@@ -123,18 +150,26 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 if reader.domain != .gem_global_ensemble {
                     try prefetchData(raw: .init(.surface(.showers), member), time: time)
                 }
+            case .cloud_cover_low:
+                fallthrough
             case .cloudcover_low:
                 try prefetchData(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 1000)), member), time: time)
                 try prefetchData(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 950)), member), time: time)
                 try prefetchData(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 850)), member), time: time)
+            case .cloud_cover_mid:
+                fallthrough
             case .cloudcover_mid:
                 try prefetchData(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 700)), member), time: time)
                 try prefetchData(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 600)), member), time: time)
                 try prefetchData(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 500)), member), time: time)
+            case .cloud_cover_high:
+                fallthrough
             case .cloudcover_high:
                 try prefetchData(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 400)), member), time: time)
                 try prefetchData(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 300)), member), time: time)
                 try prefetchData(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 200)), member), time: time)
+            case .weather_code:
+                fallthrough
             case .weathercode:
                 try prefetchData(raw: .init(.surface(.cloudcover), member), time: time)
                 try prefetchData(raw: .init(.surface(.precipitation), member), time: time)
@@ -147,13 +182,45 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             case .wet_bulb_temperature_2m:
                 try prefetchData(raw: .init(.surface(.temperature_2m), member), time: time)
                 try prefetchData(raw: .init(.surface(.relativehumidity_2m), member), time: time)
+            case .relative_humidity_2m:
+                try prefetchData(raw: .init(.surface(.relativehumidity_2m), member), time: time)
+            case .cloud_cover:
+                try prefetchData(raw: .init(.surface(.cloudcover), member), time: time)
+            case .wind_speed_10m:
+                try prefetchData(raw: .init(.surface(.windspeed_10m), member), time: time)
+            case .wind_direction_10m:
+                try prefetchData(raw: .init(.surface(.winddirection_10m), member), time: time)
+            case .wind_speed_40m:
+                try prefetchData(raw: .init(.surface(.windspeed_40m), member), time: time)
+            case .wind_direction_40m:
+                try prefetchData(raw: .init(.surface(.winddirection_40m), member), time: time)
+            case .wind_speed_80m:
+                try prefetchData(raw: .init(.surface(.windspeed_80m), member), time: time)
+            case .wind_direction_80m:
+                try prefetchData(raw: .init(.surface(.winddirection_80m), member), time: time)
+            case .wind_speed_120m:
+                try prefetchData(raw: .init(.surface(.windspeed_120m), member), time: time)
+            case .wind_direction_120m:
+                try prefetchData(raw: .init(.surface(.winddirection_120m), member), time: time)
+            case .wind_gusts_10m:
+                try prefetchData(raw: .init(.surface(.windgusts_10m), member), time: time)
             }
         case .pressure(let v):
             switch v.variable {
+            case .dew_point:
+                fallthrough
             case .dewpoint:
                 try prefetchData(raw: .init(.pressure(GemPressureVariable(variable: .temperature, level: v.level)), member), time: time)
                 try prefetchData(raw: .init(.pressure(GemPressureVariable(variable: .relativehumidity, level: v.level)), member), time: time)
+            case .cloud_cover:
+                fallthrough
             case .cloudcover:
+                try prefetchData(raw: .init(.pressure(GemPressureVariable(variable: .relativehumidity, level: v.level)), member), time: time)
+            case .wind_speed:
+                try prefetchData(raw: .init(.pressure(GemPressureVariable(variable: .windspeed, level: v.level)), member), time: time)
+            case .wind_direction:
+                try prefetchData(raw: .init(.pressure(GemPressureVariable(variable: .winddirection, level: v.level)), member), time: time)
+            case .relative_humidity:
                 try prefetchData(raw: .init(.pressure(GemPressureVariable(variable: .relativehumidity, level: v.level)), member), time: time)
             }
         }
@@ -170,6 +237,8 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 let relhum = try get(raw: .init(.surface(.relativehumidity_2m), member), time: time).data
                 let radiation = try get(raw: .init(.surface(.shortwave_radiation), member), time: time).data
                 return DataAndUnit(Meteorology.apparentTemperature(temperature_2m: temperature, relativehumidity_2m: relhum, windspeed_10m: windspeed, shortware_radiation: radiation), .celsius)
+            case .vapour_pressure_deficit:
+                fallthrough
             case .vapor_pressure_deficit:
                 let temperature = try get(raw: .init(.surface(.temperature_2m), member), time: time).data
                 let rh = try get(raw: .init(.surface(.relativehumidity_2m), member), time: time).data
@@ -227,6 +296,8 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 let diff = try get(derived: .init(.surface(.diffuse_radiation), member), time: time)
                 let factor = Zensun.backwardsAveragedToInstantFactor(time: time, latitude: reader.modelLat, longitude: reader.modelLon)
                 return DataAndUnit(zip(diff.data, factor).map(*), diff.unit)
+            case .dew_point_2m:
+                fallthrough
             case .dewpoint_2m:
                 let temperature = try get(raw: .init(.surface(.temperature_2m), member), time: time)
                 let rh = try get(raw: .init(.surface(.relativehumidity_2m), member), time: time)
@@ -248,21 +319,29 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                     return max(total - snowwater - showers, 0)
                 }
                 return DataAndUnit(rain, .millimetre)
+            case .cloud_cover_low:
+                fallthrough
             case .cloudcover_low:
                 let cl0 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 1000)), member), time: time)
                 let cl1 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 950)), member), time: time)
                 let cl2 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 850)), member), time: time)
                 return DataAndUnit(zip(zip(cl0.data, cl1.data).map(max), cl2.data).map(max), .percentage)
+            case .cloud_cover_mid:
+                fallthrough
             case .cloudcover_mid:
                 let cl0 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 700)), member), time: time)
                 let cl1 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 600)), member), time: time)
                 let cl2 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 500)), member), time: time)
                 return DataAndUnit(zip(zip(cl0.data, cl1.data).map(max), cl2.data).map(max), .percentage)
+            case .cloud_cover_high:
+                fallthrough
             case .cloudcover_high:
                 let cl0 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 400)), member), time: time)
                 let cl1 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 300)), member), time: time)
                 let cl2 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 200)), member), time: time)
                 return DataAndUnit(zip(zip(cl0.data, cl1.data).map(max), cl2.data).map(max), .percentage)
+            case .weather_code:
+                fallthrough
             case .weathercode:
                 let cloudcover = try get(raw: .init(.surface(.cloudcover), member), time: time).data
                 let precipitation = try get(raw: .init(.surface(.precipitation), member), time: time).data
@@ -288,16 +367,48 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 let temperature = try get(raw: .init(.surface(.temperature_2m), member), time: time)
                 let rh = try get(raw: .init(.surface(.relativehumidity_2m), member), time: time)
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.wetBulbTemperature), temperature.unit)
+            case .relative_humidity_2m:
+                return try get(raw: .init(.surface(.relativehumidity_2m), member), time: time)
+            case .cloud_cover:
+                return try get(raw: .init(.surface(.cloudcover), member), time: time)
+            case .wind_speed_10m:
+                return try get(raw: .init(.surface(.windspeed_10m), member), time: time)
+            case .wind_direction_10m:
+                return try get(raw: .init(.surface(.winddirection_10m), member), time: time)
+            case .wind_speed_40m:
+                return try get(raw: .init(.surface(.windspeed_40m), member), time: time)
+            case .wind_direction_40m:
+                return try get(raw: .init(.surface(.winddirection_40m), member), time: time)
+            case .wind_speed_80m:
+                return try get(raw: .init(.surface(.windspeed_80m), member), time: time)
+            case .wind_direction_80m:
+                return try get(raw: .init(.surface(.winddirection_80m), member), time: time)
+            case .wind_speed_120m:
+                return try get(raw: .init(.surface(.windspeed_120m), member), time: time)
+            case .wind_direction_120m:
+                return try get(raw: .init(.surface(.winddirection_120m), member), time: time)
+            case .wind_gusts_10m:
+                return try get(raw: .init(.surface(.windgusts_10m), member), time: time)
             }
         case .pressure(let v):
             switch v.variable {
+            case .dew_point:
+                fallthrough
             case .dewpoint:
                 let temperature = try get(raw: .init(.pressure(GemPressureVariable(variable: .temperature, level: v.level)), member), time: time)
                 let rh = try get(raw: .init(.pressure(GemPressureVariable(variable: .relativehumidity, level: v.level)), member), time: time)
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+            case .cloud_cover:
+                fallthrough
             case .cloudcover:
                 let rh = try get(raw: .init(.pressure(GemPressureVariable(variable: .relativehumidity, level: v.level)), member), time: time)
                 return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: Float(v.level))}), .percentage)
+            case .wind_speed:
+                return try get(raw: .init(.pressure(GemPressureVariable(variable: .windspeed, level: v.level)), member), time: time)
+            case .wind_direction:
+                return try get(raw: .init(.pressure(GemPressureVariable(variable: .winddirection, level: v.level)), member), time: time)
+            case .relative_humidity:
+                return try get(raw: .init(.pressure(GemPressureVariable(variable: .relativehumidity, level: v.level)), member), time: time)
             }
         }
     }

--- a/Sources/App/Gem/GemController.swift
+++ b/Sources/App/Gem/GemController.swift
@@ -174,7 +174,7 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 let temperature = try get(raw: .init(.surface(.temperature_2m), member), time: time).data
                 let rh = try get(raw: .init(.surface(.relativehumidity_2m), member), time: time).data
                 let dewpoint = zip(temperature,rh).map(Meteorology.dewpoint)
-                return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kiloPascal)
+                return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kilopascal)
             case .et0_fao_evapotranspiration:
                 let exrad = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
                 let swrad = try get(raw: .init(.surface(.shortwave_radiation), member), time: time).data
@@ -186,7 +186,7 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 let et0 = swrad.indices.map { i in
                     return Meteorology.et0Evapotranspiration(temperature2mCelsius: temperature[i], windspeed10mMeterPerSecond: windspeed[i], dewpointCelsius: dewpoint[i], shortwaveRadiationWatts: swrad[i], elevation: reader.targetElevation, extraTerrestrialRadiation: exrad[i], dtSeconds: 3600)
                 }
-                return DataAndUnit(et0, .millimeter)
+                return DataAndUnit(et0, .millimetre)
             case .surface_pressure:
                 let temperature = try get(raw: .init(.surface(.temperature_2m), member), time: time).data
                 let pressure = try get(raw: .init(.surface(.pressure_msl), member), time: time)
@@ -194,11 +194,11 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             case .terrestrial_radiation:
                 /// Use center averaged
                 let solar = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-                return DataAndUnit(solar, .wattPerSquareMeter)
+                return DataAndUnit(solar, .wattPerSquareMetre)
             case .terrestrial_radiation_instant:
                 /// Use center averaged
                 let solar = Zensun.extraTerrestrialRadiationInstant(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-                return DataAndUnit(solar, .wattPerSquareMeter)
+                return DataAndUnit(solar, .wattPerSquareMetre)
             case .shortwave_radiation_instant:
                 let sw = try get(raw: .init(.surface(.shortwave_radiation), member), time: time)
                 let factor = Zensun.backwardsAveragedToInstantFactor(time: time, latitude: reader.modelLat, longitude: reader.modelLon)
@@ -206,7 +206,7 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             case .direct_normal_irradiance:
                 let dhi = try get(derived: .init(.surface(.direct_radiation), member), time: time).data
                 let dni = Zensun.calculateBackwardsDNI(directRadiation: dhi, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-                return DataAndUnit(dni, .wattPerSquareMeter)
+                return DataAndUnit(dni, .wattPerSquareMetre)
             case .direct_normal_irradiance_instant:
                 let direct = try get(derived: .init(.surface(.direct_radiation_instant), member), time: time)
                 let dni = Zensun.calculateInstantDNI(directRadiation: direct.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
@@ -234,35 +234,35 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             case .snowfall:
                 let snowwater = try get(raw: .init(.surface(.snowfall_water_equivalent), member), time: time).data
                 let snowfall = snowwater.map { $0 * 0.7 }
-                return DataAndUnit(snowfall, .centimeter)
+                return DataAndUnit(snowfall, .centimetre)
             case .rain:
                 let snowwater = try get(raw: .init(.surface(.snowfall_water_equivalent), member), time: time).data
                 let total = try get(raw: .init(.surface(.precipitation), member), time: time).data
                 if reader.domain == .gem_global_ensemble {
                     // no showers in ensemble
-                    return DataAndUnit(zip(total, snowwater).map(-), .millimeter)
+                    return DataAndUnit(zip(total, snowwater).map(-), .millimetre)
                 }
                 let showers = try get(raw: .init(.surface(.showers), member), time: time).data
                 let rain = zip(zip(total, snowwater), showers).map { (arg0, showers) in
                     let (total, snowwater) = arg0
                     return max(total - snowwater - showers, 0)
                 }
-                return DataAndUnit(rain, .millimeter)
+                return DataAndUnit(rain, .millimetre)
             case .cloudcover_low:
                 let cl0 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 1000)), member), time: time)
                 let cl1 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 950)), member), time: time)
                 let cl2 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 850)), member), time: time)
-                return DataAndUnit(zip(zip(cl0.data, cl1.data).map(max), cl2.data).map(max), .percent)
+                return DataAndUnit(zip(zip(cl0.data, cl1.data).map(max), cl2.data).map(max), .percentage)
             case .cloudcover_mid:
                 let cl0 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 700)), member), time: time)
                 let cl1 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 600)), member), time: time)
                 let cl2 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 500)), member), time: time)
-                return DataAndUnit(zip(zip(cl0.data, cl1.data).map(max), cl2.data).map(max), .percent)
+                return DataAndUnit(zip(zip(cl0.data, cl1.data).map(max), cl2.data).map(max), .percentage)
             case .cloudcover_high:
                 let cl0 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 400)), member), time: time)
                 let cl1 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 300)), member), time: time)
                 let cl2 = try get(derived: .init(.pressure(GemPressureVariableDerived(variable: .cloudcover, level: 200)), member), time: time)
-                return DataAndUnit(zip(zip(cl0.data, cl1.data).map(max), cl2.data).map(max), .percent)
+                return DataAndUnit(zip(zip(cl0.data, cl1.data).map(max), cl2.data).map(max), .percentage)
             case .weathercode:
                 let cloudcover = try get(raw: .init(.surface(.cloudcover), member), time: time).data
                 let precipitation = try get(raw: .init(.surface(.precipitation), member), time: time).data
@@ -297,7 +297,7 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
             case .cloudcover:
                 let rh = try get(raw: .init(.pressure(GemPressureVariable(variable: .relativehumidity, level: v.level)), member), time: time)
-                return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: Float(v.level))}), .percent)
+                return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: Float(v.level))}), .percentage)
             }
         }
     }

--- a/Sources/App/Gem/GemVariable.swift
+++ b/Sources/App/Gem/GemVariable.swift
@@ -380,13 +380,13 @@ enum GemSurfaceVariable: String, CaseIterable, GemVariableDownloadable, GenericV
         case .temperature_2m:
             return .celsius
         case .cloudcover:
-            return .percent
+            return .percentage
         case .precipitation:
-            return .millimeter
+            return .millimetre
         case .pressure_msl:
-            return .hectoPascal
+            return .hectopascal
         case .shortwave_radiation:
-            return .wattPerSquareMeter
+            return .wattPerSquareMetre
         case .temperature_40m:
             return .celsius
         case .temperature_80m:
@@ -394,7 +394,7 @@ enum GemSurfaceVariable: String, CaseIterable, GemVariableDownloadable, GenericV
         case .temperature_120m:
             return .celsius
         case .relativehumidity_2m:
-            return .percent
+            return .percentage
         case .windspeed_10m:
             fallthrough
         case .windspeed_40m:
@@ -404,7 +404,7 @@ enum GemSurfaceVariable: String, CaseIterable, GemVariableDownloadable, GenericV
         case .windspeed_120m:
             fallthrough
         case .windgusts_10m:
-            return .ms
+            return .metrePerSecond
         case .winddirection_10m:
             fallthrough
         case .winddirection_40m:
@@ -414,17 +414,17 @@ enum GemSurfaceVariable: String, CaseIterable, GemVariableDownloadable, GenericV
         case .winddirection_120m:
             return .degreeDirection
         case .showers:
-            return .millimeter
+            return .millimetre
         case .snowfall_water_equivalent:
-            return .millimeter
+            return .millimetre
         case .soil_temperature_0_to_10cm:
             return .celsius
         case .soil_moisture_0_to_10cm:
-            return .qubicMeterPerQubicMeter
+            return .cubicMetrePerCubicMetre
         case .cape:
-            return .joulesPerKilogram
+            return .joulePerKilogram
         case .snow_depth:
-            return .meter
+            return .metre
         }
     }
     
@@ -571,13 +571,13 @@ struct GemPressureVariable: PressureVariableRespresentable, GemVariableDownloada
         case .temperature:
             return .celsius
         case .windspeed:
-            return .ms
+            return .metrePerSecond
         case .winddirection:
             return .degreeDirection
         case .geopotential_height:
-            return .meter
+            return .metre
         case .relativehumidity:
-            return .percent
+            return .percentage
         }
     }
     

--- a/Sources/App/Gfs/GfsController.swift
+++ b/Sources/App/Gfs/GfsController.swift
@@ -4,7 +4,6 @@ import Vapor
 
 enum GfsVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case apparent_temperature
-    case relativehumitidy_2m
     case dewpoint_2m
     case temperature_120m
     case windspeed_10m
@@ -16,6 +15,16 @@ enum GfsVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     // Map 100m wind to 120m level
     case windspeed_120m
     case winddirection_120m
+    case relative_humidity_2m
+    case dew_point_2m
+    case wind_speed_10m
+    case wind_direction_10m
+    case wind_speed_80m
+    case wind_direction_80m
+    case wind_speed_100m
+    case wind_direction_100m
+    case wind_speed_120m
+    case wind_direction_120m
     case direct_normal_irradiance
     case direct_normal_irradiance_instant
     case direct_radiation
@@ -25,14 +34,24 @@ enum GfsVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case evapotranspiration
     case et0_fao_evapotranspiration
     case vapor_pressure_deficit
+    case vapour_pressure_deficit
     case snowfall
     case rain
     case surface_pressure
     case terrestrial_radiation
     case terrestrial_radiation_instant
     case weathercode
+    case weather_code
     case is_day
     case wet_bulb_temperature_2m
+    case cloud_cover
+    case cloud_cover_low
+    case cloud_cover_mid
+    case cloud_cover_high
+    case sensible_heat_flux
+    case latent_heat_flux
+    case wind_gusts_10m
+    case freezing_level_height
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false
@@ -46,6 +65,11 @@ enum GfsPressureVariableDerivedType: String, CaseIterable {
     case windspeed
     case winddirection
     case dewpoint
+    case wind_speed
+    case wind_direction
+    case dew_point
+    case cloud_cover
+    case relative_humidity
 }
 
 /**
@@ -189,32 +213,50 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(raw: .init(.surface(.wind_v_component_10m), member), time: time)
                 try prefetchData(raw: .init(.surface(.relativehumidity_2m), member), time: time)
                 try prefetchData(raw: .init(.surface(.shortwave_radiation), member), time: time)
-            case .relativehumitidy_2m:
+            case .relative_humidity_2m:
                 try prefetchData(raw: .init(.surface(.relativehumidity_2m), member), time: time)
+            case .wind_speed_10m:
+                fallthrough
             case .windspeed_10m:
                 try prefetchData(raw: .init(.surface(.wind_u_component_10m), member), time: time)
                 try prefetchData(raw: .init(.surface(.wind_v_component_10m), member), time: time)
+            case .wind_direction_10m:
+                fallthrough
             case .winddirection_10m:
                 try prefetchData(raw: .init(.surface(.wind_u_component_10m), member), time: time)
                 try prefetchData(raw: .init(.surface(.wind_v_component_10m), member), time: time)
+            case .wind_speed_80m:
+                fallthrough
             case .windspeed_80m:
                 try prefetchData(raw: .init(.surface(.wind_u_component_80m), member), time: time)
                 try prefetchData(raw: .init(.surface(.wind_v_component_80m), member), time: time)
+            case .wind_direction_80m:
+                fallthrough
             case .winddirection_80m:
                 try prefetchData(raw: .init(.surface(.wind_u_component_80m), member), time: time)
                 try prefetchData(raw: .init(.surface(.wind_v_component_80m), member), time: time)
+            case .wind_speed_120m:
+                fallthrough
             case .windspeed_120m:
+                fallthrough
+            case .wind_speed_100m:
                 fallthrough
             case .windspeed_100m:
                 try prefetchData(raw: .init(.surface(.wind_u_component_100m), member), time: time)
                 try prefetchData(raw: .init(.surface(.wind_v_component_100m), member), time: time)
+            case .wind_direction_120m:
+                fallthrough
             case .winddirection_120m:
+                fallthrough
+            case .wind_direction_100m:
                 fallthrough
             case .winddirection_100m:
                 try prefetchData(raw: .init(.surface(.wind_u_component_100m), member), time: time)
                 try prefetchData(raw: .init(.surface(.wind_v_component_100m), member), time: time)
             case .evapotranspiration:
                 try prefetchData(raw: .init(.surface(.latent_heatflux), member), time: time)
+            case .vapour_pressure_deficit:
+                fallthrough
             case .vapor_pressure_deficit:
                 try prefetchData(raw: .init(.surface(.temperature_2m), member), time: time)
                 try prefetchData(raw: .init(.surface(.relativehumidity_2m), member), time: time)
@@ -240,6 +282,8 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 break
             case .terrestrial_radiation_instant:
                 break
+            case .dew_point_2m:
+                fallthrough
             case .dewpoint_2m:
                 try prefetchData(raw: .init(.surface(.temperature_2m), member), time: time)
                 try prefetchData(raw: .init(.surface(.relativehumidity_2m), member), time: time)
@@ -256,6 +300,8 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(raw: .init(.surface(.diffuse_radiation), member), time: time)
             case .shortwave_radiation_instant:
                 try prefetchData(raw: .init(.surface(.shortwave_radiation), member), time: time)
+            case .weather_code:
+                fallthrough
             case .weathercode:
                 try prefetchData(raw: .init(.surface(.cloudcover), member), time: time)
                 try prefetchData(raw: .init(.surface(.precipitation), member), time: time)
@@ -272,16 +318,42 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
             case .wet_bulb_temperature_2m:
                 try prefetchData(raw: .init(.surface(.temperature_2m), member), time: time)
                 try prefetchData(raw: .init(.surface(.relativehumidity_2m), member), time: time)
+            case .cloud_cover:
+                try prefetchData(raw: .init(.surface(.cloudcover), member), time: time)
+            case .cloud_cover_low:
+                try prefetchData(raw: .init(.surface(.cloudcover_low), member), time: time)
+            case .cloud_cover_mid:
+                try prefetchData(raw: .init(.surface(.cloudcover_mid), member), time: time)
+            case .cloud_cover_high:
+                try prefetchData(raw: .init(.surface(.cloudcover_high), member), time: time)
+            case .sensible_heat_flux:
+                try prefetchData(raw: .init(.surface(.sensible_heatflux), member), time: time)
+            case .latent_heat_flux:
+                try prefetchData(raw: .init(.surface(.latent_heatflux), member), time: time)
+            case .wind_gusts_10m:
+                try prefetchData(raw: .init(.surface(.windgusts_10m), member), time: time)
+            case .freezing_level_height:
+                try prefetchData(raw: .init(.surface(.freezinglevel_height), member), time: time)
             }
         case .pressure(let v):
             switch v.variable {
+            case .wind_speed:
+                fallthrough
             case .windspeed:
+                fallthrough
+            case .wind_direction:
                 fallthrough
             case .winddirection:
                 try prefetchData(raw: .init(.pressure(GfsPressureVariable(variable: .wind_u_component, level: v.level)), member), time: time)
                 try prefetchData(raw: .init(.pressure(GfsPressureVariable(variable: .wind_v_component, level: v.level)), member), time: time)
+            case .dew_point:
+                fallthrough
             case .dewpoint:
                 try prefetchData(raw: .init(.pressure(GfsPressureVariable(variable: .temperature, level: v.level)), member), time: time)
+                try prefetchData(raw: .init(.pressure(GfsPressureVariable(variable: .relativehumidity, level: v.level)), member), time: time)
+            case .cloud_cover:
+                try prefetchData(raw: .init(.pressure(GfsPressureVariable(variable: .cloudcover, level: v.level)), member), time: time)
+            case .relative_humidity:
                 try prefetchData(raw: .init(.pressure(GfsPressureVariable(variable: .relativehumidity, level: v.level)), member), time: time)
             }
         }
@@ -292,26 +364,36 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
         switch derived.variable {
         case .surface(let gfsVariableDerivedSurface):
             switch gfsVariableDerivedSurface {
+            case .wind_speed_10m:
+                fallthrough
             case .windspeed_10m:
                 let u = try get(raw: .init(.surface(.wind_u_component_10m), member), time: time).data
                 let v = try get(raw: .init(.surface(.wind_v_component_10m), member), time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
+            case .wind_direction_10m:
+                fallthrough
             case .winddirection_10m:
                 let u = try get(raw: .init(.surface(.wind_u_component_10m), member), time: time).data
                 let v = try get(raw: .init(.surface(.wind_v_component_10m), member), time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
+            case .wind_speed_80m:
+                fallthrough
             case .windspeed_80m:
                 let u = try get(raw: .init(.surface(.wind_u_component_80m), member), time: time).data
                 let v = try get(raw: .init(.surface(.wind_v_component_80m), member), time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
+            case .wind_direction_80m:
+                fallthrough
             case .winddirection_80m:
                 let u = try get(raw: .init(.surface(.wind_u_component_80m), member), time: time).data
                 let v = try get(raw: .init(.surface(.wind_v_component_80m), member), time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
+            case .wind_speed_120m:
+                fallthrough
             case .windspeed_120m:
                 // Take 100m wind and scale to 120m
                 let u = try get(raw: .init(.surface(.wind_u_component_100m), member), time: time).data
@@ -320,12 +402,18 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 var speed = zip(u,v).map(Meteorology.windspeed)
                 speed.multiplyAdd(multiply: scalefactor, add: 0)
                 return DataAndUnit(speed, .metrePerSecond)
+            case .wind_speed_100m:
+                fallthrough
             case .windspeed_100m:
                 let u = try get(raw: .init(.surface(.wind_u_component_100m), member), time: time).data
                 let v = try get(raw: .init(.surface(.wind_v_component_100m), member), time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
+            case .wind_direction_120m:
+                fallthrough
             case .winddirection_120m:
+                fallthrough
+            case .wind_direction_100m:
                 fallthrough
             case .winddirection_100m:
                 let u = try get(raw: .init(.surface(.wind_u_component_100m), member), time: time).data
@@ -342,6 +430,8 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 let latent = try get(raw: .init(.surface(.latent_heatflux), member), time: time).data
                 let evapotranspiration = latent.map(Meteorology.evapotranspiration)
                 return DataAndUnit(evapotranspiration, .millimetre)
+            case .vapour_pressure_deficit:
+                fallthrough
             case .vapor_pressure_deficit:
                 let temperature = try get(raw: .init(.surface(.temperature_2m), member), time: time).data
                 let rh = try get(raw: .init(.surface(.relativehumidity_2m), member), time: time).data
@@ -385,7 +475,7 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                     })
                     return DataAndUnit(rain, .millimetre)
                 }
-            case .relativehumitidy_2m:
+            case .relative_humidity_2m:
                 return try get(raw: .init(.surface(.relativehumidity_2m), member), time: time)
             case .surface_pressure:
                 let temperature = try get(raw: .init(.surface(.temperature_2m), member), time: time).data
@@ -397,6 +487,8 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
             case .terrestrial_radiation_instant:
                 let solar = Zensun.extraTerrestrialRadiationInstant(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
                 return DataAndUnit(solar, .wattPerSquareMetre)
+            case .dew_point_2m:
+                fallthrough
             case .dewpoint_2m:
                 let temperature = try get(raw: .init(.surface(.temperature_2m), member), time: time)
                 let rh = try get(raw: .init(.surface(.relativehumidity_2m), member), time: time)
@@ -425,6 +517,8 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 let diff = try get(raw: .init(.surface(.diffuse_radiation), member), time: time)
                 let factor = Zensun.backwardsAveragedToInstantFactor(time: time, latitude: reader.modelLat, longitude: reader.modelLon)
                 return DataAndUnit(zip(diff.data, factor).map(*), diff.unit)
+            case .weather_code:
+                fallthrough
             case .weathercode:
                 let cloudcover = try get(raw: .init(.surface(.cloudcover), member), time: time).data
                 let precipitation = try get(raw: .init(.surface(.precipitation), member), time: time).data
@@ -455,23 +549,49 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 let temperature = try get(raw: .init(.surface(.temperature_2m), member), time: time)
                 let rh = try get(raw: .init(.surface(.relativehumidity_2m), member), time: time)
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.wetBulbTemperature), temperature.unit)
+            case .cloud_cover:
+                return try get(raw: .init(.surface(.cloudcover), member), time: time)
+            case .cloud_cover_low:
+                return try get(raw: .init(.surface(.cloudcover_low), member), time: time)
+            case .cloud_cover_mid:
+                return try get(raw: .init(.surface(.cloudcover_mid), member), time: time)
+            case .cloud_cover_high:
+                return try get(raw: .init(.surface(.cloudcover_high), member), time: time)
+            case .sensible_heat_flux:
+                return try get(raw: .init(.surface(.sensible_heatflux), member), time: time)
+            case .latent_heat_flux:
+                return try get(raw: .init(.surface(.latent_heatflux), member), time: time)
+            case .wind_gusts_10m:
+                return try get(raw: .init(.surface(.windgusts_10m), member), time: time)
+            case .freezing_level_height:
+                return try get(raw: .init(.surface(.freezinglevel_height), member), time: time)
             }
         case .pressure(let v):
             switch v.variable {
+            case .wind_speed:
+                fallthrough
             case .windspeed:
                 let u = try get(raw: .init(.pressure(GfsPressureVariable(variable: .wind_u_component, level: v.level)), member), time: time)
                 let v = try get(raw: .init(.pressure(GfsPressureVariable(variable: .wind_v_component, level: v.level)), member), time: time)
                 let speed = zip(u.data,v.data).map(Meteorology.windspeed)
                 return DataAndUnit(speed, u.unit)
+            case .wind_direction:
+                fallthrough
             case .winddirection:
                 let u = try get(raw: .init(.pressure(GfsPressureVariable(variable: .wind_u_component, level: v.level)), member), time: time).data
                 let v = try get(raw: .init(.pressure(GfsPressureVariable(variable: .wind_v_component, level: v.level)), member), time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
+            case .dew_point:
+                fallthrough
             case .dewpoint:
                 let temperature = try get(raw: .init(.pressure(GfsPressureVariable(variable: .temperature, level: v.level)), member), time: time)
                 let rh = try get(raw: .init(.pressure(GfsPressureVariable(variable: .relativehumidity, level: v.level)), member), time: time)
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+            case .cloud_cover:
+                return try get(raw: .init(.pressure(GfsPressureVariable(variable: .cloudcover, level: v.level)), member), time: time)
+            case .relative_humidity:
+                return try get(raw: .init(.pressure(GfsPressureVariable(variable: .relativehumidity, level: v.level)), member), time: time)
             }
         }
     }

--- a/Sources/App/Gfs/GfsVariable.swift
+++ b/Sources/App/Gfs/GfsVariable.swift
@@ -227,43 +227,43 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .temperature_2m: return .celsius
         case .temperature_80m: return .celsius
         case .temperature_100m: return .celsius
-        case .cloudcover: return .percent
-        case .cloudcover_low: return .percent
-        case .cloudcover_mid: return .percent
-        case .cloudcover_high: return .percent
-        case .relativehumidity_2m: return .percent
-        case .precipitation: return .millimeter
-        case .wind_v_component_10m: return .ms
-        case .wind_u_component_10m: return .ms
-        case .wind_v_component_80m: return .ms
-        case .wind_u_component_80m: return .ms
-        case .wind_v_component_100m: return .ms
-        case .wind_u_component_100m: return .ms
+        case .cloudcover: return .percentage
+        case .cloudcover_low: return .percentage
+        case .cloudcover_mid: return .percentage
+        case .cloudcover_high: return .percentage
+        case .relativehumidity_2m: return .percentage
+        case .precipitation: return .millimetre
+        case .wind_v_component_10m: return .metrePerSecond
+        case .wind_u_component_10m: return .metrePerSecond
+        case .wind_v_component_80m: return .metrePerSecond
+        case .wind_u_component_80m: return .metrePerSecond
+        case .wind_v_component_100m: return .metrePerSecond
+        case .wind_u_component_100m: return .metrePerSecond
         case .surface_temperature: return .celsius
         case .soil_temperature_0_to_10cm: return .celsius
         case .soil_temperature_10_to_40cm: return .celsius
         case .soil_temperature_40_to_100cm: return .celsius
         case .soil_temperature_100_to_200cm: return .celsius
-        case .soil_moisture_0_to_10cm: return .qubicMeterPerQubicMeter
-        case .soil_moisture_10_to_40cm: return .qubicMeterPerQubicMeter
-        case .soil_moisture_40_to_100cm: return .qubicMeterPerQubicMeter
-        case .soil_moisture_100_to_200cm: return .qubicMeterPerQubicMeter
-        case .snow_depth: return .meter
-        case .sensible_heatflux: return .wattPerSquareMeter
-        case .latent_heatflux: return .wattPerSquareMeter
-        case .showers: return .millimeter
-        case .windgusts_10m: return .ms
-        case .freezinglevel_height: return .meter
-        case .pressure_msl: return .hectoPascal
-        case .shortwave_radiation: return .wattPerSquareMeter
-        case .frozen_precipitation_percent: return .percent
-        case .cape: return .joulesPerKilogram
+        case .soil_moisture_0_to_10cm: return .cubicMetrePerCubicMetre
+        case .soil_moisture_10_to_40cm: return .cubicMetrePerCubicMetre
+        case .soil_moisture_40_to_100cm: return .cubicMetrePerCubicMetre
+        case .soil_moisture_100_to_200cm: return .cubicMetrePerCubicMetre
+        case .snow_depth: return .metre
+        case .sensible_heatflux: return .wattPerSquareMetre
+        case .latent_heatflux: return .wattPerSquareMetre
+        case .showers: return .millimetre
+        case .windgusts_10m: return .metrePerSecond
+        case .freezinglevel_height: return .metre
+        case .pressure_msl: return .hectopascal
+        case .shortwave_radiation: return .wattPerSquareMetre
+        case .frozen_precipitation_percent: return .percentage
+        case .cape: return .joulePerKilogram
         case .lifted_index: return .dimensionless
-        case .visibility: return .meter
-        case .diffuse_radiation: return .wattPerSquareMeter
+        case .visibility: return .metre
+        case .diffuse_radiation: return .wattPerSquareMetre
         case .uv_index: return .dimensionless
         case .uv_index_clear_sky: return .dimensionless
-        case .precipitation_probability: return .percent
+        case .precipitation_probability: return .percentage
         case .categorical_freezing_rain: return .dimensionless
         }
     }
@@ -367,17 +367,17 @@ struct GfsPressureVariable: PressureVariableRespresentable, GenericVariable, Has
         case .temperature:
             return .celsius
         case .wind_u_component:
-            return .ms
+            return .metrePerSecond
         case .wind_v_component:
-            return .ms
+            return .metrePerSecond
         case .geopotential_height:
-            return .meter
+            return .metre
         case .cloudcover:
-            return .percent
+            return .percentage
         case .relativehumidity:
-            return .percent
+            return .percentage
         case .vertical_velocity:
-            return .msNotUnitConverted
+            return .metrePerSecondNotUnitConverted
         }
     }
     

--- a/Sources/App/GloFas/GloFasController.swift
+++ b/Sources/App/GloFas/GloFasController.swift
@@ -157,7 +157,7 @@ struct GloFasController {
             guard !readers.isEmpty else {
                 throw ForecastapiError.noDataAvilableForThisLocation
             }
-            return .init(timezone: timezone, time: time, results: readers)
+            return .init(timezone: timezone, time: time, locationId: coordinates.locationId, results: readers)
         }
         let result = ForecastapiResult<GlofasDomainApi>(timeformat: params.timeformatOrDefault, results: locations)
         req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))

--- a/Sources/App/GloFas/GloFasController.swift
+++ b/Sources/App/GloFas/GloFasController.swift
@@ -54,33 +54,33 @@ struct GloFasReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             try reader.get(variable: .init(.river_discharge, $0), time: time).data
         })
         if data[0].onlyNaN() {
-            return DataAndUnit(data[0], .qubicMeterPerSecond)
+            return DataAndUnit(data[0], .cubicMetrePerSecond)
         }
         switch derived {
         case .river_discharge_mean:
             return DataAndUnit((0..<time.count).map { t in
                 data.reduce(0, {$0 + $1[t]}) / Float(data.count)
-            }, .qubicMeterPerSecond)
+            }, .cubicMetrePerSecond)
         case .river_discharge_min:
             return DataAndUnit((0..<time.count).map { t in
                 data.reduce(Float.nan, { $0.isNaN || $1[t] < $0 ? $1[t] : $0 })
-            }, .qubicMeterPerSecond)
+            }, .cubicMetrePerSecond)
         case .river_discharge_max:
             return DataAndUnit((0..<time.count).map { t in
                 data.reduce(Float.nan, { $0.isNaN || $1[t] > $0 ? $1[t] : $0 })
-            }, .qubicMeterPerSecond)
+            }, .cubicMetrePerSecond)
         case .river_discharge_median:
             return DataAndUnit((0..<time.count).map { t in
                 data.map({$0[t]}).sorted().interpolateLinear(Int(Float(data.count)*0.5), (Float(data.count)*0.5).truncatingRemainder(dividingBy: 1) )
-            }, .qubicMeterPerSecond)
+            }, .cubicMetrePerSecond)
         case .river_discharge_p25:
             return DataAndUnit((0..<time.count).map { t in
                 data.map({$0[t]}).sorted().interpolateLinear(Int(Float(data.count)*0.25), (Float(data.count)*0.25).truncatingRemainder(dividingBy: 1) )
-            }, .qubicMeterPerSecond)
+            }, .cubicMetrePerSecond)
         case .river_discharge_p75:
             return DataAndUnit((0..<time.count).map { t in
                 data.map({$0[t]}).sorted().interpolateLinear(Int(Float(data.count)*0.75), (Float(data.count)*0.75).truncatingRemainder(dividingBy: 1) )
-            }, .qubicMeterPerSecond)
+            }, .cubicMetrePerSecond)
         }
     }
 }
@@ -142,11 +142,11 @@ struct GloFasController {
                                     assert(dailyTime.count == d.data.count, "days \(dailyTime.count), values \(d.data.count)")
                                     return ApiArray.float(d.data)
                                 }
-                                return ApiColumn<GloFasVariableOrDerived>(variable: variable, unit: .qubicMeterPerSecond, variables: d)
+                                return ApiColumn<GloFasVariableOrDerived>(variable: variable, unit: .cubicMetrePerSecond, variables: d)
                             case .derived(let derived):
                                 let d = try reader.get(variable: .derived(derived), time: dailyTime).convertAndRound(params: params)
                                 assert(dailyTime.count == d.data.count, "days \(dailyTime.count), values \(d.data.count)")
-                                return ApiColumn<GloFasVariableOrDerived>(variable: variable, unit: .qubicMeterPerSecond, variables: [.float(d.data)])
+                                return ApiColumn<GloFasVariableOrDerived>(variable: variable, unit: .cubicMetrePerSecond, variables: [.float(d.data)])
                             }
                         })
                     },

--- a/Sources/App/GloFas/GloFasDownloader.swift
+++ b/Sources/App/GloFas/GloFasDownloader.swift
@@ -571,7 +571,7 @@ enum GloFasVariable: String, GenericVariable {
     }
     
     var unit: SiUnit {
-        return .qubicMeterPerSecond
+        return .cubicMetrePerSecond
     }
     
     var isElevationCorrectable: Bool {

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+AirQualityApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+AirQualityApi.swift
@@ -3,6 +3,82 @@ import FlatBuffers
 import OpenMeteoSdk
 
 
+extension CamsVariable: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .pm10:
+            return .init(variable: .pm10)
+        case .pm2_5:
+            return .init(variable: .pm2p5)
+        case .dust:
+            return .init(variable: .dust)
+        case .aerosol_optical_depth:
+            return .init(variable: .aerosolOpticalDepth)
+        case .carbon_monoxide:
+            return .init(variable: .carbonMonoxide)
+        case .nitrogen_dioxide:
+            return .init(variable: .nitrogenDioxide)
+        case .ammonia:
+            return .init(variable: .ammonia)
+        case .ozone:
+            return .init(variable: .ozone)
+        case .sulphur_dioxide:
+            return .init(variable: .sulphurDioxide)
+        case .uv_index:
+            return .init(variable: .uvIndex)
+        case .uv_index_clear_sky:
+            return .init(variable: .uvIndexClearSky)
+        case .alder_pollen:
+            return .init(variable: .alderPollen)
+        case .birch_pollen:
+            return .init(variable: .birchPollen)
+        case .grass_pollen:
+            return .init(variable: .grassPollen)
+        case .mugwort_pollen:
+            return .init(variable: .mugwortPollen)
+        case .olive_pollen:
+            return .init(variable: .olivePollen)
+        case .ragweed_pollen:
+            return .init(variable: .ragweedPollen)
+        }
+    }
+}
+
+extension CamsVariableDerived: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .european_aqi:
+            return .init(variable: .europeanAqi)
+        case .european_aqi_pm2_5:
+            return .init(variable: .europeanAqiPm2p5)
+        case .european_aqi_pm10:
+            return .init(variable: .europeanAqiPm10)
+        case .european_aqi_no2:
+            return .init(variable: .europeanAqiNo2)
+        case .european_aqi_o3:
+            return .init(variable: .europeanAqiO3)
+        case .european_aqi_so2:
+            return .init(variable: .europeanAqiSo2)
+        case .us_aqi:
+            return .init(variable: .usAqi)
+        case .us_aqi_pm2_5:
+            return .init(variable: .usAqiPm2p5)
+        case .us_aqi_pm10:
+            return .init(variable: .usAqiPm10)
+        case .us_aqi_no2:
+            return .init(variable: .usAqiNo2)
+        case .us_aqi_o3:
+            return .init(variable: .usAqiO3)
+        case .us_aqi_so2:
+            return .init(variable: .usAqiSo2)
+        case .us_aqi_co:
+            return .init(variable: .usAqiCo)
+        case .is_day:
+            return .init(variable: .isDay)
+        }
+    }
+}
+
 extension CamsQuery.Domain: ModelFlatbufferSerialisable {
     typealias HourlyVariable = CamsReader.MixingVar
     
@@ -10,196 +86,7 @@ extension CamsQuery.Domain: ModelFlatbufferSerialisable {
     
     typealias DailyVariable = ForecastVariableDaily
     
-    static func encodeHourly(section: ApiSection<ForecastapiResult<Self>.SurfaceAndPressureVariable>, _ fbb: inout FlatBufferBuilder) -> Offset {
-        let offsets = ForecastapiResult.encode(section: section, &fbb)
-        let start = openmeteo_sdk_AirQualityHourly.startAirQualityHourly(&fbb)
-        openmeteo_sdk_AirQualityHourly.add(time: section.timeFlatBuffers(), &fbb)
-        for (surface, offset) in offsets.surface {
-            switch surface {
-            case .raw(let v):
-                switch v {
-                case .pm10:
-                    openmeteo_sdk_AirQualityHourly.add(pm10: offset, &fbb)
-                case .pm2_5:
-                    openmeteo_sdk_AirQualityHourly.add(pm25: offset, &fbb)
-                case .dust:
-                    openmeteo_sdk_AirQualityHourly.add(dust: offset, &fbb)
-                case .aerosol_optical_depth:
-                    openmeteo_sdk_AirQualityHourly.add(aerosolOpticalDepth: offset, &fbb)
-                case .carbon_monoxide:
-                    openmeteo_sdk_AirQualityHourly.add(carbonMonoxide: offset, &fbb)
-                case .nitrogen_dioxide:
-                    openmeteo_sdk_AirQualityHourly.add(nitrogenDioxide: offset, &fbb)
-                case .ammonia:
-                    openmeteo_sdk_AirQualityHourly.add(ammonia: offset, &fbb)
-                case .ozone:
-                    openmeteo_sdk_AirQualityHourly.add(ozone: offset, &fbb)
-                case .sulphur_dioxide:
-                    openmeteo_sdk_AirQualityHourly.add(sulphurDioxide: offset, &fbb)
-                case .uv_index:
-                    openmeteo_sdk_AirQualityHourly.add(uvIndex: offset, &fbb)
-                case .uv_index_clear_sky:
-                    openmeteo_sdk_AirQualityHourly.add(uvIndexClearSky: offset, &fbb)
-                case .alder_pollen:
-                    openmeteo_sdk_AirQualityHourly.add(alderPollen: offset, &fbb)
-                case .birch_pollen:
-                    openmeteo_sdk_AirQualityHourly.add(birchPollen: offset, &fbb)
-                case .grass_pollen:
-                    openmeteo_sdk_AirQualityHourly.add(grassPollen: offset, &fbb)
-                case .mugwort_pollen:
-                    openmeteo_sdk_AirQualityHourly.add(mugwortPollen: offset, &fbb)
-                case .olive_pollen:
-                    openmeteo_sdk_AirQualityHourly.add(olivePollen: offset, &fbb)
-                case .ragweed_pollen:
-                    openmeteo_sdk_AirQualityHourly.add(ragweedPollen: offset, &fbb)
-                }
-            case .derived(let v):
-                switch v {
-                case .european_aqi:
-                    openmeteo_sdk_AirQualityHourly.add(europeanAqi: offset, &fbb)
-                case .european_aqi_pm2_5:
-                    openmeteo_sdk_AirQualityHourly.add(europeanAqiPm25: offset, &fbb)
-                case .european_aqi_pm10:
-                    openmeteo_sdk_AirQualityHourly.add(europeanAqiPm10: offset, &fbb)
-                case .european_aqi_no2:
-                    openmeteo_sdk_AirQualityHourly.add(europeanAqiNo2: offset, &fbb)
-                case .european_aqi_o3:
-                    openmeteo_sdk_AirQualityHourly.add(europeanAqiO3: offset, &fbb)
-                case .european_aqi_so2:
-                    openmeteo_sdk_AirQualityHourly.add(europeanAqiSo2: offset, &fbb)
-                case .us_aqi:
-                    openmeteo_sdk_AirQualityHourly.add(usAqi: offset, &fbb)
-                case .us_aqi_pm2_5:
-                    openmeteo_sdk_AirQualityHourly.add(usAqiPm25: offset, &fbb)
-                case .us_aqi_pm10:
-                    openmeteo_sdk_AirQualityHourly.add(usAqiPm10: offset, &fbb)
-                case .us_aqi_no2:
-                    openmeteo_sdk_AirQualityHourly.add(usAqiNo2: offset, &fbb)
-                case .us_aqi_o3:
-                    openmeteo_sdk_AirQualityHourly.add(usAqiO3: offset, &fbb)
-                case .us_aqi_so2:
-                    openmeteo_sdk_AirQualityHourly.add(usAqiSo2: offset, &fbb)
-                case .us_aqi_co:
-                    openmeteo_sdk_AirQualityHourly.add(usAqiCo: offset, &fbb)
-                case .is_day:
-                    openmeteo_sdk_AirQualityHourly.add(isDay: offset, &fbb)
-                }
-            }
-        }
-        for (_, _) in offsets.pressure {
-            fatalError("No pressure levels")
-        }
-        return openmeteo_sdk_AirQualityHourly.endAirQualityHourly(&fbb, start: start)
-    }
-    
-    static func encodeCurrent(section: ApiSectionSingle<ForecastapiResult<Self>.SurfaceAndPressureVariable>, _ fbb: inout FlatBufferBuilder) throws -> Offset {
-        let start = openmeteo_sdk_AirQualityCurrent.startAirQualityCurrent(&fbb)
-        openmeteo_sdk_AirQualityCurrent.add(time: Int64(section.time.timeIntervalSince1970), &fbb)
-        openmeteo_sdk_AirQualityCurrent.add(interval: Int32(section.dtSeconds), &fbb)
-        for column in section.columns {
-            switch column.variable {
-            case .surface(let surface):
-                let offset = openmeteo_sdk_ValueAndUnit(value: column.value, unit: column.unit)
-                switch surface {
-                case .raw(let v):
-                    switch v {
-                    case .pm10:
-                        openmeteo_sdk_AirQualityCurrent.add(pm10: offset, &fbb)
-                    case .pm2_5:
-                        openmeteo_sdk_AirQualityCurrent.add(pm25: offset, &fbb)
-                    case .dust:
-                        openmeteo_sdk_AirQualityCurrent.add(dust: offset, &fbb)
-                    case .aerosol_optical_depth:
-                        openmeteo_sdk_AirQualityCurrent.add(aerosolOpticalDepth: offset, &fbb)
-                    case .carbon_monoxide:
-                        openmeteo_sdk_AirQualityCurrent.add(carbonMonoxide: offset, &fbb)
-                    case .nitrogen_dioxide:
-                        openmeteo_sdk_AirQualityCurrent.add(nitrogenDioxide: offset, &fbb)
-                    case .ammonia:
-                        openmeteo_sdk_AirQualityCurrent.add(ammonia: offset, &fbb)
-                    case .ozone:
-                        openmeteo_sdk_AirQualityCurrent.add(ozone: offset, &fbb)
-                    case .sulphur_dioxide:
-                        openmeteo_sdk_AirQualityCurrent.add(sulphurDioxide: offset, &fbb)
-                    case .uv_index:
-                        openmeteo_sdk_AirQualityCurrent.add(uvIndex: offset, &fbb)
-                    case .uv_index_clear_sky:
-                        openmeteo_sdk_AirQualityCurrent.add(uvIndexClearSky: offset, &fbb)
-                    case .alder_pollen:
-                        openmeteo_sdk_AirQualityCurrent.add(alderPollen: offset, &fbb)
-                    case .birch_pollen:
-                        openmeteo_sdk_AirQualityCurrent.add(birchPollen: offset, &fbb)
-                    case .grass_pollen:
-                        openmeteo_sdk_AirQualityCurrent.add(grassPollen: offset, &fbb)
-                    case .mugwort_pollen:
-                        openmeteo_sdk_AirQualityCurrent.add(mugwortPollen: offset, &fbb)
-                    case .olive_pollen:
-                        openmeteo_sdk_AirQualityCurrent.add(olivePollen: offset, &fbb)
-                    case .ragweed_pollen:
-                        openmeteo_sdk_AirQualityCurrent.add(ragweedPollen: offset, &fbb)
-                    }
-                case .derived(let v):
-                    switch v {
-                    case .european_aqi:
-                        openmeteo_sdk_AirQualityCurrent.add(europeanAqi: offset, &fbb)
-                    case .european_aqi_pm2_5:
-                        openmeteo_sdk_AirQualityCurrent.add(europeanAqiPm25: offset, &fbb)
-                    case .european_aqi_pm10:
-                        openmeteo_sdk_AirQualityCurrent.add(europeanAqiPm10: offset, &fbb)
-                    case .european_aqi_no2:
-                        openmeteo_sdk_AirQualityCurrent.add(europeanAqiNo2: offset, &fbb)
-                    case .european_aqi_o3:
-                        openmeteo_sdk_AirQualityCurrent.add(europeanAqiO3: offset, &fbb)
-                    case .european_aqi_so2:
-                        openmeteo_sdk_AirQualityCurrent.add(europeanAqiSo2: offset, &fbb)
-                    case .us_aqi:
-                        openmeteo_sdk_AirQualityCurrent.add(usAqi: offset, &fbb)
-                    case .us_aqi_pm2_5:
-                        openmeteo_sdk_AirQualityCurrent.add(usAqiPm25: offset, &fbb)
-                    case .us_aqi_pm10:
-                        openmeteo_sdk_AirQualityCurrent.add(usAqiPm10: offset, &fbb)
-                    case .us_aqi_no2:
-                        openmeteo_sdk_AirQualityCurrent.add(usAqiNo2: offset, &fbb)
-                    case .us_aqi_o3:
-                        openmeteo_sdk_AirQualityCurrent.add(usAqiO3: offset, &fbb)
-                    case .us_aqi_so2:
-                        openmeteo_sdk_AirQualityCurrent.add(usAqiSo2: offset, &fbb)
-                    case .us_aqi_co:
-                        openmeteo_sdk_AirQualityCurrent.add(usAqiCo: offset, &fbb)
-                    case .is_day:
-                        openmeteo_sdk_AirQualityCurrent.add(isDay: offset, &fbb)
-                    }
-                }
-            case .pressure(_):
-                throw ForecastapiError.generic(message: "Pressure level variables currently not supported for flatbuffers encoding in current block")
-            }
-        }
-        return openmeteo_sdk_AirQualityCurrent.endAirQualityCurrent(&fbb, start: start)
-    }
-    
-    static func writeToFlatbuffer(section: ForecastapiResult<Self>.PerModel, _ fbb: inout FlatBufferBuilder, timezone: TimezoneWithOffset, fixedGenerationTime: Double?) throws {
-        let generationTimeStart = Date()
-        let hourly = (try section.hourly?()).map { encodeHourly(section: $0, &fbb) } ?? Offset()
-        let current = try (try section.current?()).map { try encodeCurrent(section: $0, &fbb) } ?? Offset()
-        let generationTimeMs = fixedGenerationTime ?? (Date().timeIntervalSince(generationTimeStart) * 1000)
-        
-        let result = openmeteo_sdk_AirQualityApiResponse.createAirQualityApiResponse(
-            &fbb,
-            latitude: section.latitude,
-            longitude: section.longitude,
-            elevation: section.elevation ?? .nan,
-            model: section.model.flatBufferModel,
-            generationtimeMs: Float32(generationTimeMs),
-            utcOffsetSeconds: Int32(timezone.utcOffsetSeconds),
-            timezoneOffset: timezone.identifier == "GMT" ? Offset() : fbb.create(string: timezone.identifier),
-            timezoneAbbreviationOffset: timezone.abbreviation == "GMT" ? Offset() : fbb.create(string: timezone.abbreviation),
-            hourlyOffset: hourly,
-            currentOffset: current
-        )
-        fbb.finish(offset: result, addPrefix: true)
-    }
-    
-    var flatBufferModel: openmeteo_sdk_AirQualityModel {
+    var flatBufferModel: openmeteo_sdk_Model {
         switch self {
         case .auto:
             return .bestMatch

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+AirQualityApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+AirQualityApi.swift
@@ -54,11 +54,11 @@ extension CamsVariableDerived: FlatBuffersVariable {
         case .european_aqi_pm10:
             return .init(variable: .europeanAqiPm10)
         case .european_aqi_no2:
-            return .init(variable: .europeanAqiNo2)
+            return .init(variable: .europeanAqiNitrogenDioxide)
         case .european_aqi_o3:
-            return .init(variable: .europeanAqiO3)
+            return .init(variable: .europeanAqiOzone)
         case .european_aqi_so2:
-            return .init(variable: .europeanAqiSo2)
+            return .init(variable: .europeanAqiSulphurDioxide)
         case .us_aqi:
             return .init(variable: .usAqi)
         case .us_aqi_pm2_5:
@@ -66,13 +66,13 @@ extension CamsVariableDerived: FlatBuffersVariable {
         case .us_aqi_pm10:
             return .init(variable: .usAqiPm10)
         case .us_aqi_no2:
-            return .init(variable: .usAqiNo2)
+            return .init(variable: .usAqiNitrogenDioxide)
         case .us_aqi_o3:
-            return .init(variable: .usAqiO3)
+            return .init(variable: .usAqiOzone)
         case .us_aqi_so2:
-            return .init(variable: .usAqiSo2)
+            return .init(variable: .usAqiSulphurDioxide)
         case .us_aqi_co:
-            return .init(variable: .usAqiCo)
+            return .init(variable: .usAqiCarbonMonoxide)
         case .is_day:
             return .init(variable: .isDay)
         }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+AirQualityApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+AirQualityApi.swift
@@ -53,10 +53,16 @@ extension CamsVariableDerived: FlatBuffersVariable {
             return .init(variable: .europeanAqiPm2p5)
         case .european_aqi_pm10:
             return .init(variable: .europeanAqiPm10)
+        case .european_aqi_nitrogen_dioxide:
+            fallthrough
         case .european_aqi_no2:
             return .init(variable: .europeanAqiNitrogenDioxide)
+        case .european_aqi_ozone:
+            fallthrough
         case .european_aqi_o3:
             return .init(variable: .europeanAqiOzone)
+        case .european_aqi_sulphur_dioxide:
+            fallthrough
         case .european_aqi_so2:
             return .init(variable: .europeanAqiSulphurDioxide)
         case .us_aqi:
@@ -65,12 +71,20 @@ extension CamsVariableDerived: FlatBuffersVariable {
             return .init(variable: .usAqiPm2p5)
         case .us_aqi_pm10:
             return .init(variable: .usAqiPm10)
+        case .us_aqi_nitrogen_dioxide:
+            fallthrough
         case .us_aqi_no2:
             return .init(variable: .usAqiNitrogenDioxide)
+        case .us_aqi_ozone:
+            fallthrough
         case .us_aqi_o3:
             return .init(variable: .usAqiOzone)
+        case .us_aqi_sulphur_dioxide:
+            fallthrough
         case .us_aqi_so2:
             return .init(variable: .usAqiSulphurDioxide)
+        case .us_aqi_carbon_monoxide:
+            fallthrough
         case .us_aqi_co:
             return .init(variable: .usAqiCarbonMonoxide)
         case .is_day:

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+ClimateApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+ClimateApi.swift
@@ -45,11 +45,11 @@ extension Cmip6VariableDerivedPostBiasCorrection: FlatBuffersVariable {
             return .init(variable: .snowfall, aggregation: .sum)
         case .rain_sum:
             return .init(variable: .rain, aggregation: .sum)
-        case .dewpoint_2m_max:
+        case .dewpoint_2m_max, .dew_point_2m_max:
             return .init(variable: .dewPoint, aggregation: .maximum, altitude: 2)
-        case .dewpoint_2m_min:
+        case .dewpoint_2m_min, .dew_point_2m_min:
             return .init(variable: .dewPoint, aggregation: .minimum, altitude: 2)
-        case .dewpoint_2m_mean:
+        case .dewpoint_2m_mean, .dew_point_2m_mean:
             return .init(variable: .dewPoint, aggregation: .mean, altitude: 2)
         case .growing_degree_days_base_0_limit_50:
             return .init(variable: .growingDegreeDays)
@@ -59,10 +59,16 @@ extension Cmip6VariableDerivedPostBiasCorrection: FlatBuffersVariable {
             return .init(variable: .soilMoistureIndex, aggregation: .mean, depth: 0, depthTo: 100)
         case .daylight_duration:
             return .init(variable: .daylightDuration)
-        case .windspeed_2m_max:
+        case .windspeed_2m_max, .wind_speed_2m_max:
             return .init(variable: .windSpeed, aggregation: .maximum, altitude: 2)
-        case .windspeed_2m_mean:
+        case .windspeed_2m_mean, .wind_speed_2m_mean:
             return .init(variable: .windSpeed, aggregation: .mean, altitude: 2)
+        case .vapour_pressure_deficit_max:
+            return .init(variable: .vapourPressureDeficit, aggregation: .maximum)
+        case .wind_gusts_10m_mean:
+            return .init(variable: .windGusts, aggregation: .mean, altitude: 10)
+        case .wind_gusts_10m_max:
+            return .init(variable: .windGusts, aggregation: .maximum, altitude: 10)
         }
     }
 }
@@ -90,16 +96,10 @@ extension Cmip6VariableDerivedBiasCorrected: FlatBuffersVariable {
             return .init(variable: .soilTemperature, aggregation: .mean, depth: 7, depthTo: 28)
         case .soil_temperature_28_to_100cm_mean:
             return .init(variable: .soilTemperature, aggregation: .mean, depth: 28, depthTo: 100)
-        case .vapour_pressure_deficit_max:
-            fallthrough
         case .vapor_pressure_deficit_max:
             return .init(variable: .vapourPressureDeficit, aggregation: .maximum)
-        case .wind_gusts_10m_mean:
-            fallthrough
         case .windgusts_10m_mean:
             return .init(variable: .windGusts, aggregation: .mean, altitude: 10)
-        case .wind_gusts_10m_max:
-            fallthrough
         case .windgusts_10m_max:
             return .init(variable: .windGusts, aggregation: .maximum, altitude: 10)
         }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+ClimateApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+ClimateApi.swift
@@ -90,10 +90,16 @@ extension Cmip6VariableDerivedBiasCorrected: FlatBuffersVariable {
             return .init(variable: .soilTemperature, aggregation: .mean, depth: 7, depthTo: 28)
         case .soil_temperature_28_to_100cm_mean:
             return .init(variable: .soilTemperature, aggregation: .mean, depth: 28, depthTo: 100)
+        case .vapour_pressure_deficit_max:
+            fallthrough
         case .vapor_pressure_deficit_max:
             return .init(variable: .vapourPressureDeficit, aggregation: .maximum)
+        case .wind_gusts_10m_mean:
+            fallthrough
         case .windgusts_10m_mean:
             return .init(variable: .windGusts, aggregation: .mean, altitude: 10)
+        case .wind_gusts_10m_max:
+            fallthrough
         case .windgusts_10m_max:
             return .init(variable: .windGusts, aggregation: .maximum, altitude: 10)
         }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+ClimateApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+ClimateApi.swift
@@ -3,130 +3,111 @@ import FlatBuffers
 import OpenMeteoSdk
 
 
+extension Cmip6Variable: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .temperature_2m_min:
+            return .init(variable: .temperature, aggregation: .minimum, altitude: 2)
+        case .temperature_2m_max:
+            return .init(variable: .temperature, aggregation: .maximum, altitude: 2)
+        case .temperature_2m_mean:
+            return .init(variable: .temperature, aggregation: .mean, altitude: 2)
+        case .pressure_msl_mean:
+            return .init(variable: .pressureMsl, aggregation: .mean)
+        case .cloudcover_mean:
+            return .init(variable: .cloudcover, aggregation: .mean)
+        case .precipitation_sum:
+            return .init(variable: .precipitation, aggregation: .sum)
+        case .snowfall_water_equivalent_sum:
+            return .init(variable: .snowfallWaterEquivalent, aggregation: .sum)
+        case .relative_humidity_2m_min:
+            return .init(variable: .relativehumidity, aggregation: .minimum, altitude: 2)
+        case .relative_humidity_2m_max:
+            return .init(variable: .temperature, aggregation: .maximum, altitude: 2)
+        case .relative_humidity_2m_mean:
+            return .init(variable: .temperature, aggregation: .mean, altitude: 2)
+        case .windspeed_10m_mean:
+            return .init(variable: .windspeed, aggregation: .mean, altitude: 10)
+        case .windspeed_10m_max:
+            return .init(variable: .windspeed, aggregation: .maximum, altitude: 10)
+        case .soil_moisture_0_to_10cm_mean:
+            return .init(variable: .soilMoisture, aggregation: .mean, depth: 0, depthTo: 10)
+        case .shortwave_radiation_sum:
+            return .init(variable: .shortwaveRadiation, aggregation: .sum)
+        }
+    }
+}
+
+extension Cmip6VariableDerivedPostBiasCorrection: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .snowfall_sum:
+            return .init(variable: .snowfall, aggregation: .sum)
+        case .rain_sum:
+            return .init(variable: .rain, aggregation: .sum)
+        case .dewpoint_2m_max:
+            return .init(variable: .dewpoint, aggregation: .maximum, altitude: 2)
+        case .dewpoint_2m_min:
+            return .init(variable: .dewpoint, aggregation: .minimum, altitude: 2)
+        case .dewpoint_2m_mean:
+            return .init(variable: .dewpoint, aggregation: .mean, altitude: 2)
+        case .growing_degree_days_base_0_limit_50:
+            return .init(variable: .growingDegreeDays)
+        case .soil_moisture_index_0_to_10cm_mean:
+            return .init(variable: .soilMoistureIndex, aggregation: .mean, depth: 0, depthTo: 10)
+        case .soil_moisture_index_0_to_100cm_mean:
+            return .init(variable: .soilMoistureIndex, aggregation: .mean, depth: 0, depthTo: 100)
+        case .daylight_duration:
+            return .init(variable: .daylightDuration)
+        case .windspeed_2m_max:
+            return .init(variable: .windspeed, aggregation: .maximum, altitude: 2)
+        case .windspeed_2m_mean:
+            return .init(variable: .windspeed, aggregation: .mean, altitude: 2)
+        }
+    }
+}
+
+extension Cmip6VariableDerivedBiasCorrected: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .et0_fao_evapotranspiration_sum:
+            return .init(variable: .et0FaoEvapotranspiration, aggregation: .sum)
+        case .leaf_wetness_probability_mean:
+            return .init(variable: .leafWetnessProbability, aggregation: .mean)
+        case .soil_moisture_0_to_100cm_mean:
+            return .init(variable: .soilMoisture, aggregation: .mean, depth: 0, depthTo: 100)
+        case .soil_moisture_0_to_7cm_mean:
+            return .init(variable: .soilMoisture, aggregation: .mean, depth: 0, depthTo: 7)
+        case .soil_moisture_7_to_28cm_mean:
+            return .init(variable: .soilMoisture, aggregation: .mean, depth: 7, depthTo: 28)
+        case .soil_moisture_28_to_100cm_mean:
+            return .init(variable: .soilMoisture, aggregation: .mean, depth: 28, depthTo: 100)
+        case .soil_temperature_0_to_100cm_mean:
+            return .init(variable: .soilTemperature, aggregation: .mean, depth: 0, depthTo: 100)
+        case .soil_temperature_0_to_7cm_mean:
+            return .init(variable: .soilTemperature, aggregation: .mean, depth: 0, depthTo: 7)
+        case .soil_temperature_7_to_28cm_mean:
+            return .init(variable: .soilTemperature, aggregation: .mean, depth: 7, depthTo: 28)
+        case .soil_temperature_28_to_100cm_mean:
+            return .init(variable: .soilTemperature, aggregation: .mean, depth: 28, depthTo: 100)
+        case .vapor_pressure_deficit_max:
+            return .init(variable: .vaporPressureDeficit, aggregation: .maximum)
+        case .windgusts_10m_mean:
+            return .init(variable: .windgusts, aggregation: .mean, altitude: 10)
+        case .windgusts_10m_max:
+            return .init(variable: .windgusts, aggregation: .maximum, altitude: 10)
+        }
+    }
+}
+
 extension Cmip6Domain: ModelFlatbufferSerialisable {
     typealias HourlyVariable = ForecastSurfaceVariable
     
     typealias HourlyPressureType = ForecastPressureVariableType
     
     typealias DailyVariable = Cmip6VariableOrDerivedPostBias
-  
-    static func encodeDaily(section: ApiSection<DailyVariable>, _ fbb: inout FlatBufferBuilder) -> Offset {
-        let offsets = ForecastapiResult<Self>.encode(section: section, &fbb)
-        let start = openmeteo_sdk_ClimateDaily.startClimateDaily(&fbb)
-        openmeteo_sdk_ClimateDaily.add(time: section.timeFlatBuffers(), &fbb)
-        for (variable, offset) in zip(section.columns, offsets) {
-            switch variable.variable {
-            case .raw(let v):
-                switch v {
-                case .raw(let v):
-                    switch v {
-                    case .temperature_2m_min:
-                        openmeteo_sdk_ClimateDaily.add(temperature2mMin: offset, &fbb)
-                    case .temperature_2m_max:
-                        openmeteo_sdk_ClimateDaily.add(temperature2mMax: offset, &fbb)
-                    case .temperature_2m_mean:
-                        openmeteo_sdk_ClimateDaily.add(temperature2mMean: offset, &fbb)
-                    case .pressure_msl_mean:
-                        openmeteo_sdk_ClimateDaily.add(pressureMslMean: offset, &fbb)
-                    case .cloudcover_mean:
-                        openmeteo_sdk_ClimateDaily.add(cloudcoverMean: offset, &fbb)
-                    case .precipitation_sum:
-                        openmeteo_sdk_ClimateDaily.add(precipitationSum: offset, &fbb)
-                    case .snowfall_water_equivalent_sum:
-                        openmeteo_sdk_ClimateDaily.add(snowfallWaterEquivalentSum: offset, &fbb)
-                    case .relative_humidity_2m_min:
-                        openmeteo_sdk_ClimateDaily.add(relativeHumidity2mMin: offset, &fbb)
-                    case .relative_humidity_2m_max:
-                        openmeteo_sdk_ClimateDaily.add(relativeHumidity2mMax: offset, &fbb)
-                    case .relative_humidity_2m_mean:
-                        openmeteo_sdk_ClimateDaily.add(relativeHumidity2mMean: offset, &fbb)
-                    case .windspeed_10m_mean:
-                        openmeteo_sdk_ClimateDaily.add(windspeed10mMean: offset, &fbb)
-                    case .windspeed_10m_max:
-                        openmeteo_sdk_ClimateDaily.add(windspeed10mMax: offset, &fbb)
-                    case .soil_moisture_0_to_10cm_mean:
-                        openmeteo_sdk_ClimateDaily.add(soilMoisture0To10cmMean: offset, &fbb)
-                    case .shortwave_radiation_sum:
-                        openmeteo_sdk_ClimateDaily.add(shortwaveRadiationSum: offset, &fbb)
-                    }
-                case .derived(let v):
-                    switch v {
-                    case .et0_fao_evapotranspiration_sum:
-                        openmeteo_sdk_ClimateDaily.add(et0FaoEvapotranspirationSum: offset, &fbb)
-                    case .leaf_wetness_probability_mean:
-                        openmeteo_sdk_ClimateDaily.add(leafWetnessProbabilityMean: offset, &fbb)
-                    case .soil_moisture_0_to_100cm_mean:
-                        openmeteo_sdk_ClimateDaily.add(soilMoisture0To100cmMean:  offset, &fbb)
-                    case .soil_moisture_0_to_7cm_mean:
-                        openmeteo_sdk_ClimateDaily.add(soilMoisture0To7cmMean: offset, &fbb)
-                    case .soil_moisture_7_to_28cm_mean:
-                        openmeteo_sdk_ClimateDaily.add(soilMoisture7To28cmMean: offset, &fbb)
-                    case .soil_moisture_28_to_100cm_mean:
-                        openmeteo_sdk_ClimateDaily.add(soilMoisture28To100cmMean: offset, &fbb)
-                    case .soil_temperature_0_to_100cm_mean:
-                        openmeteo_sdk_ClimateDaily.add(soilTemperature0To100cmMean: offset, &fbb)
-                    case .soil_temperature_0_to_7cm_mean:
-                        openmeteo_sdk_ClimateDaily.add(soilTemperature0To7cmMean: offset, &fbb)
-                    case .soil_temperature_7_to_28cm_mean:
-                        openmeteo_sdk_ClimateDaily.add(soilTemperature7To28cmMean: offset, &fbb)
-                    case .soil_temperature_28_to_100cm_mean:
-                        openmeteo_sdk_ClimateDaily.add(soilTemperature28To100cmMean: offset, &fbb)
-                    case .vapor_pressure_deficit_max:
-                        openmeteo_sdk_ClimateDaily.add(vaporPressureDeficitMax: offset, &fbb)
-                    case .windgusts_10m_mean:
-                        openmeteo_sdk_ClimateDaily.add(windgusts10mMean: offset, &fbb)
-                    case .windgusts_10m_max:
-                        openmeteo_sdk_ClimateDaily.add(windgusts10mMax: offset, &fbb)
-                    }
-                }
-            case .derived(let v):
-                switch v {
-                case .snowfall_sum:
-                    openmeteo_sdk_ClimateDaily.add(snowfallSum: offset, &fbb)
-                case .rain_sum:
-                    openmeteo_sdk_ClimateDaily.add(rainSum: offset, &fbb)
-                case .dewpoint_2m_max:
-                    openmeteo_sdk_ClimateDaily.add(dewpoint2mMax: offset, &fbb)
-                case .dewpoint_2m_min:
-                    openmeteo_sdk_ClimateDaily.add(dewpoint2mMin: offset, &fbb)
-                case .dewpoint_2m_mean:
-                    openmeteo_sdk_ClimateDaily.add(dewpoint2mMean: offset, &fbb)
-                case .growing_degree_days_base_0_limit_50:
-                    openmeteo_sdk_ClimateDaily.add(growingDegreeDaysBase0Limit50: offset, &fbb)
-                case .soil_moisture_index_0_to_10cm_mean:
-                    openmeteo_sdk_ClimateDaily.add(soilMoistureIndex0To10cmMean: offset, &fbb)
-                case .soil_moisture_index_0_to_100cm_mean:
-                    openmeteo_sdk_ClimateDaily.add(soilMoistureIndex0To100cmMean: offset, &fbb)
-                case .daylight_duration:
-                    openmeteo_sdk_ClimateDaily.add(daylightDuration: offset, &fbb)
-                case .windspeed_2m_max:
-                    openmeteo_sdk_ClimateDaily.add(windspeed2mMax: offset, &fbb)
-                case .windspeed_2m_mean:
-                    openmeteo_sdk_ClimateDaily.add(windspeed2mMean: offset, &fbb)
-                }
-            }
-        }
-        return openmeteo_sdk_ClimateDaily.endClimateDaily(&fbb, start: start)
-    }
     
-    static func writeToFlatbuffer(section: ForecastapiResult<Self>.PerModel, _ fbb: inout FlatBufferBuilder, timezone: TimezoneWithOffset, fixedGenerationTime: Double?) throws {
-        let generationTimeStart = Date()
-        let daily = (try section.daily?()).map { encodeDaily(section: $0, &fbb) } ?? Offset()
-        let generationTimeMs = fixedGenerationTime ?? (Date().timeIntervalSince(generationTimeStart) * 1000)
-        
-        let result = openmeteo_sdk_ClimateApiResponse.createClimateApiResponse(
-            &fbb,
-            latitude: section.latitude,
-            longitude: section.longitude,
-            elevation: section.elevation ?? .nan,
-            model: section.model.flatBufferModel,
-            generationtimeMs: Float32(generationTimeMs),
-            dailyOffset: daily
-        )
-        fbb.finish(offset: result, addPrefix: true)
-    }
-    
-    var flatBufferModel: openmeteo_sdk_ClimateModel {
+    var flatBufferModel: openmeteo_sdk_Model {
         switch self {
         case .CMCC_CM2_VHR4:
             return .cmccCm2Vhr4

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+ClimateApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+ClimateApi.swift
@@ -15,21 +15,21 @@ extension Cmip6Variable: FlatBuffersVariable {
         case .pressure_msl_mean:
             return .init(variable: .pressureMsl, aggregation: .mean)
         case .cloudcover_mean:
-            return .init(variable: .cloudcover, aggregation: .mean)
+            return .init(variable: .cloudCover, aggregation: .mean)
         case .precipitation_sum:
             return .init(variable: .precipitation, aggregation: .sum)
         case .snowfall_water_equivalent_sum:
             return .init(variable: .snowfallWaterEquivalent, aggregation: .sum)
         case .relative_humidity_2m_min:
-            return .init(variable: .relativehumidity, aggregation: .minimum, altitude: 2)
+            return .init(variable: .relativeHumidity, aggregation: .minimum, altitude: 2)
         case .relative_humidity_2m_max:
             return .init(variable: .temperature, aggregation: .maximum, altitude: 2)
         case .relative_humidity_2m_mean:
             return .init(variable: .temperature, aggregation: .mean, altitude: 2)
         case .windspeed_10m_mean:
-            return .init(variable: .windspeed, aggregation: .mean, altitude: 10)
+            return .init(variable: .windSpeed, aggregation: .mean, altitude: 10)
         case .windspeed_10m_max:
-            return .init(variable: .windspeed, aggregation: .maximum, altitude: 10)
+            return .init(variable: .windSpeed, aggregation: .maximum, altitude: 10)
         case .soil_moisture_0_to_10cm_mean:
             return .init(variable: .soilMoisture, aggregation: .mean, depth: 0, depthTo: 10)
         case .shortwave_radiation_sum:
@@ -46,11 +46,11 @@ extension Cmip6VariableDerivedPostBiasCorrection: FlatBuffersVariable {
         case .rain_sum:
             return .init(variable: .rain, aggregation: .sum)
         case .dewpoint_2m_max:
-            return .init(variable: .dewpoint, aggregation: .maximum, altitude: 2)
+            return .init(variable: .dewPoint, aggregation: .maximum, altitude: 2)
         case .dewpoint_2m_min:
-            return .init(variable: .dewpoint, aggregation: .minimum, altitude: 2)
+            return .init(variable: .dewPoint, aggregation: .minimum, altitude: 2)
         case .dewpoint_2m_mean:
-            return .init(variable: .dewpoint, aggregation: .mean, altitude: 2)
+            return .init(variable: .dewPoint, aggregation: .mean, altitude: 2)
         case .growing_degree_days_base_0_limit_50:
             return .init(variable: .growingDegreeDays)
         case .soil_moisture_index_0_to_10cm_mean:
@@ -60,9 +60,9 @@ extension Cmip6VariableDerivedPostBiasCorrection: FlatBuffersVariable {
         case .daylight_duration:
             return .init(variable: .daylightDuration)
         case .windspeed_2m_max:
-            return .init(variable: .windspeed, aggregation: .maximum, altitude: 2)
+            return .init(variable: .windSpeed, aggregation: .maximum, altitude: 2)
         case .windspeed_2m_mean:
-            return .init(variable: .windspeed, aggregation: .mean, altitude: 2)
+            return .init(variable: .windSpeed, aggregation: .mean, altitude: 2)
         }
     }
 }
@@ -91,11 +91,11 @@ extension Cmip6VariableDerivedBiasCorrected: FlatBuffersVariable {
         case .soil_temperature_28_to_100cm_mean:
             return .init(variable: .soilTemperature, aggregation: .mean, depth: 28, depthTo: 100)
         case .vapor_pressure_deficit_max:
-            return .init(variable: .vaporPressureDeficit, aggregation: .maximum)
+            return .init(variable: .vapourPressureDeficit, aggregation: .maximum)
         case .windgusts_10m_mean:
-            return .init(variable: .windgusts, aggregation: .mean, altitude: 10)
+            return .init(variable: .windGusts, aggregation: .mean, altitude: 10)
         case .windgusts_10m_max:
-            return .init(variable: .windgusts, aggregation: .maximum, altitude: 10)
+            return .init(variable: .windGusts, aggregation: .maximum, altitude: 10)
         }
     }
 }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+EnsembleApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+EnsembleApi.swift
@@ -5,7 +5,7 @@ import OpenMeteoSdk
 extension EnsembleSurfaceVariable: FlatBuffersVariable {
     func getFlatBuffersMeta() -> FlatBufferVariableMeta {
         switch self {
-        case .weathercode:
+        case .weathercode, .weather_code:
             return .init(variable: .weatherCode)
         case .temperature_2m:
             return .init(variable: .temperature, altitude: 2)
@@ -13,19 +13,19 @@ extension EnsembleSurfaceVariable: FlatBuffersVariable {
             return .init(variable: .temperature, altitude: 80)
         case .temperature_120m:
             return .init(variable: .temperature, altitude: 120)
-        case .cloudcover:
+        case .cloudcover, .cloud_cover:
             return .init(variable: .cloudCover)
         case .pressure_msl:
             return .init(variable: .pressureMsl)
-        case .relativehumidity_2m:
+        case .relativehumidity_2m, .relative_humidity_2m:
             return .init(variable: .relativeHumidity, altitude: 2)
         case .precipitation:
             return .init(variable: .precipitation)
         case .rain:
             return .init(variable: .rain)
-        case .windgusts_10m:
+        case .windgusts_10m, .wind_gusts_10m:
             return .init(variable: .windGusts, altitude: 10)
-        case .dewpoint_2m:
+        case .dewpoint_2m, .dew_point_2m:
             return .init(variable: .dewPoint, altitude: 2)
         case .diffuse_radiation:
             return .init(variable: .diffuseRadiation)
@@ -33,23 +33,23 @@ extension EnsembleSurfaceVariable: FlatBuffersVariable {
             return .init(variable: .directRadiation)
         case .apparent_temperature:
             return .init(variable: .apparentTemperature, altitude: 2)
-        case .windspeed_10m:
+        case .windspeed_10m, .wind_speed_10m:
             return .init(variable: .windSpeed, altitude: 10)
-        case .winddirection_10m:
+        case .winddirection_10m, .wind_direction_10m:
             return .init(variable: .windDirection, altitude: 10)
-        case .windspeed_80m:
+        case .windspeed_80m, .wind_speed_80m:
             return .init(variable: .windSpeed, altitude: 80)
-        case .winddirection_80m:
+        case .winddirection_80m, .wind_direction_80m:
             return .init(variable: .windDirection, altitude: 80)
-        case .windspeed_120m:
+        case .windspeed_120m, .wind_speed_120m:
             return .init(variable: .windSpeed, altitude: 120)
-        case .winddirection_120m:
+        case .winddirection_120m, .wind_direction_120m:
             return .init(variable: .windDirection, altitude: 120)
         case .direct_normal_irradiance:
             return .init(variable: .directNormalIrradiance)
         case .et0_fao_evapotranspiration:
             return .init(variable: .et0FaoEvapotranspiration)
-        case .vapor_pressure_deficit:
+        case .vapor_pressure_deficit, .vapour_pressure_deficit:
             return .init(variable: .vapourPressureDeficit)
         case .shortwave_radiation:
             return .init(variable: .shortwaveRadiation)
@@ -71,7 +71,7 @@ extension EnsembleSurfaceVariable: FlatBuffersVariable {
             return .init(variable: .isDay)
         case .visibility:
             return .init(variable: .visibility)
-        case .freezinglevel_height:
+        case .freezinglevel_height, .freezing_level_height:
             return .init(variable: .freezingLevelHeight)
         case .uv_index:
             return .init(variable: .uvIndex)
@@ -108,15 +108,15 @@ extension EnsemblePressureVariableType: FlatBuffersVariable {
             return .init(variable: .temperature)
         case .geopotential_height:
             return .init(variable: .geopotentialHeight)
-        case .relativehumidity:
+        case .relativehumidity, .relative_humidity:
             return .init(variable: .relativeHumidity)
-        case .windspeed:
+        case .windspeed, .wind_speed:
             return .init(variable: .windSpeed)
-        case .winddirection:
+        case .winddirection, .wind_direction:
             return .init(variable: .windDirection)
-        case .dewpoint:
+        case .dewpoint, .dew_point:
             return .init(variable: .dewPoint)
-        case .cloudcover:
+        case .cloudcover, .cloud_cover:
             return .init(variable: .cloudCover)
         case .vertical_velocity:
             return .init(variable: .verticalVelocity)

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+EnsembleApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+EnsembleApi.swift
@@ -2,6 +2,128 @@ import Foundation
 import FlatBuffers
 import OpenMeteoSdk
 
+extension EnsembleSurfaceVariable: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .weathercode:
+            return .init(variable: .weathercode)
+        case .temperature_2m:
+            return .init(variable: .temperature, altitude: 2)
+        case .temperature_80m:
+            return .init(variable: .temperature, altitude: 80)
+        case .temperature_120m:
+            return .init(variable: .temperature, altitude: 120)
+        case .cloudcover:
+            return .init(variable: .cloudcover)
+        case .pressure_msl:
+            return .init(variable: .pressureMsl)
+        case .relativehumidity_2m:
+            return .init(variable: .relativehumidity, altitude: 2)
+        case .precipitation:
+            return .init(variable: .precipitation)
+        case .rain:
+            return .init(variable: .rain)
+        case .windgusts_10m:
+            return .init(variable: .windgusts, altitude: 10)
+        case .dewpoint_2m:
+            return .init(variable: .dewpoint, altitude: 2)
+        case .diffuse_radiation:
+            return .init(variable: .diffuseRadiation)
+        case .direct_radiation:
+            return .init(variable: .directRadiation)
+        case .apparent_temperature:
+            return .init(variable: .apparentTemperature, altitude: 2)
+        case .windspeed_10m:
+            return .init(variable: .windspeed, altitude: 10)
+        case .winddirection_10m:
+            return .init(variable: .winddirection, altitude: 10)
+        case .windspeed_80m:
+            return .init(variable: .windspeed, altitude: 80)
+        case .winddirection_80m:
+            return .init(variable: .winddirection, altitude: 80)
+        case .windspeed_120m:
+            return .init(variable: .windspeed, altitude: 120)
+        case .winddirection_120m:
+            return .init(variable: .winddirection, altitude: 120)
+        case .direct_normal_irradiance:
+            return .init(variable: .directNormalIrradiance)
+        case .et0_fao_evapotranspiration:
+            return .init(variable: .et0FaoEvapotranspiration)
+        case .vapor_pressure_deficit:
+            return .init(variable: .vaporPressureDeficit)
+        case .shortwave_radiation:
+            return .init(variable: .shortwaveRadiation)
+        case .snowfall:
+            return .init(variable: .snowfall)
+        case .snow_depth:
+            return .init(variable: .snowDepth)
+        case .surface_pressure:
+            return .init(variable: .surfacePressure)
+        case .shortwave_radiation_instant:
+            return .init(variable: .shortwaveRadiationInstant)
+        case .diffuse_radiation_instant:
+            return .init(variable: .diffuseRadiationInstant)
+        case .direct_radiation_instant:
+            return .init(variable: .directRadiationInstant)
+        case .direct_normal_irradiance_instant:
+            return .init(variable: .directNormalIrradianceInstant)
+        case .is_day:
+            return .init(variable: .isDay)
+        case .visibility:
+            return .init(variable: .visibility)
+        case .freezinglevel_height:
+            return .init(variable: .freezinglevelHeight)
+        case .uv_index:
+            return .init(variable: .uvIndex)
+        case .uv_index_clear_sky:
+            return .init(variable: .uvIndexClearSky)
+        case .cape:
+            return .init(variable: .cape)
+        case .surface_temperature:
+            return .init(variable: .surfacePressure)
+        case .soil_temperature_0_to_10cm:
+            return .init(variable: .soilTemperature, depth: 0, depthTo: 10)
+        case .soil_temperature_10_to_40cm:
+            return .init(variable: .soilTemperature, depth: 10, depthTo: 40)
+        case .soil_temperature_40_to_100cm:
+            return .init(variable: .soilTemperature, depth: 40, depthTo: 100)
+        case .soil_temperature_100_to_200cm:
+            return .init(variable: .soilTemperature, depth: 100, depthTo: 200)
+        case .soil_moisture_0_to_10cm:
+            return .init(variable: .soilMoisture, depth: 0, depthTo: 10)
+        case .soil_moisture_10_to_40cm:
+            return .init(variable: .soilMoisture, depth: 10, depthTo: 40)
+        case .soil_moisture_40_to_100cm:
+            return .init(variable: .soilMoisture, depth: 40, depthTo: 100)
+        case .soil_moisture_100_to_200cm:
+            return .init(variable: .soilMoisture, depth: 100, depthTo: 255)
+        }
+    }
+}
+
+extension EnsemblePressureVariableType: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .temperature:
+            return .init(variable: .temperature)
+        case .geopotential_height:
+            return .init(variable: .geopotentialHeight)
+        case .relativehumidity:
+            return .init(variable: .relativehumidity)
+        case .windspeed:
+            return .init(variable: .windspeed)
+        case .winddirection:
+            return .init(variable: .winddirection)
+        case .dewpoint:
+            return .init(variable: .dewpoint)
+        case .cloudcover:
+            return .init(variable: .cloudcover)
+        case .vertical_velocity:
+            return .init(variable: .verticalVelocity)
+        }
+    }
+}
+
 
 extension EnsembleMultiDomains: ModelFlatbufferSerialisable {
     typealias HourlyVariable = EnsembleSurfaceVariable
@@ -10,7 +132,7 @@ extension EnsembleMultiDomains: ModelFlatbufferSerialisable {
     
     typealias DailyVariable = ForecastVariableDaily
     
-    var flatBufferModel: openmeteo_sdk_EnsembleModel {
+    var flatBufferModel: openmeteo_sdk_Model {
         switch self {
         case .icon_seamless:
             return .iconSeamless
@@ -31,148 +153,5 @@ extension EnsembleMultiDomains: ModelFlatbufferSerialisable {
         case .gfs05:
             return .gfs025
         }
-    }
-    
-    static func encodeHourly(section: ApiSection<ForecastapiResult<Self>.SurfaceAndPressureVariable>, _ fbb: inout FlatBufferBuilder) -> Offset {
-        let offsets = ForecastapiResult.encodeEnsemble(section: section, &fbb)
-        let start = openmeteo_sdk_EnsembleHourly.startEnsembleHourly(&fbb)
-        openmeteo_sdk_EnsembleHourly.add(time: section.timeFlatBuffers(), &fbb)
-        for (surface, offset) in offsets.surface {
-            switch surface {
-            case .weathercode:
-                openmeteo_sdk_EnsembleHourly.add(weathercode: offset, &fbb)
-            case .temperature_2m:
-                openmeteo_sdk_EnsembleHourly.add(temperature2m: offset, &fbb)
-            case .temperature_80m:
-                openmeteo_sdk_EnsembleHourly.add(temperature80m: offset, &fbb)
-            case .temperature_120m:
-                openmeteo_sdk_EnsembleHourly.add(temperature120m: offset, &fbb)
-            case .cloudcover:
-                openmeteo_sdk_EnsembleHourly.add(cloudcover: offset, &fbb)
-            case .pressure_msl:
-                openmeteo_sdk_EnsembleHourly.add(pressureMsl: offset, &fbb)
-            case .relativehumidity_2m:
-                openmeteo_sdk_EnsembleHourly.add(relativehumidity2m: offset, &fbb)
-            case .precipitation:
-                openmeteo_sdk_EnsembleHourly.add(precipitation: offset, &fbb)
-            case .rain:
-                openmeteo_sdk_EnsembleHourly.add(rain: offset, &fbb)
-            case .windgusts_10m:
-                openmeteo_sdk_EnsembleHourly.add(windgusts10m: offset, &fbb)
-            case .dewpoint_2m:
-                openmeteo_sdk_EnsembleHourly.add(dewpoint2m: offset, &fbb)
-            case .diffuse_radiation:
-                openmeteo_sdk_EnsembleHourly.add(diffuseRadiation: offset, &fbb)
-            case .direct_radiation:
-                openmeteo_sdk_EnsembleHourly.add(directRadiation: offset, &fbb)
-            case .apparent_temperature:
-                openmeteo_sdk_EnsembleHourly.add(apparentTemperature: offset, &fbb)
-            case .windspeed_10m:
-                openmeteo_sdk_EnsembleHourly.add(windspeed10m: offset, &fbb)
-            case .winddirection_10m:
-                openmeteo_sdk_EnsembleHourly.add(winddirection10m: offset, &fbb)
-            case .windspeed_80m:
-                openmeteo_sdk_EnsembleHourly.add(windspeed80m: offset, &fbb)
-            case .winddirection_80m:
-                openmeteo_sdk_EnsembleHourly.add(winddirection80m: offset, &fbb)
-            case .windspeed_120m:
-                openmeteo_sdk_EnsembleHourly.add(windspeed120m: offset, &fbb)
-            case .winddirection_120m:
-                openmeteo_sdk_EnsembleHourly.add(winddirection120m: offset, &fbb)
-            case .direct_normal_irradiance:
-                openmeteo_sdk_EnsembleHourly.add(directNormalIrradiance: offset, &fbb)
-            case .et0_fao_evapotranspiration:
-                openmeteo_sdk_EnsembleHourly.add(et0FaoEvapotranspiration: offset, &fbb)
-            case .vapor_pressure_deficit:
-                openmeteo_sdk_EnsembleHourly.add(vaporPressureDeficit: offset, &fbb)
-            case .shortwave_radiation:
-                openmeteo_sdk_EnsembleHourly.add(shortwaveRadiation: offset, &fbb)
-            case .snowfall:
-                openmeteo_sdk_EnsembleHourly.add(snowfall: offset, &fbb)
-            case .snow_depth:
-                openmeteo_sdk_EnsembleHourly.add(snowDepth: offset, &fbb)
-            case .surface_pressure:
-                openmeteo_sdk_EnsembleHourly.add(surfacePressure: offset, &fbb)
-            case .shortwave_radiation_instant:
-                openmeteo_sdk_EnsembleHourly.add(shortwaveRadiationInstant: offset, &fbb)
-            case .diffuse_radiation_instant:
-                openmeteo_sdk_EnsembleHourly.add(diffuseRadiationInstant: offset, &fbb)
-            case .direct_radiation_instant:
-                openmeteo_sdk_EnsembleHourly.add(directRadiationInstant: offset, &fbb)
-            case .direct_normal_irradiance_instant:
-                openmeteo_sdk_EnsembleHourly.add(directNormalIrradianceInstant: offset, &fbb)
-            case .is_day:
-                openmeteo_sdk_EnsembleHourly.add(isDay: offset, &fbb)
-            case .visibility:
-                openmeteo_sdk_EnsembleHourly.add(visibility: offset, &fbb)
-            case .freezinglevel_height:
-                openmeteo_sdk_EnsembleHourly.add(freezinglevelHeight: offset, &fbb)
-            case .uv_index:
-                openmeteo_sdk_EnsembleHourly.add(uvIndex: offset, &fbb)
-            case .uv_index_clear_sky:
-                openmeteo_sdk_EnsembleHourly.add(uvIndexClearSky: offset, &fbb)
-            case .cape:
-                openmeteo_sdk_EnsembleHourly.add(cape: offset, &fbb)
-            case .surface_temperature:
-                openmeteo_sdk_EnsembleHourly.add(surfaceTemperature: offset, &fbb)
-            case .soil_temperature_0_to_10cm:
-                openmeteo_sdk_EnsembleHourly.add(soilTemperature0To10cm: offset, &fbb)
-            case .soil_temperature_10_to_40cm:
-                openmeteo_sdk_EnsembleHourly.add(soilTemperature10To40cm: offset, &fbb)
-            case .soil_temperature_40_to_100cm:
-                openmeteo_sdk_EnsembleHourly.add(soilTemperature40To100cm: offset, &fbb)
-            case .soil_temperature_100_to_200cm:
-                openmeteo_sdk_EnsembleHourly.add(soilTemperature100To200cm: offset, &fbb)
-            case .soil_moisture_0_to_10cm:
-                openmeteo_sdk_EnsembleHourly.add(soilMoisture0To10cm: offset, &fbb)
-            case .soil_moisture_10_to_40cm:
-                openmeteo_sdk_EnsembleHourly.add(soilMoisture10To40cm: offset, &fbb)
-            case .soil_moisture_40_to_100cm:
-                openmeteo_sdk_EnsembleHourly.add(soilMoisture40To100cm: offset, &fbb)
-            case .soil_moisture_100_to_200cm:
-                openmeteo_sdk_EnsembleHourly.add(soilTemperature100To200cm: offset, &fbb)
-            }
-        }
-        for (pressure, offset) in offsets.pressure {
-            switch pressure {
-            case .temperature:
-                openmeteo_sdk_EnsembleHourly.add(pressureLevelTemperature: offset, &fbb)
-            case .geopotential_height:
-                openmeteo_sdk_EnsembleHourly.add(pressureLevelGeopotentialHeight: offset, &fbb)
-            case .relativehumidity:
-                openmeteo_sdk_EnsembleHourly.add(pressureLevelRelativehumidity: offset, &fbb)
-            case .windspeed:
-                openmeteo_sdk_EnsembleHourly.add(pressureLevelWindspeed: offset, &fbb)
-            case .winddirection:
-                openmeteo_sdk_EnsembleHourly.add(pressureLevelWinddirection: offset, &fbb)
-            case .dewpoint:
-                openmeteo_sdk_EnsembleHourly.add(pressureLevelDewpoint: offset, &fbb)
-            case .cloudcover:
-                openmeteo_sdk_EnsembleHourly.add(pressureLevelCloudcover: offset, &fbb)
-            case .vertical_velocity:
-                openmeteo_sdk_EnsembleHourly.add(pressureLevelVerticalVelocity: offset, &fbb)
-            }
-        }
-        return openmeteo_sdk_EnsembleHourly.endEnsembleHourly(&fbb, start: start)
-    }
-    
-    static func writeToFlatbuffer(section: ForecastapiResult<Self>.PerModel, _ fbb: inout FlatBufferBuilder, timezone: TimezoneWithOffset, fixedGenerationTime: Double?) throws {
-        let generationTimeStart = Date()
-        let hourly = (try section.hourly?()).map { encodeHourly(section: $0, &fbb) } ?? Offset()
-        let generationTimeMs = fixedGenerationTime ?? (Date().timeIntervalSince(generationTimeStart) * 1000)
-        
-        let result = openmeteo_sdk_EnsembleApiResponse.createEnsembleApiResponse(
-            &fbb,
-            latitude: section.latitude,
-            longitude: section.longitude,
-            elevation: section.elevation ?? .nan,
-            model: section.model.flatBufferModel,
-            generationtimeMs: Float32(generationTimeMs),
-            utcOffsetSeconds: Int32(timezone.utcOffsetSeconds),
-            timezoneOffset: timezone.identifier == "GMT" ? Offset() : fbb.create(string: timezone.identifier),
-            timezoneAbbreviationOffset: timezone.abbreviation == "GMT" ? Offset() : fbb.create(string: timezone.abbreviation),
-            hourlyOffset: hourly
-        )
-        fbb.finish(offset: result, addPrefix: true)
     }
 }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+EnsembleApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+EnsembleApi.swift
@@ -6,7 +6,7 @@ extension EnsembleSurfaceVariable: FlatBuffersVariable {
     func getFlatBuffersMeta() -> FlatBufferVariableMeta {
         switch self {
         case .weathercode:
-            return .init(variable: .weathercode)
+            return .init(variable: .weatherCode)
         case .temperature_2m:
             return .init(variable: .temperature, altitude: 2)
         case .temperature_80m:
@@ -14,19 +14,19 @@ extension EnsembleSurfaceVariable: FlatBuffersVariable {
         case .temperature_120m:
             return .init(variable: .temperature, altitude: 120)
         case .cloudcover:
-            return .init(variable: .cloudcover)
+            return .init(variable: .cloudCover)
         case .pressure_msl:
             return .init(variable: .pressureMsl)
         case .relativehumidity_2m:
-            return .init(variable: .relativehumidity, altitude: 2)
+            return .init(variable: .relativeHumidity, altitude: 2)
         case .precipitation:
             return .init(variable: .precipitation)
         case .rain:
             return .init(variable: .rain)
         case .windgusts_10m:
-            return .init(variable: .windgusts, altitude: 10)
+            return .init(variable: .windGusts, altitude: 10)
         case .dewpoint_2m:
-            return .init(variable: .dewpoint, altitude: 2)
+            return .init(variable: .dewPoint, altitude: 2)
         case .diffuse_radiation:
             return .init(variable: .diffuseRadiation)
         case .direct_radiation:
@@ -34,23 +34,23 @@ extension EnsembleSurfaceVariable: FlatBuffersVariable {
         case .apparent_temperature:
             return .init(variable: .apparentTemperature, altitude: 2)
         case .windspeed_10m:
-            return .init(variable: .windspeed, altitude: 10)
+            return .init(variable: .windSpeed, altitude: 10)
         case .winddirection_10m:
-            return .init(variable: .winddirection, altitude: 10)
+            return .init(variable: .windDirection, altitude: 10)
         case .windspeed_80m:
-            return .init(variable: .windspeed, altitude: 80)
+            return .init(variable: .windSpeed, altitude: 80)
         case .winddirection_80m:
-            return .init(variable: .winddirection, altitude: 80)
+            return .init(variable: .windDirection, altitude: 80)
         case .windspeed_120m:
-            return .init(variable: .windspeed, altitude: 120)
+            return .init(variable: .windSpeed, altitude: 120)
         case .winddirection_120m:
-            return .init(variable: .winddirection, altitude: 120)
+            return .init(variable: .windDirection, altitude: 120)
         case .direct_normal_irradiance:
             return .init(variable: .directNormalIrradiance)
         case .et0_fao_evapotranspiration:
             return .init(variable: .et0FaoEvapotranspiration)
         case .vapor_pressure_deficit:
-            return .init(variable: .vaporPressureDeficit)
+            return .init(variable: .vapourPressureDeficit)
         case .shortwave_radiation:
             return .init(variable: .shortwaveRadiation)
         case .snowfall:
@@ -72,7 +72,7 @@ extension EnsembleSurfaceVariable: FlatBuffersVariable {
         case .visibility:
             return .init(variable: .visibility)
         case .freezinglevel_height:
-            return .init(variable: .freezinglevelHeight)
+            return .init(variable: .freezingLevelHeight)
         case .uv_index:
             return .init(variable: .uvIndex)
         case .uv_index_clear_sky:
@@ -109,15 +109,15 @@ extension EnsemblePressureVariableType: FlatBuffersVariable {
         case .geopotential_height:
             return .init(variable: .geopotentialHeight)
         case .relativehumidity:
-            return .init(variable: .relativehumidity)
+            return .init(variable: .relativeHumidity)
         case .windspeed:
-            return .init(variable: .windspeed)
+            return .init(variable: .windSpeed)
         case .winddirection:
-            return .init(variable: .winddirection)
+            return .init(variable: .windDirection)
         case .dewpoint:
-            return .init(variable: .dewpoint)
+            return .init(variable: .dewPoint)
         case .cloudcover:
-            return .init(variable: .cloudcover)
+            return .init(variable: .cloudCover)
         case .vertical_velocity:
             return .init(variable: .verticalVelocity)
         }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+FloodApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+FloodApi.swift
@@ -3,6 +3,36 @@ import FlatBuffers
 import OpenMeteoSdk
 
 
+extension GloFasVariable: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .river_discharge:
+            return .init(variable: .riverDischarge)
+        }
+    }
+}
+
+extension GlofasDerivedVariable: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .river_discharge_mean:
+            return .init(variable: .riverDischarge, aggregation: .mean)
+        case .river_discharge_min:
+            return .init(variable: .riverDischarge, aggregation: .minimum)
+        case .river_discharge_max:
+            return .init(variable: .riverDischarge, aggregation: .maximum)
+        case .river_discharge_median:
+            return .init(variable: .riverDischarge, aggregation: .median)
+        case .river_discharge_p25:
+            return .init(variable: .riverDischarge, aggregation: .p25)
+        case .river_discharge_p75:
+            return .init(variable: .riverDischarge, aggregation: .p75)
+        }
+    }
+}
+
+
+
 extension GlofasDomainApi: ModelFlatbufferSerialisable {
     typealias HourlyVariable = EnsembleSurfaceVariable
     
@@ -10,7 +40,7 @@ extension GlofasDomainApi: ModelFlatbufferSerialisable {
     
     typealias DailyVariable = GloFasVariableOrDerived
     
-    var flatBufferModel: openmeteo_sdk_FloodModel {
+    var flatBufferModel: openmeteo_sdk_Model {
         switch self {
         case .best_match:
             return .bestMatch
@@ -27,74 +57,5 @@ extension GlofasDomainApi: ModelFlatbufferSerialisable {
         case .consolidated_v4:
             return .glofasConsolidatedV4
         }
-    }
-    
-    static func encodeDaily(section: ApiSection<DailyVariable>, _ fbb: inout FlatBufferBuilder) -> Offset {
-        let offsets: [Offset] = section.columns.map { v in
-            switch v.variable {
-            case .raw(_):
-                /// ensemble data `river_dischage`
-                let oo = v.variables.enumerated().map { (member, data) in
-                    openmeteo_sdk_ValuesAndMember.createValuesAndMember(&fbb, member: Int32(member), valuesVectorOffset: data.expectFloatArray(&fbb))
-                }
-                return openmeteo_sdk_ValuesUnitAndMember.createValuesUnitAndMember(&fbb, unit: v.unit, valuesVectorOffset: fbb.createVector(ofOffsets: oo))
-            case .derived(_):
-                /// Single e.g. `river_dischage_max`
-                switch v.variables[0] {
-                case .float(let float):
-                    return openmeteo_sdk_ValuesAndUnit.createValuesAndUnit(&fbb, valuesVectorOffset: fbb.createVector(float), unit: v.unit)
-                case .timestamp(let time):
-                    return fbb.createVector(time.map({$0.timeIntervalSince1970}))
-                }
-            }
-        }
-        
-        let start = openmeteo_sdk_FloodDaily.startFloodDaily(&fbb)
-        openmeteo_sdk_FloodDaily.add(time: section.timeFlatBuffers(), &fbb)
-        for (variable, offset) in zip(section.columns, offsets) {
-            switch variable.variable {
-            case .derived(let v):
-                switch v {
-                case .river_discharge_mean:
-                    openmeteo_sdk_FloodDaily.add(riverDischargeMean: offset, &fbb)
-                case .river_discharge_min:
-                    openmeteo_sdk_FloodDaily.add(riverDischargeMin: offset, &fbb)
-                case .river_discharge_max:
-                    openmeteo_sdk_FloodDaily.add(riverDischargeMax: offset, &fbb)
-                case .river_discharge_median:
-                    openmeteo_sdk_FloodDaily.add(riverDischargeMedian: offset, &fbb)
-                case .river_discharge_p25:
-                    openmeteo_sdk_FloodDaily.add(riverDischargeP25: offset, &fbb)
-                case .river_discharge_p75:
-                    openmeteo_sdk_FloodDaily.add(riverDischargeP75: offset, &fbb)
-                }
-            case .raw(let v):
-                switch v {
-                case .river_discharge:
-                    openmeteo_sdk_FloodDaily.add(riverDischarge: offset, &fbb)
-                }
-            }
-        }
-        return openmeteo_sdk_FloodDaily.endFloodDaily(&fbb, start: start)
-    }
-    
-    static func writeToFlatbuffer(section: ForecastapiResult<Self>.PerModel, _ fbb: inout FlatBufferBuilder, timezone: TimezoneWithOffset, fixedGenerationTime: Double?) throws {
-        let generationTimeStart = Date()
-        let daily = (try section.daily?()).map { encodeDaily(section: $0, &fbb) } ?? Offset()
-        let generationTimeMs = fixedGenerationTime ?? (Date().timeIntervalSince(generationTimeStart) * 1000)
-        
-        let result = openmeteo_sdk_FloodApiResponse.createFloodApiResponse(
-            &fbb,
-            latitude: section.latitude,
-            longitude: section.longitude,
-            elevation: section.elevation ?? .nan,
-            model: section.model.flatBufferModel,
-            generationtimeMs: Float32(generationTimeMs),
-            utcOffsetSeconds: Int32(timezone.utcOffsetSeconds),
-            timezoneOffset: timezone.identifier == "GMT" ? Offset() : fbb.create(string: timezone.identifier),
-            timezoneAbbreviationOffset: timezone.abbreviation == "GMT" ? Offset() : fbb.create(string: timezone.abbreviation),
-            dailyOffset: daily
-        )
-        fbb.finish(offset: result, addPrefix: true)
     }
 }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+MarineApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+MarineApi.swift
@@ -6,6 +6,28 @@ import OpenMeteoSdk
 extension IconWaveVariable: FlatBuffersVariable {
     func getFlatBuffersMeta() -> FlatBufferVariableMeta {
         switch self {
+        case .wave_height:
+            return .init(variable: .waveHeight)
+        case .wave_period:
+            return .init(variable: .wavePeriod)
+        case .wave_direction:
+            return .init(variable: .waveDirection)
+        case .wind_wave_height:
+            return .init(variable: .windWaveHeight)
+        case .wind_wave_period:
+            return .init(variable: .windWavePeriod)
+        case .wind_wave_peak_period:
+            return .init(variable: .windWavePeakPeriod)
+        case .wind_wave_direction:
+            return .init(variable: .windWaveDirection)
+        case .swell_wave_height:
+            return .init(variable: .swellWaveHeight)
+        case .swell_wave_period:
+            return .init(variable: .swellWavePeriod)
+        case .swell_wave_peak_period:
+            return .init(variable: .swellWavePeakPeriod)
+        case .swell_wave_direction:
+            return .init(variable: .swellWaveDirection)
         }
     }
 }
@@ -13,6 +35,28 @@ extension IconWaveVariable: FlatBuffersVariable {
 extension IconWaveVariableDaily: FlatBuffersVariable {
     func getFlatBuffersMeta() -> FlatBufferVariableMeta {
         switch self {
+        case .wave_height_max:
+            return .init(variable: .windWaveHeight, aggregation: .maximum)
+        case .wind_wave_height_max:
+            return .init(variable: .windWaveHeight, aggregation: .maximum)
+        case .swell_wave_height_max:
+            return .init(variable: .swellWaveHeight, aggregation: .maximum)
+        case .wave_direction_dominant:
+            return .init(variable: .waveDirection, aggregation: .dominant)
+        case .wind_wave_direction_dominant:
+            return .init(variable: .windWaveDirection, aggregation: .dominant)
+        case .swell_wave_direction_dominant:
+            return .init(variable: .swellWaveDirection, aggregation: .dominant)
+        case .wave_period_max:
+            return .init(variable: .wavePeriod, aggregation: .maximum)
+        case .wind_wave_period_max:
+            return .init(variable: .windWavePeriod, aggregation: .maximum)
+        case .wind_wave_peak_period_max:
+            return .init(variable: .windWavePeakPeriod, aggregation: .maximum)
+        case .swell_wave_period_max:
+            return .init(variable: .swellWavePeriod, aggregation: .maximum)
+        case .swell_wave_peak_period_max:
+            return .init(variable: .swellWavePeakPeriod, aggregation: .maximum)
         }
     }
 }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+MarineApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+MarineApi.swift
@@ -3,6 +3,20 @@ import FlatBuffers
 import OpenMeteoSdk
 
 
+extension IconWaveVariable: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        }
+    }
+}
+
+extension IconWaveVariableDaily: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        }
+    }
+}
+
 extension IconWaveDomainApi: ModelFlatbufferSerialisable {
     typealias HourlyVariable = IconWaveVariable
     
@@ -10,139 +24,7 @@ extension IconWaveDomainApi: ModelFlatbufferSerialisable {
     
     typealias DailyVariable = IconWaveVariableDaily
     
-    static func encodeHourly(section: ApiSection<ForecastapiResult<Self>.SurfaceAndPressureVariable>, _ fbb: inout FlatBufferBuilder) -> Offset {
-        let offsets = ForecastapiResult.encode(section: section, &fbb)
-        let start = openmeteo_sdk_MarineHourly.startMarineHourly(&fbb)
-        openmeteo_sdk_MarineHourly.add(time: section.timeFlatBuffers(), &fbb)
-        for (surface, offset) in offsets.surface {
-            switch surface {
-            case .wave_height:
-                openmeteo_sdk_MarineHourly.add(waveHeight: offset, &fbb)
-            case .wave_period:
-                openmeteo_sdk_MarineHourly.add(wavePeriod: offset, &fbb)
-            case .wave_direction:
-                openmeteo_sdk_MarineHourly.add(waveDirection: offset, &fbb)
-            case .wind_wave_height:
-                openmeteo_sdk_MarineHourly.add(windWaveHeight: offset, &fbb)
-            case .wind_wave_period:
-                openmeteo_sdk_MarineHourly.add(windWavePeriod: offset, &fbb)
-            case .wind_wave_peak_period:
-                openmeteo_sdk_MarineHourly.add(windWavePeakPeriod: offset, &fbb)
-            case .wind_wave_direction:
-                openmeteo_sdk_MarineHourly.add(windWaveDirection: offset, &fbb)
-            case .swell_wave_height:
-                openmeteo_sdk_MarineHourly.add(swellWaveHeight: offset, &fbb)
-            case .swell_wave_period:
-                openmeteo_sdk_MarineHourly.add(swellWavePeriod: offset, &fbb)
-            case .swell_wave_peak_period:
-                openmeteo_sdk_MarineHourly.add(swellWavePeakPeriod: offset, &fbb)
-            case .swell_wave_direction:
-                openmeteo_sdk_MarineHourly.add(swellWaveDirection: offset, &fbb)
-            }
-        }
-        for (_, _) in offsets.pressure {
-            fatalError("No pressure levels")
-        }
-        return openmeteo_sdk_MarineHourly.endMarineHourly(&fbb, start: start)
-    }
-    
-    static func encodeCurrent(section: ApiSectionSingle<ForecastapiResult<Self>.SurfaceAndPressureVariable>, _ fbb: inout FlatBufferBuilder) throws -> Offset {
-        let start = openmeteo_sdk_MarineCurrent.startMarineCurrent(&fbb)
-        openmeteo_sdk_MarineCurrent.add(time: Int64(section.time.timeIntervalSince1970), &fbb)
-        openmeteo_sdk_MarineCurrent.add(interval: Int32(section.dtSeconds), &fbb)
-        for column in section.columns {
-            switch column.variable {
-            case .surface(let v):
-                let offset = openmeteo_sdk_ValueAndUnit(value: column.value, unit: column.unit)
-                switch v {
-                case .wave_height:
-                    openmeteo_sdk_MarineCurrent.add(waveHeight: offset, &fbb)
-                case .wave_period:
-                    openmeteo_sdk_MarineCurrent.add(wavePeriod: offset, &fbb)
-                case .wave_direction:
-                    openmeteo_sdk_MarineCurrent.add(waveDirection: offset, &fbb)
-                case .wind_wave_height:
-                    openmeteo_sdk_MarineCurrent.add(windWaveHeight: offset, &fbb)
-                case .wind_wave_period:
-                    openmeteo_sdk_MarineCurrent.add(windWavePeriod: offset, &fbb)
-                case .wind_wave_peak_period:
-                    openmeteo_sdk_MarineCurrent.add(windWavePeakPeriod: offset, &fbb)
-                case .wind_wave_direction:
-                    openmeteo_sdk_MarineCurrent.add(windWaveDirection: offset, &fbb)
-                case .swell_wave_height:
-                    openmeteo_sdk_MarineCurrent.add(swellWaveHeight: offset, &fbb)
-                case .swell_wave_period:
-                    openmeteo_sdk_MarineCurrent.add(swellWavePeriod: offset, &fbb)
-                case .swell_wave_peak_period:
-                    openmeteo_sdk_MarineCurrent.add(swellWavePeakPeriod: offset, &fbb)
-                case .swell_wave_direction:
-                    openmeteo_sdk_MarineCurrent.add(swellWaveDirection: offset, &fbb)
-                }
-                
-            case .pressure(_):
-                throw ForecastapiError.generic(message: "Pressure level variables currently not supported for flatbuffers encoding in current block")
-            }
-        }
-        return openmeteo_sdk_MarineCurrent.endMarineCurrent(&fbb, start: start)
-    }
-    
-    
-    static func encodeDaily(section: ApiSection<DailyVariable>, _ fbb: inout FlatBufferBuilder) -> Offset {
-        let offsets = ForecastapiResult<Self>.encode(section: section, &fbb)
-        let start = openmeteo_sdk_MarineDaily.startMarineDaily(&fbb)
-        openmeteo_sdk_MarineDaily.add(time: section.timeFlatBuffers(), &fbb)
-        for (variable, offset) in zip(section.columns, offsets) {
-            switch variable.variable {
-            case .wave_height_max:
-                openmeteo_sdk_MarineDaily.add(waveHeightMax: offset, &fbb)
-            case .wind_wave_height_max:
-                openmeteo_sdk_MarineDaily.add(windWaveHeightMax: offset, &fbb)
-            case .swell_wave_height_max:
-                openmeteo_sdk_MarineDaily.add(swellWaveHeightMax: offset, &fbb)
-            case .wave_direction_dominant:
-                openmeteo_sdk_MarineDaily.add(waveDirectionDominant: offset, &fbb)
-            case .wind_wave_direction_dominant:
-                openmeteo_sdk_MarineDaily.add(windWaveDirectionDominant: offset, &fbb)
-            case .swell_wave_direction_dominant:
-                openmeteo_sdk_MarineDaily.add(swellWaveDirectionDominant: offset, &fbb)
-            case .wave_period_max:
-                openmeteo_sdk_MarineDaily.add(wavePeriodMax: offset, &fbb)
-            case .wind_wave_period_max:
-                openmeteo_sdk_MarineDaily.add(windWavePeriodMax: offset, &fbb)
-            case .wind_wave_peak_period_max:
-                openmeteo_sdk_MarineDaily.add(windWavePeakPeriodMax: offset, &fbb)
-            case .swell_wave_period_max:
-                openmeteo_sdk_MarineDaily.add(swellWaveHeightMax: offset, &fbb)
-            case .swell_wave_peak_period_max:
-                openmeteo_sdk_MarineDaily.add(swellWavePeakPeriodMax: offset, &fbb)
-            }
-        }
-        return openmeteo_sdk_MarineDaily.endMarineDaily(&fbb, start: start)
-    }
-    
-    static func writeToFlatbuffer(section: ForecastapiResult<Self>.PerModel, _ fbb: inout FlatBufferBuilder, timezone: TimezoneWithOffset, fixedGenerationTime: Double?) throws {
-        let generationTimeStart = Date()
-        let hourly = (try section.hourly?()).map { encodeHourly(section: $0, &fbb) } ?? Offset()
-        let current = try (try section.current?()).map { try encodeCurrent(section: $0, &fbb) } ?? Offset()
-        let generationTimeMs = fixedGenerationTime ?? (Date().timeIntervalSince(generationTimeStart) * 1000)
-        
-        let result = openmeteo_sdk_MarineApiResponse.createMarineApiResponse(
-            &fbb,
-            latitude: section.latitude,
-            longitude: section.longitude,
-            elevation: section.elevation ?? .nan,
-            model: section.model.flatBufferModel,
-            generationtimeMs: Float32(generationTimeMs),
-            utcOffsetSeconds: Int32(timezone.utcOffsetSeconds),
-            timezoneOffset: timezone.identifier == "GMT" ? Offset() : fbb.create(string: timezone.identifier),
-            timezoneAbbreviationOffset: timezone.abbreviation == "GMT" ? Offset() : fbb.create(string: timezone.abbreviation),
-            hourlyOffset: hourly,
-            currentOffset: current
-        )
-        fbb.finish(offset: result, addPrefix: true)
-    }
-    
-    var flatBufferModel: openmeteo_sdk_MarineModel {
+    var flatBufferModel: openmeteo_sdk_Model {
         switch self {
         case.best_match:
             return .bestMatch

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+SeasonalApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+SeasonalApi.swift
@@ -25,7 +25,7 @@ extension CfsVariable: FlatBuffersVariable {
         case .shortwave_radiation:
             return .init(variable: .shortwaveRadiation)
         case .cloudcover:
-            return .init(variable: .cloudcover)
+            return .init(variable: .cloudCover)
         case .wind_u_component_10m:
             return .init(variable: .undefined)
         case .wind_v_component_10m:
@@ -35,7 +35,7 @@ extension CfsVariable: FlatBuffersVariable {
         case .showers:
             return .init(variable: .showers)
         case .relativehumidity_2m:
-            return .init(variable: .relativehumidity, altitude: 2)
+            return .init(variable: .relativeHumidity, altitude: 2)
         case .pressure_msl:
             return .init(variable: .pressureMsl)
         }
@@ -47,9 +47,9 @@ extension CfsVariableDerived: FlatBuffersVariable {
     func getFlatBuffersMeta() -> FlatBufferVariableMeta {
         switch self {
         case .windspeed_10m:
-            return .init(variable: .windspeed, altitude: 10)
+            return .init(variable: .windSpeed, altitude: 10)
         case .winddirection_10m:
-            return .init(variable: .winddirection, altitude: 10)
+            return .init(variable: .windDirection, altitude: 10)
         }
     }
 }
@@ -68,9 +68,9 @@ extension DailyCfsVariable: FlatBuffersVariable {
         case .shortwave_radiation_sum:
             return .init(variable: .shortwaveRadiation, aggregation: .sum)
         case .windspeed_10m_max:
-            return .init(variable: .windspeed, aggregation: .maximum, altitude: 10)
+            return .init(variable: .windSpeed, aggregation: .maximum, altitude: 10)
         case .winddirection_10m_dominant:
-            return .init(variable: .winddirection, aggregation: .dominant, altitude: 2)
+            return .init(variable: .windDirection, aggregation: .dominant, altitude: 2)
         case .precipitation_hours:
             return .init(variable: .precipitationHours)
         }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+SeasonalApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+SeasonalApi.swift
@@ -46,10 +46,14 @@ extension CfsVariable: FlatBuffersVariable {
 extension CfsVariableDerived: FlatBuffersVariable {
     func getFlatBuffersMeta() -> FlatBufferVariableMeta {
         switch self {
-        case .windspeed_10m:
+        case .windspeed_10m, .wind_speed_10m:
             return .init(variable: .windSpeed, altitude: 10)
-        case .winddirection_10m:
+        case .winddirection_10m, .wind_direction_10m:
             return .init(variable: .windDirection, altitude: 10)
+        case .cloud_cover:
+            return .init(variable: .cloudCover)
+        case .relative_humidity_2m:
+            return .init(variable: .relativeHumidity, altitude: 2)
         }
     }
 }
@@ -67,9 +71,9 @@ extension DailyCfsVariable: FlatBuffersVariable {
             return .init(variable: .showers, aggregation: .sum)
         case .shortwave_radiation_sum:
             return .init(variable: .shortwaveRadiation, aggregation: .sum)
-        case .windspeed_10m_max:
+        case .windspeed_10m_max, .wind_speed_10m_max:
             return .init(variable: .windSpeed, aggregation: .maximum, altitude: 10)
-        case .winddirection_10m_dominant:
+        case .winddirection_10m_dominant, .wind_direction_10m_dominant:
             return .init(variable: .windDirection, aggregation: .dominant, altitude: 2)
         case .precipitation_hours:
             return .init(variable: .precipitationHours)

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+SeasonalApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+SeasonalApi.swift
@@ -3,6 +3,80 @@ import FlatBuffers
 import OpenMeteoSdk
 
 
+extension CfsVariable: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .temperature_2m:
+            return .init(variable: .temperature, altitude: 2)
+        case .temperature_2m_max:
+            return .init(variable: .temperature, aggregation: .maximum, altitude: 2)
+        case .temperature_2m_min:
+            return .init(variable: .temperature, aggregation: .minimum, altitude: 2)
+        case .soil_moisture_0_to_10cm:
+            return .init(variable: .soilMoisture, depth: 0, depthTo: 10)
+        case .soil_moisture_10_to_40cm:
+            return .init(variable: .soilMoisture, depth: 10, depthTo: 40)
+        case .soil_moisture_40_to_100cm:
+            return .init(variable: .soilMoisture, depth: 40, depthTo: 100)
+        case .soil_moisture_100_to_200cm:
+            return .init(variable: .soilMoisture, depth: 100, depthTo: 200)
+        case .soil_temperature_0_to_10cm:
+            return .init(variable: .soilTemperature, depth: 0, depthTo: 10)
+        case .shortwave_radiation:
+            return .init(variable: .shortwaveRadiation)
+        case .cloudcover:
+            return .init(variable: .cloudcover)
+        case .wind_u_component_10m:
+            return .init(variable: .undefined)
+        case .wind_v_component_10m:
+            return .init(variable: .undefined)
+        case .precipitation:
+            return .init(variable: .precipitation)
+        case .showers:
+            return .init(variable: .showers)
+        case .relativehumidity_2m:
+            return .init(variable: .relativehumidity, altitude: 2)
+        case .pressure_msl:
+            return .init(variable: .pressureMsl)
+        }
+    }
+}
+
+
+extension CfsVariableDerived: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .windspeed_10m:
+            return .init(variable: .windspeed, altitude: 10)
+        case .winddirection_10m:
+            return .init(variable: .winddirection, altitude: 10)
+        }
+    }
+}
+
+extension DailyCfsVariable: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .temperature_2m_max:
+            return .init(variable: .temperature, aggregation: .maximum, altitude: 2)
+        case .temperature_2m_min:
+            return .init(variable: .temperature, aggregation: .minimum, altitude: 2)
+        case .precipitation_sum:
+            return .init(variable: .precipitation, aggregation: .sum)
+        case .showers_sum:
+            return .init(variable: .showers, aggregation: .sum)
+        case .shortwave_radiation_sum:
+            return .init(variable: .shortwaveRadiation, aggregation: .sum)
+        case .windspeed_10m_max:
+            return .init(variable: .windspeed, aggregation: .maximum, altitude: 10)
+        case .winddirection_10m_dominant:
+            return .init(variable: .winddirection, aggregation: .dominant, altitude: 2)
+        case .precipitation_hours:
+            return .init(variable: .precipitationHours)
+        }
+    }
+}
+
 extension SeasonalForecastDomainApi: ModelFlatbufferSerialisable {
     typealias HourlyVariable = SeasonalForecastVariable
     
@@ -10,7 +84,7 @@ extension SeasonalForecastDomainApi: ModelFlatbufferSerialisable {
     
     typealias DailyVariable = DailyCfsVariable
     
-    var flatBufferModel: openmeteo_sdk_EnsembleModel {
+    var flatBufferModel: openmeteo_sdk_Model {
         switch self {
         case .cfsv2:
             return .cfsv2
@@ -19,111 +93,5 @@ extension SeasonalForecastDomainApi: ModelFlatbufferSerialisable {
     
     static var memberOffset: Int {
         return 1
-    }
-    
-    static func encodeHourly(section: ApiSection<ForecastapiResult<Self>.SurfaceAndPressureVariable>, _ fbb: inout FlatBufferBuilder) -> Offset {
-        let offsets = ForecastapiResult.encodeEnsemble(section: section, &fbb)
-        let start = openmeteo_sdk_EnsembleHourly.startEnsembleHourly(&fbb)
-        openmeteo_sdk_EnsembleHourly.add(time: section.timeFlatBuffers(), &fbb)
-        for (surface, offset) in offsets.surface {
-            switch surface {
-            case .raw(let v):
-                switch v {
-                case .temperature_2m:
-                    openmeteo_sdk_EnsembleHourly.add(temperature2m: offset, &fbb)
-                case .temperature_2m_max:
-                    openmeteo_sdk_EnsembleHourly.add(temperature2mMax: offset, &fbb)
-                case .temperature_2m_min:
-                    openmeteo_sdk_EnsembleHourly.add(temperature2mMin: offset, &fbb)
-                case .soil_moisture_0_to_10cm:
-                    openmeteo_sdk_EnsembleHourly.add(soilMoisture0To10cm: offset, &fbb)
-                case .soil_moisture_10_to_40cm:
-                    openmeteo_sdk_EnsembleHourly.add(soilMoisture10To40cm: offset, &fbb)
-                case .soil_moisture_40_to_100cm:
-                    openmeteo_sdk_EnsembleHourly.add(soilMoisture40To100cm: offset, &fbb)
-                case .soil_moisture_100_to_200cm:
-                    openmeteo_sdk_EnsembleHourly.add(soilMoisture100To200cm: offset, &fbb)
-                case .soil_temperature_0_to_10cm:
-                    openmeteo_sdk_EnsembleHourly.add(soilTemperature0To10cm: offset, &fbb)
-                case .shortwave_radiation:
-                    openmeteo_sdk_EnsembleHourly.add(shortwaveRadiation: offset, &fbb)
-                case .cloudcover:
-                    openmeteo_sdk_EnsembleHourly.add(cloudcover: offset, &fbb)
-                case .wind_u_component_10m:
-                    continue
-                case .wind_v_component_10m:
-                    continue
-                case .precipitation:
-                    openmeteo_sdk_EnsembleHourly.add(precipitation: offset, &fbb)
-                case .showers:
-                    openmeteo_sdk_EnsembleHourly.add(showers: offset, &fbb)
-                case .relativehumidity_2m:
-                    openmeteo_sdk_EnsembleHourly.add(relativehumidity2m: offset, &fbb)
-                case .pressure_msl:
-                    openmeteo_sdk_EnsembleHourly.add(pressureMsl: offset, &fbb)
-                }
-            case .derived(let v):
-                switch v {
-                case .windspeed_10m:
-                    openmeteo_sdk_EnsembleHourly.add(windspeed10m:  offset, &fbb)
-                case .winddirection_10m:
-                    openmeteo_sdk_EnsembleHourly.add(winddirection10m: offset, &fbb)
-                }
-            }
-        }
-        for (_, _) in offsets.pressure {
-            fatalError("no pressure variables in seasonal forecast models")
-        }
-        return openmeteo_sdk_EnsembleHourly.endEnsembleHourly(&fbb, start: start)
-    }
-    
-    static func encodeDaily(section: ApiSection<DailyVariable>, _ fbb: inout FlatBufferBuilder) -> Offset {
-        let offsets = ForecastapiResult<Self>.encodeEnsemble(section: section, &fbb)
-        let start = openmeteo_sdk_EnsembleDaily.startEnsembleDaily(&fbb)
-        openmeteo_sdk_EnsembleDaily.add(time: section.timeFlatBuffers(), &fbb)
-        for (variable, offset) in zip(section.columns, offsets) {
-            switch variable.variable {
-            case .temperature_2m_max:
-                openmeteo_sdk_EnsembleDaily.add(temperature2mMax: offset, &fbb)
-            case .temperature_2m_min:
-                openmeteo_sdk_EnsembleDaily.add(temperature2mMin: offset, &fbb)
-            case .precipitation_sum:
-                openmeteo_sdk_EnsembleDaily.add(precipitationSum: offset, &fbb)
-            case .showers_sum:
-                openmeteo_sdk_EnsembleDaily.add(showersSum: offset, &fbb)
-            case .shortwave_radiation_sum:
-                openmeteo_sdk_EnsembleDaily.add(shortwaveRadiationSum: offset, &fbb)
-            case .windspeed_10m_max:
-                openmeteo_sdk_EnsembleDaily.add(windspeed10mMax: offset, &fbb)
-            case .winddirection_10m_dominant:
-                openmeteo_sdk_EnsembleDaily.add(winddirection10mDominant: offset, &fbb)
-            case .precipitation_hours:
-                openmeteo_sdk_EnsembleDaily.add(precipitationHours: offset, &fbb)
-            }
-        }
-        return openmeteo_sdk_EnsembleDaily.endEnsembleDaily(&fbb, start: start)
-    }
-    
-    static func writeToFlatbuffer(section: ForecastapiResult<Self>.PerModel, _ fbb: inout FlatBufferBuilder, timezone: TimezoneWithOffset, fixedGenerationTime: Double?) throws {
-        let generationTimeStart = Date()
-        let sixHourly = (try section.sixHourly?()).map { encodeHourly(section: $0, &fbb) } ?? Offset()
-        let daily = (try section.daily?()).map { encodeDaily(section: $0, &fbb) } ?? Offset()
-        let generationTimeMs = fixedGenerationTime ?? (Date().timeIntervalSince(generationTimeStart) * 1000)
-        
-        let result = openmeteo_sdk_EnsembleApiResponse.createEnsembleApiResponse(
-            &fbb,
-            latitude: section.latitude,
-            longitude: section.longitude,
-            elevation: section.elevation ?? .nan,
-            model: section.model.flatBufferModel,
-            generationtimeMs: Float32(generationTimeMs),
-            utcOffsetSeconds: Int32(timezone.utcOffsetSeconds),
-            timezoneOffset: timezone.identifier == "GMT" ? Offset() : fbb.create(string: timezone.identifier),
-            timezoneAbbreviationOffset: timezone.abbreviation == "GMT" ? Offset() : fbb.create(string: timezone.abbreviation),
-            dailyOffset: daily,
-            sixHourlyOffset: sixHourly
-            
-        )
-        fbb.finish(offset: result, addPrefix: true)
     }
 }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
@@ -18,15 +18,15 @@ extension ForecastSurfaceVariable: FlatBuffersVariable {
             return .init(variable: .apparentTemperature, altitude: 2)
         case .cape:
             return .init(variable: .cape)
-        case .cloudcover:
+        case .cloudcover, .cloud_cover:
             return .init(variable: .cloudCover)
-        case .cloudcover_high:
+        case .cloudcover_high, .cloud_cover_high:
             return .init(variable: .cloudCoverHigh)
-        case .cloudcover_low:
+        case .cloudcover_low, .cloud_cover_low:
             return .init(variable: .cloudCoverLow)
-        case .cloudcover_mid:
+        case .cloudcover_mid, .cloud_cover_mid:
             return .init(variable: .cloudCoverMid)
-        case .dewpoint_2m:
+        case .dewpoint_2m, .dew_point_2m:
             return .init(variable: .dewPoint, altitude: 2)
         case .diffuse_radiation:
             return .init(variable: .diffuseRadiation)
@@ -44,13 +44,13 @@ extension ForecastSurfaceVariable: FlatBuffersVariable {
             return .init(variable: .et0FaoEvapotranspiration)
         case .evapotranspiration:
             return .init(variable: .evapotranspiration)
-        case .freezinglevel_height:
+        case .freezinglevel_height, .freezing_level_height:
             return .init(variable: .freezingLevelHeight)
         case .growing_degree_days_base_0_limit_50:
             return .init(variable: .growingDegreeDays)
         case .is_day:
             return .init(variable: .isDay)
-        case .latent_heatflux:
+        case .latent_heatflux, .latent_heat_flux:
             return .init(variable: .latentHeatFlux)
         case .lifted_index:
             return .init(variable: .liftedIndex)
@@ -66,11 +66,11 @@ extension ForecastSurfaceVariable: FlatBuffersVariable {
             return .init(variable: .pressureMsl)
         case .rain:
             return .init(variable: .rain)
-        case .relativehumidity_2m:
+        case .relativehumidity_2m, .relative_humidity_2m:
             return .init(variable: .relativeHumidity)
         case .runoff:
             return .init(variable: .runoff)
-        case .sensible_heatflux:
+        case .sensible_heatflux, .sensible_heat_flux:
             return .init(variable: .sensibleHeatFlux)
         case .shortwave_radiation:
             return .init(variable: .shortwaveRadiation)
@@ -202,53 +202,53 @@ extension ForecastSurfaceVariable: FlatBuffersVariable {
             return .init(variable: .uvIndex)
         case .uv_index_clear_sky:
             return .init(variable: .uvIndexClearSky)
-        case .vapor_pressure_deficit:
+        case .vapor_pressure_deficit, .vapour_pressure_deficit:
             return .init(variable: .vapourPressureDeficit)
         case .visibility:
             return .init(variable: .visibility)
-        case .weathercode:
+        case .weathercode, .weather_code:
             return .init(variable: .weatherCode)
-        case .winddirection_100m:
+        case .winddirection_100m, .wind_direction_100m:
             return .init(variable: .windDirection, altitude: 100)
-        case .winddirection_10m:
+        case .winddirection_10m, .wind_direction_10m:
             return .init(variable: .windDirection, altitude: 10)
-        case .winddirection_120m:
+        case .winddirection_120m, .wind_direction_120m:
             return .init(variable: .windDirection, altitude: 120)
-        case .winddirection_150m:
+        case .winddirection_150m, .wind_direction_150m:
             return .init(variable: .windDirection, altitude: 150)
-        case .winddirection_180m:
+        case .winddirection_180m, .wind_direction_180m:
             return .init(variable: .windDirection, altitude: 180)
-        case .winddirection_200m:
+        case .winddirection_200m, .wind_direction_200m:
             return .init(variable: .windDirection, altitude: 200)
-        case .winddirection_20m:
+        case .winddirection_20m, .wind_direction_20m:
             return .init(variable: .windDirection, altitude: 20)
-        case .winddirection_40m:
+        case .winddirection_40m, .wind_direction_40m:
             return .init(variable: .windDirection, altitude: 40)
-        case .winddirection_50m:
+        case .winddirection_50m, .wind_direction_50m:
             return .init(variable: .windDirection, altitude: 50)
-        case .winddirection_80m:
+        case .winddirection_80m, .wind_direction_80m:
             return .init(variable: .windDirection, altitude: 80)
-        case .windgusts_10m:
+        case .windgusts_10m, .wind_gusts_10m:
             return .init(variable: .windGusts, altitude: 10)
-        case .windspeed_100m:
+        case .windspeed_100m, .wind_speed_100m:
             return .init(variable: .windSpeed, altitude: 100)
-        case .windspeed_10m:
+        case .windspeed_10m, .wind_speed_10m:
             return .init(variable: .windSpeed, altitude: 10)
-        case .windspeed_120m:
+        case .windspeed_120m, .wind_speed_120m:
             return .init(variable: .windSpeed, altitude: 120)
-        case .windspeed_150m:
+        case .windspeed_150m, .wind_speed_150m:
             return .init(variable: .windSpeed, altitude: 150)
-        case .windspeed_180m:
+        case .windspeed_180m, .wind_speed_180m:
             return .init(variable: .windSpeed, altitude: 180)
-        case .windspeed_200m:
+        case .windspeed_200m, .wind_speed_200m:
             return .init(variable: .windSpeed, altitude: 200)
-        case .windspeed_20m:
+        case .windspeed_20m, .wind_speed_20m:
             return .init(variable: .windSpeed, altitude: 20)
-        case .windspeed_40m:
+        case .windspeed_40m, .wind_speed_40m:
             return .init(variable: .windSpeed, altitude: 40)
-        case .windspeed_50m:
+        case .windspeed_50m, .wind_speed_50m:
             return .init(variable: .windSpeed, altitude: 50)
-        case .windspeed_80m:
+        case .windspeed_80m, .wind_speed_80m:
             return .init(variable: .windSpeed, altitude: 80)
         }
     }
@@ -261,20 +261,18 @@ extension ForecastPressureVariableType: FlatBuffersVariable {
             return .init(variable: .temperature)
         case .geopotential_height:
             return .init(variable: .geopotentialHeight)
-        case .relativehumidity:
+        case .relativehumidity, .relative_humidity:
             return .init(variable: .relativeHumidity)
-        case .windspeed:
+        case .windspeed, .wind_speed:
             return .init(variable: .windSpeed)
-        case .winddirection:
+        case .winddirection, .wind_direction:
             return .init(variable: .windDirection)
-        case .dewpoint:
+        case .dewpoint, .dew_point:
             return .init(variable: .dewPoint)
-        case .cloudcover:
+        case .cloudcover, .cloud_cover:
             return .init(variable: .cloudCover)
         case .vertical_velocity:
             return .init(variable: .verticalVelocity)
-        case .relative_humidity:
-            return .init(variable: .relativeHumidity)
         }
     }
 }
@@ -294,17 +292,17 @@ extension ForecastVariableDaily: FlatBuffersVariable {
             return .init(variable: .cape, aggregation: .mean)
         case .cape_min:
             return .init(variable: .cape, aggregation: .minimum)
-        case .cloudcover_max:
+        case .cloudcover_max, .cloud_cover_max:
             return .init(variable: .cloudCover, aggregation: .maximum)
-        case .cloudcover_mean:
+        case .cloudcover_mean, .cloud_cover_mean:
             return .init(variable: .cloudCover, aggregation: .mean)
-        case .cloudcover_min:
+        case .cloudcover_min, .cloud_cover_min:
             return .init(variable: .cloudCover, aggregation: .minimum)
-        case .dewpoint_2m_max:
+        case .dewpoint_2m_max, .dew_point_2m_max:
             return .init(variable: .dewPoint, aggregation: .maximum, altitude: 2)
-        case .dewpoint_2m_mean:
+        case .dewpoint_2m_mean, .dew_point_2m_mean:
             return .init(variable: .dewPoint, aggregation: .mean, altitude: 2)
-        case .dewpoint_2m_min:
+        case .dewpoint_2m_min, .dew_point_2m_min:
             return .init(variable: .dewPoint, aggregation: .minimum, altitude: 2)
         case .et0_fao_evapotranspiration:
             return .init(variable: .et0FaoEvapotranspiration)
@@ -396,7 +394,7 @@ extension ForecastVariableDaily: FlatBuffersVariable {
             return .init(variable: .uvIndexClearSky, aggregation: .maximum)
         case .uv_index_max:
             return .init(variable: .uvIndex, aggregation: .maximum)
-        case .vapor_pressure_deficit_max:
+        case .vapor_pressure_deficit_max, .vapour_pressure_deficit_max:
             return .init(variable: .vapourPressureDeficit, aggregation: .maximum)
         case .visibility_max:
             return .init(variable: .visibility, aggregation: .maximum)
@@ -404,21 +402,21 @@ extension ForecastVariableDaily: FlatBuffersVariable {
             return .init(variable: .visibility, aggregation: .mean)
         case .visibility_min:
             return .init(variable: .visibility, aggregation: .minimum)
-        case .weathercode:
+        case .weathercode, .weather_code:
             return .init(variable: .weatherCode)
-        case .winddirection_10m_dominant:
+        case .winddirection_10m_dominant, .wind_direction_10m_dominant:
             return .init(variable: .windDirection, aggregation: .dominant, altitude: 10)
-        case .windgusts_10m_max:
+        case .windgusts_10m_max, .wind_gusts_10m_max:
             return .init(variable: .windGusts, aggregation: .maximum, altitude: 10)
-        case .windgusts_10m_mean:
+        case .windgusts_10m_mean, .wind_gusts_10m_mean:
             return .init(variable: .windGusts, aggregation: .mean, altitude: 10)
-        case .windgusts_10m_min:
+        case .windgusts_10m_min, .wind_gusts_10m_min:
             return .init(variable: .windGusts, aggregation: .minimum, altitude: 10)
-        case .windspeed_10m_max:
+        case .windspeed_10m_max, .wind_speed_10m_max:
             return .init(variable: .windSpeed, aggregation: .maximum, altitude: 10)
-        case .windspeed_10m_mean:
+        case .windspeed_10m_mean, .wind_speed_10m_mean:
             return .init(variable: .windSpeed, aggregation: .mean, altitude: 10)
-        case .windspeed_10m_min:
+        case .windspeed_10m_min, .wind_speed_10m_min:
             return .init(variable: .windSpeed, aggregation: .minimum, altitude: 10)
         case .wet_bulb_temperature_2m_max:
             return .init(variable: .wetBulbTemperature, aggregation: .maximum, altitude: 2)

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
@@ -3,6 +3,435 @@ import FlatBuffers
 import OpenMeteoSdk
 
 
+extension ForecastSurfaceVariable: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .temperature:
+            return .init(variable: .temperature, altitude: 2)
+        case .windspeed:
+            return .init(variable: .windspeed, altitude: 10)
+        case .winddirection:
+            return .init(variable: .winddirection, altitude: 10)
+        case .wet_bulb_temperature_2m:
+            return .init(variable: .wetBulbTemperature, altitude: 2)
+        case .apparent_temperature:
+            return .init(variable: .apparentTemperature, altitude: 2)
+        case .cape:
+            return .init(variable: .cape)
+        case .cloudcover:
+            return .init(variable: .cloudcover)
+        case .cloudcover_high:
+            return .init(variable: .cloudcoverHigh)
+        case .cloudcover_low:
+            return .init(variable: .cloudcoverLow)
+        case .cloudcover_mid:
+            return .init(variable: .cloudcoverMid)
+        case .dewpoint_2m:
+            return .init(variable: .dewpoint, altitude: 2)
+        case .diffuse_radiation:
+            return .init(variable: .diffuseRadiation)
+        case .diffuse_radiation_instant:
+            return .init(variable: .diffuseRadiationInstant)
+        case .direct_normal_irradiance:
+            return .init(variable: .directNormalIrradiance)
+        case .direct_normal_irradiance_instant:
+            return .init(variable: .directNormalIrradianceInstant)
+        case .direct_radiation:
+            return .init(variable: .directRadiation)
+        case .direct_radiation_instant:
+            return .init(variable: .directRadiationInstant)
+        case .et0_fao_evapotranspiration:
+            return .init(variable: .et0FaoEvapotranspiration)
+        case .evapotranspiration:
+            return .init(variable: .evapotranspiration)
+        case .freezinglevel_height:
+            return .init(variable: .freezinglevelHeight)
+        case .growing_degree_days_base_0_limit_50:
+            return .init(variable: .growingDegreeDays)
+        case .is_day:
+            return .init(variable: .isDay)
+        case .latent_heatflux:
+            return .init(variable: .latentHeatflux)
+        case .lifted_index:
+            return .init(variable: .liftedIndex)
+        case .leaf_wetness_probability:
+            return .init(variable: .leafWetnessProbability)
+        case .lightning_potential:
+            return .init(variable: .lightningPotential)
+        case .precipitation:
+            return .init(variable: .precipitation)
+        case .precipitation_probability:
+            return .init(variable: .precipitationProbability)
+        case .pressure_msl:
+            return .init(variable: .pressureMsl)
+        case .rain:
+            return .init(variable: .rain)
+        case .relativehumidity_2m:
+            return .init(variable: .relativehumidity)
+        case .runoff:
+            return .init(variable: .runoff)
+        case .sensible_heatflux:
+            return .init(variable: .sensibleHeatflux)
+        case .shortwave_radiation:
+            return .init(variable: .shortwaveRadiation)
+        case .shortwave_radiation_instant:
+            return .init(variable: .shortwaveRadiationInstant)
+        case .showers:
+            return .init(variable: .showers)
+        case .skin_temperature:
+            return .init(variable: .surfaceTemperature)
+        case .snow_depth:
+            return .init(variable: .snowDepth)
+        case .snow_height:
+            return .init(variable: .snowHeight)
+        case .snowfall:
+            return .init(variable: .snowfall)
+        case .snowfall_water_equivalent:
+            return .init(variable: .snowfallWaterEquivalent)
+        case .soil_moisture_0_1cm:
+            fallthrough
+        case .soil_moisture_0_to_1cm:
+            return .init(variable: .soilMoisture, depth: 0, depthTo: 1)
+        case .soil_moisture_0_to_100cm:
+            return .init(variable: .soilMoisture, depth: 0, depthTo: 100)
+        case .soil_moisture_0_to_10cm:
+            return .init(variable: .soilMoisture, depth: 0, depthTo: 10)
+        case .soil_moisture_0_to_7cm:
+            return .init(variable: .soilMoisture, depth: 0, depthTo: 7)
+        case .soil_moisture_100_to_200cm:
+            return .init(variable: .soilMoisture, depth: 100, depthTo: 200)
+        case .soil_moisture_100_to_255cm:
+            return .init(variable: .soilMoisture, depth: 100, depthTo: 255)
+        case .soil_moisture_10_to_40cm:
+            return .init(variable: .soilMoisture, depth: 10, depthTo: 40)
+        case .soil_moisture_1_3cm:
+            fallthrough
+        case .soil_moisture_1_to_3cm:
+            return .init(variable: .soilMoisture, depth: 1, depthTo: 3)
+        case .soil_moisture_27_81cm:
+            fallthrough
+        case .soil_moisture_27_to_81cm:
+            return .init(variable: .soilMoisture, depth: 27, depthTo: 81)
+        case .soil_moisture_28_to_100cm:
+            return .init(variable: .soilMoisture, depth: 28, depthTo: 100)
+        case .soil_moisture_3_9cm:
+            fallthrough
+        case .soil_moisture_3_to_9cm:
+            return .init(variable: .soilMoisture, depth: 3, depthTo: 9)
+        case .soil_moisture_40_to_100cm:
+            return .init(variable: .soilMoisture, depth: 40, depthTo: 100)
+        case .soil_moisture_7_to_28cm:
+            return .init(variable: .soilMoisture, depth: 7, depthTo: 28)
+        case .soil_moisture_9_27cm:
+            return .init(variable: .soilMoisture, depth: 9, depthTo: 27)
+        case .soil_moisture_9_to_27cm:
+            return .init(variable: .soilMoisture, depth: 9, depthTo: 27)
+        case .soil_moisture_index_0_to_100cm:
+            return .init(variable: .soilMoisture, depth: 0, depthTo: 100)
+        case .soil_moisture_index_0_to_7cm:
+            return .init(variable: .soilMoisture, depth: 0, depthTo: 7)
+        case .soil_moisture_index_100_to_255cm:
+            return .init(variable: .soilMoisture, depth: 100, depthTo: 255)
+        case .soil_moisture_index_28_to_100cm:
+            return .init(variable: .soilMoisture, depth: 28, depthTo: 100)
+        case .soil_moisture_index_7_to_28cm:
+            return .init(variable: .soilMoisture, depth: 7, depthTo: 28)
+        case .soil_temperature_0_to_100cm:
+            return .init(variable: .soilTemperature, depth: 0, depthTo: 100)
+        case .soil_temperature_0_to_10cm:
+            return .init(variable: .soilTemperature, depth: 0, depthTo: 10)
+        case .soil_temperature_0_to_7cm:
+            return .init(variable: .soilTemperature, depth: 0, depthTo: 7)
+        case .soil_temperature_0cm:
+            return .init(variable: .soilTemperature, depth: 0)
+        case .soil_temperature_100_to_200cm:
+            return .init(variable: .soilTemperature, depth: 100, depthTo: 200)
+        case .soil_temperature_100_to_255cm:
+            return .init(variable: .soilTemperature, depth: 100, depthTo: 255)
+        case .soil_temperature_10_to_40cm:
+            return .init(variable: .soilTemperature, depth: 10, depthTo: 40)
+        case .soil_temperature_18cm:
+            return .init(variable: .soilTemperature, depth: 18)
+        case .soil_temperature_28_to_100cm:
+            return .init(variable: .soilTemperature, depth: 28, depthTo: 100)
+        case .soil_temperature_40_to_100cm:
+            return .init(variable: .soilTemperature, depth: 40, depthTo: 100)
+        case .soil_temperature_54cm:
+            return .init(variable: .soilTemperature, depth: 54)
+        case .soil_temperature_6cm:
+            return .init(variable: .soilTemperature, depth: 6)
+        case .soil_temperature_7_to_28cm:
+            return .init(variable: .soilTemperature, depth: 7, depthTo: 28)
+        case .surface_air_pressure:
+            return .init(variable: .surfacePressure)
+        case .snowfall_height:
+            return .init(variable: .snowfallHeight)
+        case .surface_pressure:
+            return .init(variable: .surfacePressure)
+        case .surface_temperature:
+            return .init(variable: .surfaceTemperature)
+        case .temperature_100m:
+            return .init(variable: .temperature, altitude: 100)
+        case .temperature_120m:
+            return .init(variable: .temperature, altitude: 120)
+        case .temperature_150m:
+            return .init(variable: .temperature, altitude: 150)
+        case .temperature_180m:
+            return .init(variable: .temperature, altitude: 180)
+        case .temperature_2m:
+            return .init(variable: .temperature, altitude: 2)
+        case .temperature_20m:
+            return .init(variable: .temperature, altitude: 20)
+        case .temperature_200m:
+            return .init(variable: .temperature, altitude: 200)
+        case .temperature_50m:
+            return .init(variable: .temperature, altitude: 50)
+        case .temperature_40m:
+            return .init(variable: .temperature, altitude: 40)
+        case .temperature_80m:
+            return .init(variable: .temperature, altitude: 80)
+        case .terrestrial_radiation:
+            return .init(variable: .terrestrialRadiation)
+        case .terrestrial_radiation_instant:
+            return .init(variable: .terrestrialRadiationInstant)
+        case .total_column_integrated_water_vapour:
+            return .init(variable: .totalColumnIntegratedWaterVapour)
+        case .updraft:
+            return .init(variable: .updraft)
+        case .uv_index:
+            return .init(variable: .uvIndex)
+        case .uv_index_clear_sky:
+            return .init(variable: .uvIndexClearSky)
+        case .vapor_pressure_deficit:
+            return .init(variable: .vaporPressureDeficit)
+        case .visibility:
+            return .init(variable: .visibility)
+        case .weathercode:
+            return .init(variable: .weathercode)
+        case .winddirection_100m:
+            return .init(variable: .winddirection, altitude: 100)
+        case .winddirection_10m:
+            return .init(variable: .winddirection, altitude: 10)
+        case .winddirection_120m:
+            return .init(variable: .winddirection, altitude: 120)
+        case .winddirection_150m:
+            return .init(variable: .winddirection, altitude: 150)
+        case .winddirection_180m:
+            return .init(variable: .winddirection, altitude: 180)
+        case .winddirection_200m:
+            return .init(variable: .winddirection, altitude: 200)
+        case .winddirection_20m:
+            return .init(variable: .winddirection, altitude: 20)
+        case .winddirection_40m:
+            return .init(variable: .winddirection, altitude: 40)
+        case .winddirection_50m:
+            return .init(variable: .winddirection, altitude: 50)
+        case .winddirection_80m:
+            return .init(variable: .winddirection, altitude: 80)
+        case .windgusts_10m:
+            return .init(variable: .windgusts, altitude: 10)
+        case .windspeed_100m:
+            return .init(variable: .windspeed, altitude: 100)
+        case .windspeed_10m:
+            return .init(variable: .windspeed, altitude: 10)
+        case .windspeed_120m:
+            return .init(variable: .windspeed, altitude: 120)
+        case .windspeed_150m:
+            return .init(variable: .windspeed, altitude: 150)
+        case .windspeed_180m:
+            return .init(variable: .windspeed, altitude: 180)
+        case .windspeed_200m:
+            return .init(variable: .windspeed, altitude: 200)
+        case .windspeed_20m:
+            return .init(variable: .windspeed, altitude: 20)
+        case .windspeed_40m:
+            return .init(variable: .windspeed, altitude: 40)
+        case .windspeed_50m:
+            return .init(variable: .windspeed, altitude: 50)
+        case .windspeed_80m:
+            return .init(variable: .windspeed, altitude: 80)
+        }
+    }
+}
+
+extension ForecastPressureVariableType: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .temperature:
+            return .init(variable: .temperature)
+        case .geopotential_height:
+            return .init(variable: .geopotentialHeight)
+        case .relativehumidity:
+            return .init(variable: .relativehumidity)
+        case .windspeed:
+            return .init(variable: .windspeed)
+        case .winddirection:
+            return .init(variable: .winddirection)
+        case .dewpoint:
+            return .init(variable: .dewpoint)
+        case .cloudcover:
+            return .init(variable: .cloudcover)
+        case .vertical_velocity:
+            return .init(variable: .verticalVelocity)
+        case .relative_humidity:
+            return .init(variable: .relativehumidity)
+        }
+    }
+}
+
+extension ForecastVariableDaily: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .apparent_temperature_max:
+            return .init(variable: .apparentTemperature, aggregation: .maximum, altitude: 2)
+        case .apparent_temperature_mean:
+            return .init(variable: .apparentTemperature, aggregation: .mean, altitude: 2)
+        case .apparent_temperature_min:
+            return .init(variable: .apparentTemperature, aggregation: .minimum, altitude: 2)
+        case .cape_max:
+            return .init(variable: .cape, aggregation: .maximum)
+        case .cape_mean:
+            return .init(variable: .cape, aggregation: .mean)
+        case .cape_min:
+            return .init(variable: .cape, aggregation: .minimum)
+        case .cloudcover_max:
+            return .init(variable: .cloudcover, aggregation: .maximum)
+        case .cloudcover_mean:
+            return .init(variable: .cloudcover, aggregation: .mean)
+        case .cloudcover_min:
+            return .init(variable: .cloudcover, aggregation: .minimum)
+        case .dewpoint_2m_max:
+            return .init(variable: .dewpoint, aggregation: .maximum, altitude: 2)
+        case .dewpoint_2m_mean:
+            return .init(variable: .dewpoint, aggregation: .mean, altitude: 2)
+        case .dewpoint_2m_min:
+            return .init(variable: .dewpoint, aggregation: .minimum, altitude: 2)
+        case .et0_fao_evapotranspiration:
+            return .init(variable: .et0FaoEvapotranspiration)
+        case .et0_fao_evapotranspiration_sum:
+            return .init(variable: .et0FaoEvapotranspiration, aggregation: .sum)
+        case .growing_degree_days_base_0_limit_50:
+            return .init(variable: .growingDegreeDays)
+        case .leaf_wetness_probability_mean:
+            return .init(variable: .leafWetnessProbability, aggregation: .mean)
+        case .precipitation_hours:
+            return .init(variable: .precipitationHours)
+        case .precipitation_probability_max:
+            return .init(variable: .precipitationProbability, aggregation: .maximum)
+        case .precipitation_probability_mean:
+            return .init(variable: .precipitationProbability, aggregation: .mean)
+        case .precipitation_probability_min:
+            return .init(variable: .precipitationProbability, aggregation: .minimum)
+        case .precipitation_sum:
+            return .init(variable: .precipitation, aggregation: .sum)
+        case .pressure_msl_max:
+            return .init(variable: .pressureMsl, aggregation: .maximum)
+        case .pressure_msl_mean:
+            return .init(variable: .pressureMsl, aggregation: .mean)
+        case .pressure_msl_min:
+            return .init(variable: .pressureMsl, aggregation: .minimum)
+        case .rain_sum:
+            return .init(variable: .rain, aggregation: .sum)
+        case .relative_humidity_2m_max:
+            return .init(variable: .relativehumidity, aggregation: .maximum, altitude: 2)
+        case .relative_humidity_2m_mean:
+            return .init(variable: .relativehumidity, aggregation: .mean, altitude: 2)
+        case .relative_humidity_2m_min:
+            return .init(variable: .relativehumidity, aggregation: .minimum, altitude: 2)
+        case .shortwave_radiation_sum:
+            return .init(variable: .shortwaveRadiation, aggregation: .sum)
+        case .showers_sum:
+            return .init(variable: .showers, aggregation: .sum)
+        case .snowfall_sum:
+            return .init(variable: .snowfall, aggregation: .sum)
+        case .snowfall_water_equivalent_sum:
+            return .init(variable: .snowfallWaterEquivalent, aggregation: .sum)
+        case .soil_moisture_0_to_100cm_mean:
+            return .init(variable: .soilMoisture, aggregation: .mean, depth: 0, depthTo: 100)
+        case .soil_moisture_0_to_10cm_mean:
+            return .init(variable: .soilMoisture, aggregation: .mean, depth: 0, depthTo: 10)
+        case .soil_moisture_0_to_7cm_mean:
+            return .init(variable: .soilMoisture, aggregation: .mean, depth: 0, depthTo: 7)
+        case .soil_moisture_28_to_100cm_mean:
+            return .init(variable: .soilMoisture, aggregation: .mean, depth: 28, depthTo: 100)
+        case .soil_moisture_7_to_28cm_mean:
+            return .init(variable: .soilMoisture, aggregation: .mean, depth: 7, depthTo: 28)
+        case .soil_moisture_index_0_to_100cm_mean:
+            return .init(variable: .soilMoistureIndex, aggregation: .mean, depth: 0, depthTo: 100)
+        case .soil_moisture_index_0_to_7cm_mean:
+            return .init(variable: .soilMoistureIndex, aggregation: .mean, depth: 0, depthTo: 7)
+        case .soil_moisture_index_100_to_255cm_mean:
+            return .init(variable: .soilMoistureIndex, aggregation: .mean, depth: 100, depthTo: 255)
+        case .soil_moisture_index_28_to_100cm_mean:
+            return .init(variable: .soilMoistureIndex, aggregation: .mean, depth: 28, depthTo: 100)
+        case .soil_moisture_index_7_to_28cm_mean:
+            return .init(variable: .soilMoistureIndex, aggregation: .mean, depth: 7, depthTo: 28)
+        case .soil_temperature_0_to_100cm_mean:
+            return .init(variable: .soilTemperature, aggregation: .mean, depth: 0, depthTo: 100)
+        case .soil_temperature_0_to_7cm_mean:
+            return .init(variable: .soilTemperature, aggregation: .mean, depth: 0, depthTo: 7)
+        case .soil_temperature_28_to_100cm_mean:
+            return .init(variable: .soilTemperature, aggregation: .mean, depth: 28, depthTo: 100)
+        case .soil_temperature_7_to_28cm_mean:
+            return .init(variable: .soilTemperature, aggregation: .mean, depth: 7, depthTo: 28)
+        case .sunrise:
+            return .init(variable: .sunrise)
+        case .sunset:
+            return .init(variable: .sunset)
+        case .surface_pressure_max:
+            return .init(variable: .surfacePressure, aggregation: .maximum)
+        case .surface_pressure_mean:
+            return .init(variable: .surfacePressure, aggregation: .mean)
+        case .surface_pressure_min:
+            return .init(variable: .surfacePressure, aggregation: .minimum)
+        case .temperature_2m_max:
+            return .init(variable: .temperature, aggregation: .maximum, altitude: 2)
+        case .temperature_2m_mean:
+            return .init(variable: .temperature, aggregation: .mean, altitude: 2)
+        case .temperature_2m_min:
+            return .init(variable: .temperature, aggregation: .minimum, altitude: 2)
+        case .updraft_max:
+            return .init(variable: .updraft, aggregation: .maximum)
+        case .uv_index_clear_sky_max:
+            return .init(variable: .uvIndexClearSky, aggregation: .maximum)
+        case .uv_index_max:
+            return .init(variable: .uvIndex, aggregation: .maximum)
+        case .vapor_pressure_deficit_max:
+            return .init(variable: .vaporPressureDeficit, aggregation: .maximum)
+        case .visibility_max:
+            return .init(variable: .visibility, aggregation: .maximum)
+        case .visibility_mean:
+            return .init(variable: .visibility, aggregation: .mean)
+        case .visibility_min:
+            return .init(variable: .visibility, aggregation: .minimum)
+        case .weathercode:
+            return .init(variable: .weathercode)
+        case .winddirection_10m_dominant:
+            return .init(variable: .winddirection, aggregation: .dominant, altitude: 10)
+        case .windgusts_10m_max:
+            return .init(variable: .windgusts, aggregation: .maximum, altitude: 10)
+        case .windgusts_10m_mean:
+            return .init(variable: .windgusts, aggregation: .mean, altitude: 10)
+        case .windgusts_10m_min:
+            return .init(variable: .windgusts, aggregation: .minimum, altitude: 10)
+        case .windspeed_10m_max:
+            return .init(variable: .windspeed, aggregation: .maximum, altitude: 10)
+        case .windspeed_10m_mean:
+            return .init(variable: .windspeed, aggregation: .mean, altitude: 10)
+        case .windspeed_10m_min:
+            return .init(variable: .windspeed, aggregation: .minimum, altitude: 10)
+        case .wet_bulb_temperature_2m_max:
+            return .init(variable: .wetBulbTemperature, aggregation: .maximum, altitude: 2)
+        case .wet_bulb_temperature_2m_mean:
+            return .init(variable: .wetBulbTemperature, aggregation: .mean, altitude: 2)
+        case .wet_bulb_temperature_2m_min:
+            return .init(variable: .wetBulbTemperature, aggregation: .minimum, altitude: 2)
+        }
+    }
+}
+
+
+
 extension MultiDomains: ModelFlatbufferSerialisable {
     typealias HourlyVariable = ForecastSurfaceVariable
     
@@ -10,728 +439,7 @@ extension MultiDomains: ModelFlatbufferSerialisable {
     
     typealias DailyVariable = ForecastVariableDaily
     
-    static func encodeHourly(section: ApiSection<ForecastapiResult<Self>.SurfaceAndPressureVariable>, _ fbb: inout FlatBufferBuilder) -> Offset {
-        let offsets = ForecastapiResult.encode(section: section, &fbb)
-        let start = openmeteo_sdk_WeatherHourly.startWeatherHourly(&fbb)
-        openmeteo_sdk_WeatherHourly.add(time: section.timeFlatBuffers(), &fbb)
-        for (surface, offset) in offsets.surface {
-            switch surface {
-            case .temperature_2m:
-                openmeteo_sdk_WeatherHourly.add(temperature2m: offset, &fbb)
-            case .cloudcover:
-                openmeteo_sdk_WeatherHourly.add(cloudcover: offset, &fbb)
-            case .cloudcover_low:
-                openmeteo_sdk_WeatherHourly.add(cloudcoverLow: offset, &fbb)
-            case .cloudcover_mid:
-                openmeteo_sdk_WeatherHourly.add(cloudcoverMid: offset, &fbb)
-            case .cloudcover_high:
-                openmeteo_sdk_WeatherHourly.add(cloudcoverHigh: offset, &fbb)
-            case .pressure_msl:
-                openmeteo_sdk_WeatherHourly.add(pressureMsl: offset, &fbb)
-            case .relativehumidity_2m:
-                openmeteo_sdk_WeatherHourly.add(relativehumidity2m: offset, &fbb)
-            case .precipitation:
-                openmeteo_sdk_WeatherHourly.add(precipitation: offset, &fbb)
-            case .precipitation_probability:
-                openmeteo_sdk_WeatherHourly.add(precipitationProbability: offset, &fbb)
-            case .weathercode:
-                openmeteo_sdk_WeatherHourly.add(weathercode: offset, &fbb)
-            case .temperature_80m:
-                openmeteo_sdk_WeatherHourly.add(temperature80m: offset, &fbb)
-            case .temperature_120m:
-                openmeteo_sdk_WeatherHourly.add(temperature120m: offset, &fbb)
-            case .temperature_180m:
-                openmeteo_sdk_WeatherHourly.add(temperature180m: offset, &fbb)
-            case .soil_temperature_0cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature0cm: offset, &fbb)
-            case .soil_temperature_6cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature6cm: offset, &fbb)
-            case .soil_temperature_18cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature18cm: offset, &fbb)
-            case .soil_temperature_54cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature54cm: offset, &fbb)
-            case .soil_moisture_0_1cm:
-                fallthrough
-            case .soil_moisture_0_to_1cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture0To1cm: offset, &fbb)
-            case .soil_moisture_1_3cm:
-                fallthrough
-            case .soil_moisture_1_to_3cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture1To3cm: offset, &fbb)
-            case .soil_moisture_3_9cm:
-                fallthrough
-            case .soil_moisture_3_to_9cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture3To9cm: offset, &fbb)
-            case .soil_moisture_9_27cm:
-                fallthrough
-            case .soil_moisture_9_to_27cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture9To27cm: offset, &fbb)
-            case .soil_moisture_27_81cm:
-                fallthrough
-            case .soil_moisture_27_to_81cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture27To81cm: offset, &fbb)
-            case .snow_depth:
-                openmeteo_sdk_WeatherHourly.add(snowDepth: offset, &fbb)
-            case .snow_height:
-                openmeteo_sdk_WeatherHourly.add(snowHeight: offset, &fbb)
-            case .sensible_heatflux:
-                openmeteo_sdk_WeatherHourly.add(sensibleHeatflux: offset, &fbb)
-            case .latent_heatflux:
-                openmeteo_sdk_WeatherHourly.add(latentHeatflux: offset, &fbb)
-            case .showers:
-                openmeteo_sdk_WeatherHourly.add(showers: offset, &fbb)
-            case .rain:
-                openmeteo_sdk_WeatherHourly.add(rain: offset, &fbb)
-            case .windgusts_10m:
-                openmeteo_sdk_WeatherHourly.add(windgusts10m: offset, &fbb)
-            case .freezinglevel_height:
-                openmeteo_sdk_WeatherHourly.add(freezinglevelHeight: offset, &fbb)
-            case .dewpoint_2m:
-                openmeteo_sdk_WeatherHourly.add(dewpoint2m: offset, &fbb)
-            case .diffuse_radiation:
-                openmeteo_sdk_WeatherHourly.add(diffuseRadiation: offset, &fbb)
-            case .direct_radiation:
-                openmeteo_sdk_WeatherHourly.add(directRadiation: offset, &fbb)
-            case .apparent_temperature:
-                openmeteo_sdk_WeatherHourly.add(apparentTemperature: offset, &fbb)
-            case .windspeed_10m:
-                openmeteo_sdk_WeatherHourly.add(windspeed10m: offset, &fbb)
-            case .winddirection_10m:
-                openmeteo_sdk_WeatherHourly.add(winddirection10m: offset, &fbb)
-            case .windspeed_80m:
-                openmeteo_sdk_WeatherHourly.add(windspeed80m: offset, &fbb)
-            case .winddirection_80m:
-                openmeteo_sdk_WeatherHourly.add(winddirection80m: offset, &fbb)
-            case .windspeed_120m:
-                openmeteo_sdk_WeatherHourly.add(windspeed120m: offset, &fbb)
-            case .winddirection_120m:
-                openmeteo_sdk_WeatherHourly.add(winddirection120m: offset, &fbb)
-            case .windspeed_180m:
-                openmeteo_sdk_WeatherHourly.add(windspeed180m: offset, &fbb)
-            case .winddirection_180m:
-                openmeteo_sdk_WeatherHourly.add(winddirection180m: offset, &fbb)
-            case .direct_normal_irradiance:
-                openmeteo_sdk_WeatherHourly.add(directNormalIrradiance: offset, &fbb)
-            case .evapotranspiration:
-                openmeteo_sdk_WeatherHourly.add(evapotranspiration: offset, &fbb)
-            case .et0_fao_evapotranspiration:
-                openmeteo_sdk_WeatherHourly.add(et0FaoEvapotranspiration: offset, &fbb)
-            case .vapor_pressure_deficit:
-                openmeteo_sdk_WeatherHourly.add(vaporPressureDeficit: offset, &fbb)
-            case .shortwave_radiation:
-                openmeteo_sdk_WeatherHourly.add(shortwaveRadiation: offset, &fbb)
-            case .snowfall:
-                openmeteo_sdk_WeatherHourly.add(snowfall: offset, &fbb)
-            case .snowfall_height:
-                openmeteo_sdk_WeatherHourly.add(snowfallHeight: offset, &fbb)
-            case .surface_pressure:
-                openmeteo_sdk_WeatherHourly.add(surfacePressure: offset, &fbb)
-            case .terrestrial_radiation:
-                openmeteo_sdk_WeatherHourly.add(terrestrialRadiation: offset, &fbb)
-            case .terrestrial_radiation_instant:
-                openmeteo_sdk_WeatherHourly.add(terrestrialRadiationInstant: offset, &fbb)
-            case .shortwave_radiation_instant:
-                openmeteo_sdk_WeatherHourly.add(shortwaveRadiationInstant: offset, &fbb)
-            case .diffuse_radiation_instant:
-                openmeteo_sdk_WeatherHourly.add(diffuseRadiationInstant: offset, &fbb)
-            case .direct_radiation_instant:
-                openmeteo_sdk_WeatherHourly.add(directRadiationInstant: offset, &fbb)
-            case .direct_normal_irradiance_instant:
-                openmeteo_sdk_WeatherHourly.add(directNormalIrradianceInstant: offset, &fbb)
-            case .visibility:
-                openmeteo_sdk_WeatherHourly.add(visibility: offset, &fbb)
-            case .cape:
-                openmeteo_sdk_WeatherHourly.add(cape: offset, &fbb)
-            case .uv_index:
-                openmeteo_sdk_WeatherHourly.add(uvIndex: offset, &fbb)
-            case .uv_index_clear_sky:
-                openmeteo_sdk_WeatherHourly.add(uvIndexClearSky: offset, &fbb)
-            case .is_day:
-                openmeteo_sdk_WeatherHourly.add(isDay: offset, &fbb)
-            case .lightning_potential:
-                openmeteo_sdk_WeatherHourly.add(lightningPotential: offset, &fbb)
-            case .growing_degree_days_base_0_limit_50:
-                openmeteo_sdk_WeatherHourly.add(growingDegreeDaysBase0Limit50: offset, &fbb)
-            case .leaf_wetness_probability:
-                openmeteo_sdk_WeatherHourly.add(leafWetnessProbability: offset, &fbb)
-            case .runoff:
-                openmeteo_sdk_WeatherHourly.add(runoff: offset, &fbb)
-            case .skin_temperature:
-                openmeteo_sdk_WeatherHourly.add(surfaceTemperature: offset, &fbb)
-            case .snowfall_water_equivalent:
-                openmeteo_sdk_WeatherHourly.add(snowfallWaterEquivalent: offset, &fbb)
-            case .soil_moisture_0_to_100cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture0To100cm: offset, &fbb)
-            case .soil_moisture_0_to_10cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture0To10cm: offset, &fbb)
-            case .soil_moisture_0_to_7cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture0To7cm: offset, &fbb)
-            case .soil_moisture_100_to_200cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture100To200cm: offset, &fbb)
-            case .soil_moisture_100_to_255cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture100To255cm: offset, &fbb)
-            case .soil_moisture_10_to_40cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture10To40cm: offset, &fbb)
-            case .soil_moisture_28_to_100cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture28To100cm: offset, &fbb)
-            case .soil_moisture_40_to_100cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture40To100cm: offset, &fbb)
-            case .soil_moisture_7_to_28cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoisture7To28cm: offset, &fbb)
-            case .soil_moisture_index_0_to_100cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoistureIndex0To100cm: offset, &fbb)
-            case .soil_moisture_index_0_to_7cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoistureIndex0To7cm: offset, &fbb)
-            case .soil_moisture_index_100_to_255cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoistureIndex100To255cm: offset, &fbb)
-            case .soil_moisture_index_28_to_100cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoistureIndex28To100cm: offset, &fbb)
-            case .soil_moisture_index_7_to_28cm:
-                openmeteo_sdk_WeatherHourly.add(soilMoistureIndex7To28cm: offset, &fbb)
-            case .soil_temperature_0_to_100cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature0To100cm: offset, &fbb)
-            case .soil_temperature_0_to_10cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature0To10cm: offset, &fbb)
-            case .soil_temperature_0_to_7cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature0To7cm: offset, &fbb)
-            case .soil_temperature_100_to_200cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature100To200cm: offset, &fbb)
-            case .soil_temperature_100_to_255cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature100To255cm: offset, &fbb)
-            case .soil_temperature_10_to_40cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature10To40cm: offset, &fbb)
-            case .soil_temperature_28_to_100cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature28To100cm: offset, &fbb)
-            case .soil_temperature_40_to_100cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature40To100cm: offset, &fbb)
-            case .soil_temperature_7_to_28cm:
-                openmeteo_sdk_WeatherHourly.add(soilTemperature7To28cm: offset, &fbb)
-            case .surface_air_pressure:
-                openmeteo_sdk_WeatherHourly.add(surfacePressure: offset, &fbb)
-            case .surface_temperature:
-                openmeteo_sdk_WeatherHourly.add(surfaceTemperature: offset, &fbb)
-            case .temperature_40m:
-                openmeteo_sdk_WeatherHourly.add(temperature40m: offset, &fbb)
-            case .total_column_integrated_water_vapour:
-                openmeteo_sdk_WeatherHourly.add(totalColumnIntegratedWaterVapour: offset, &fbb)
-            case .updraft:
-                openmeteo_sdk_WeatherHourly.add(updraft: offset, &fbb)
-            case .winddirection_100m:
-                openmeteo_sdk_WeatherHourly.add(winddirection100m: offset, &fbb)
-            case .winddirection_150m:
-                openmeteo_sdk_WeatherHourly.add(winddirection150m: offset, &fbb)
-            case .winddirection_200m:
-                openmeteo_sdk_WeatherHourly.add(winddirection200m: offset, &fbb)
-            case .winddirection_20m:
-                openmeteo_sdk_WeatherHourly.add(winddirection20m: offset, &fbb)
-            case .winddirection_40m:
-                openmeteo_sdk_WeatherHourly.add(winddirection40m: offset, &fbb)
-            case .winddirection_50m:
-                openmeteo_sdk_WeatherHourly.add(winddirection50m: offset, &fbb)
-            case .windspeed_100m:
-                openmeteo_sdk_WeatherHourly.add(windspeed100m: offset, &fbb)
-            case .windspeed_150m:
-                openmeteo_sdk_WeatherHourly.add(windspeed150m: offset, &fbb)
-            case .windspeed_200m:
-                openmeteo_sdk_WeatherHourly.add(windspeed200m: offset, &fbb)
-            case .windspeed_20m:
-                openmeteo_sdk_WeatherHourly.add(windspeed20m: offset, &fbb)
-            case .windspeed_40m:
-                openmeteo_sdk_WeatherHourly.add(windspeed40m: offset, &fbb)
-            case .windspeed_50m:
-                openmeteo_sdk_WeatherHourly.add(windspeed50m: offset, &fbb)
-            case .temperature:
-                openmeteo_sdk_WeatherHourly.add(temperature2m: offset, &fbb)
-            case .windspeed:
-                openmeteo_sdk_WeatherHourly.add(windspeed10m: offset, &fbb)
-            case .winddirection:
-                openmeteo_sdk_WeatherHourly.add(winddirection10m: offset, &fbb)
-            case .temperature_100m:
-                openmeteo_sdk_WeatherHourly.add(temperature100m: offset, &fbb)
-            case .temperature_150m:
-                openmeteo_sdk_WeatherHourly.add(temperature150m: offset, &fbb)
-            case .temperature_20m:
-                openmeteo_sdk_WeatherHourly.add(temperature20m: offset, &fbb)
-            case .temperature_200m:
-                openmeteo_sdk_WeatherHourly.add(temperature200m: offset, &fbb)
-            case .temperature_50m:
-                openmeteo_sdk_WeatherHourly.add(temperature50m: offset, &fbb)
-            case .lifted_index:
-                openmeteo_sdk_WeatherHourly.add(liftedIndex: offset, &fbb)
-            case .wet_bulb_temperature_2m:
-                openmeteo_sdk_WeatherHourly.add(wetBulbTemperature2m: offset, &fbb)
-            }
-        }
-        for (pressure, offset) in offsets.pressure {
-            switch pressure {
-            case .temperature:
-                openmeteo_sdk_WeatherHourly.add(pressureLevelTemperature: offset, &fbb)
-            case .geopotential_height:
-                openmeteo_sdk_WeatherHourly.add(pressureLevelGeopotentialHeight: offset, &fbb)
-            case .relativehumidity:
-                openmeteo_sdk_WeatherHourly.add(pressureLevelRelativehumidity: offset, &fbb)
-            case .windspeed:
-                openmeteo_sdk_WeatherHourly.add(pressureLevelWindspeed: offset, &fbb)
-            case .winddirection:
-                openmeteo_sdk_WeatherHourly.add(pressureLevelWinddirection: offset, &fbb)
-            case .dewpoint:
-                openmeteo_sdk_WeatherHourly.add(pressureLevelDewpoint: offset, &fbb)
-            case .cloudcover:
-                openmeteo_sdk_WeatherHourly.add(pressureLevelCloudcover: offset, &fbb)
-            case .vertical_velocity:
-                openmeteo_sdk_WeatherHourly.add(pressureLevelVerticalVelocity: offset, &fbb)
-            case .relative_humidity:
-                openmeteo_sdk_WeatherHourly.add(pressureLevelRelativehumidity: offset, &fbb)
-            }
-        }
-        return openmeteo_sdk_WeatherHourly.endWeatherHourly(&fbb, start: start)
-    }
-    
-    static func encodeCurrent(section: ApiSectionSingle<ForecastapiResult<Self>.SurfaceAndPressureVariable>, _ fbb: inout FlatBufferBuilder) throws -> Offset {
-        let start = openmeteo_sdk_WeatherCurrent.startWeatherCurrent(&fbb)
-        openmeteo_sdk_WeatherCurrent.add(time: Int64(section.time.timeIntervalSince1970), &fbb)
-        openmeteo_sdk_WeatherCurrent.add(interval: Int32(section.dtSeconds), &fbb)
-        for column in section.columns {
-            switch column.variable {
-            case .surface(let surface):
-                let v = openmeteo_sdk_ValueAndUnit(value: column.value, unit: column.unit)
-                switch surface {
-                case .temperature_2m:
-                    openmeteo_sdk_WeatherCurrent.add(temperature2m: v, &fbb)
-                case .cloudcover:
-                    openmeteo_sdk_WeatherCurrent.add(cloudcover: v, &fbb)
-                case .cloudcover_low:
-                    openmeteo_sdk_WeatherCurrent.add(cloudcoverLow: v, &fbb)
-                case .cloudcover_mid:
-                    openmeteo_sdk_WeatherCurrent.add(cloudcoverMid: v, &fbb)
-                case .cloudcover_high:
-                    openmeteo_sdk_WeatherCurrent.add(cloudcoverHigh: v, &fbb)
-                case .pressure_msl:
-                    openmeteo_sdk_WeatherCurrent.add(pressureMsl: v, &fbb)
-                case .relativehumidity_2m:
-                    openmeteo_sdk_WeatherCurrent.add(relativehumidity2m: v, &fbb)
-                case .precipitation:
-                    openmeteo_sdk_WeatherCurrent.add(precipitation: v, &fbb)
-                case .precipitation_probability:
-                    openmeteo_sdk_WeatherCurrent.add(precipitationProbability: v, &fbb)
-                case .weathercode:
-                    openmeteo_sdk_WeatherCurrent.add(weathercode: v, &fbb)
-                case .temperature_80m:
-                    openmeteo_sdk_WeatherCurrent.add(temperature80m: v, &fbb)
-                case .temperature_120m:
-                    openmeteo_sdk_WeatherCurrent.add(temperature120m: v, &fbb)
-                case .temperature_180m:
-                    openmeteo_sdk_WeatherCurrent.add(temperature180m: v, &fbb)
-                case .soil_temperature_0cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature0cm: v, &fbb)
-                case .soil_temperature_6cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature6cm: v, &fbb)
-                case .soil_temperature_18cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature18cm: v, &fbb)
-                case .soil_temperature_54cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature54cm: v, &fbb)
-                case .soil_moisture_0_1cm:
-                    fallthrough
-                case .soil_moisture_0_to_1cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture0To1cm: v, &fbb)
-                case .soil_moisture_1_3cm:
-                    fallthrough
-                case .soil_moisture_1_to_3cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture1To3cm: v, &fbb)
-                case .soil_moisture_3_9cm:
-                    fallthrough
-                case .soil_moisture_3_to_9cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture3To9cm: v, &fbb)
-                case .soil_moisture_9_27cm:
-                    fallthrough
-                case .soil_moisture_9_to_27cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture9To27cm: v, &fbb)
-                case .soil_moisture_27_81cm:
-                    fallthrough
-                case .soil_moisture_27_to_81cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture27To81cm: v, &fbb)
-                case .snow_depth:
-                    openmeteo_sdk_WeatherCurrent.add(snowDepth: v, &fbb)
-                case .snow_height:
-                    openmeteo_sdk_WeatherCurrent.add(snowHeight: v, &fbb)
-                case .sensible_heatflux:
-                    openmeteo_sdk_WeatherCurrent.add(sensibleHeatflux: v, &fbb)
-                case .latent_heatflux:
-                    openmeteo_sdk_WeatherCurrent.add(latentHeatflux: v, &fbb)
-                case .showers:
-                    openmeteo_sdk_WeatherCurrent.add(showers: v, &fbb)
-                case .rain:
-                    openmeteo_sdk_WeatherCurrent.add(rain: v, &fbb)
-                case .windgusts_10m:
-                    openmeteo_sdk_WeatherCurrent.add(windgusts10m: v, &fbb)
-                case .freezinglevel_height:
-                    openmeteo_sdk_WeatherCurrent.add(freezinglevelHeight: v, &fbb)
-                case .dewpoint_2m:
-                    openmeteo_sdk_WeatherCurrent.add(dewpoint2m: v, &fbb)
-                case .diffuse_radiation:
-                    openmeteo_sdk_WeatherCurrent.add(diffuseRadiation: v, &fbb)
-                case .direct_radiation:
-                    openmeteo_sdk_WeatherCurrent.add(directRadiation: v, &fbb)
-                case .apparent_temperature:
-                    openmeteo_sdk_WeatherCurrent.add(apparentTemperature: v, &fbb)
-                case .windspeed_10m:
-                    openmeteo_sdk_WeatherCurrent.add(windspeed10m: v, &fbb)
-                case .winddirection_10m:
-                    openmeteo_sdk_WeatherCurrent.add(winddirection10m: v, &fbb)
-                case .windspeed_80m:
-                    openmeteo_sdk_WeatherCurrent.add(windspeed80m: v, &fbb)
-                case .winddirection_80m:
-                    openmeteo_sdk_WeatherCurrent.add(winddirection80m: v, &fbb)
-                case .windspeed_120m:
-                    openmeteo_sdk_WeatherCurrent.add(windspeed120m: v, &fbb)
-                case .winddirection_120m:
-                    openmeteo_sdk_WeatherCurrent.add(winddirection120m: v, &fbb)
-                case .windspeed_180m:
-                    openmeteo_sdk_WeatherCurrent.add(windspeed180m: v, &fbb)
-                case .winddirection_180m:
-                    openmeteo_sdk_WeatherCurrent.add(winddirection180m: v, &fbb)
-                case .direct_normal_irradiance:
-                    openmeteo_sdk_WeatherCurrent.add(directNormalIrradiance: v, &fbb)
-                case .evapotranspiration:
-                    openmeteo_sdk_WeatherCurrent.add(evapotranspiration: v, &fbb)
-                case .et0_fao_evapotranspiration:
-                    openmeteo_sdk_WeatherCurrent.add(et0FaoEvapotranspiration: v, &fbb)
-                case .vapor_pressure_deficit:
-                    openmeteo_sdk_WeatherCurrent.add(vaporPressureDeficit: v, &fbb)
-                case .shortwave_radiation:
-                    openmeteo_sdk_WeatherCurrent.add(shortwaveRadiation: v, &fbb)
-                case .snowfall:
-                    openmeteo_sdk_WeatherCurrent.add(snowfall: v, &fbb)
-                case .snowfall_height:
-                    openmeteo_sdk_WeatherCurrent.add(snowfallHeight: v, &fbb)
-                case .surface_pressure:
-                    openmeteo_sdk_WeatherCurrent.add(surfacePressure: v, &fbb)
-                case .terrestrial_radiation:
-                    openmeteo_sdk_WeatherCurrent.add(terrestrialRadiation: v, &fbb)
-                case .terrestrial_radiation_instant:
-                    openmeteo_sdk_WeatherCurrent.add(terrestrialRadiationInstant: v, &fbb)
-                case .shortwave_radiation_instant:
-                    openmeteo_sdk_WeatherCurrent.add(shortwaveRadiationInstant: v, &fbb)
-                case .diffuse_radiation_instant:
-                    openmeteo_sdk_WeatherCurrent.add(diffuseRadiationInstant: v, &fbb)
-                case .direct_radiation_instant:
-                    openmeteo_sdk_WeatherCurrent.add(directRadiationInstant: v, &fbb)
-                case .direct_normal_irradiance_instant:
-                    openmeteo_sdk_WeatherCurrent.add(directNormalIrradianceInstant: v, &fbb)
-                case .visibility:
-                    openmeteo_sdk_WeatherCurrent.add(visibility: v, &fbb)
-                case .cape:
-                    openmeteo_sdk_WeatherCurrent.add(cape: v, &fbb)
-                case .uv_index:
-                    openmeteo_sdk_WeatherCurrent.add(uvIndex: v, &fbb)
-                case .uv_index_clear_sky:
-                    openmeteo_sdk_WeatherCurrent.add(uvIndexClearSky: v, &fbb)
-                case .is_day:
-                    openmeteo_sdk_WeatherCurrent.add(isDay: v, &fbb)
-                case .lightning_potential:
-                    openmeteo_sdk_WeatherCurrent.add(lightningPotential: v, &fbb)
-                case .growing_degree_days_base_0_limit_50:
-                    openmeteo_sdk_WeatherCurrent.add(growingDegreeDaysBase0Limit50: v, &fbb)
-                case .leaf_wetness_probability:
-                    openmeteo_sdk_WeatherCurrent.add(leafWetnessProbability: v, &fbb)
-                case .runoff:
-                    openmeteo_sdk_WeatherCurrent.add(runoff: v, &fbb)
-                case .skin_temperature:
-                    openmeteo_sdk_WeatherCurrent.add(surfaceTemperature: v, &fbb)
-                case .snowfall_water_equivalent:
-                    openmeteo_sdk_WeatherCurrent.add(snowfallWaterEquivalent: v, &fbb)
-                case .soil_moisture_0_to_100cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture0To100cm: v, &fbb)
-                case .soil_moisture_0_to_10cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture0To10cm: v, &fbb)
-                case .soil_moisture_0_to_7cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture0To7cm: v, &fbb)
-                case .soil_moisture_100_to_200cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture100To200cm: v, &fbb)
-                case .soil_moisture_100_to_255cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture100To255cm: v, &fbb)
-                case .soil_moisture_10_to_40cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture10To40cm: v, &fbb)
-                case .soil_moisture_28_to_100cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture28To100cm: v, &fbb)
-                case .soil_moisture_40_to_100cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture40To100cm: v, &fbb)
-                case .soil_moisture_7_to_28cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoisture7To28cm: v, &fbb)
-                case .soil_moisture_index_0_to_100cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoistureIndex0To100cm: v, &fbb)
-                case .soil_moisture_index_0_to_7cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoistureIndex0To7cm: v, &fbb)
-                case .soil_moisture_index_100_to_255cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoistureIndex100To255cm: v, &fbb)
-                case .soil_moisture_index_28_to_100cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoistureIndex28To100cm: v, &fbb)
-                case .soil_moisture_index_7_to_28cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilMoistureIndex7To28cm: v, &fbb)
-                case .soil_temperature_0_to_100cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature0To100cm: v, &fbb)
-                case .soil_temperature_0_to_10cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature0To10cm: v, &fbb)
-                case .soil_temperature_0_to_7cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature0To7cm: v, &fbb)
-                case .soil_temperature_100_to_200cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature100To200cm: v, &fbb)
-                case .soil_temperature_100_to_255cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature100To255cm: v, &fbb)
-                case .soil_temperature_10_to_40cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature10To40cm: v, &fbb)
-                case .soil_temperature_28_to_100cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature28To100cm: v, &fbb)
-                case .soil_temperature_40_to_100cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature40To100cm: v, &fbb)
-                case .soil_temperature_7_to_28cm:
-                    openmeteo_sdk_WeatherCurrent.add(soilTemperature7To28cm: v, &fbb)
-                case .surface_air_pressure:
-                    openmeteo_sdk_WeatherCurrent.add(surfacePressure: v, &fbb)
-                case .surface_temperature:
-                    openmeteo_sdk_WeatherCurrent.add(surfaceTemperature: v, &fbb)
-                case .temperature_40m:
-                    openmeteo_sdk_WeatherCurrent.add(temperature40m: v, &fbb)
-                case .total_column_integrated_water_vapour:
-                    openmeteo_sdk_WeatherCurrent.add(totalColumnIntegratedWaterVapour: v, &fbb)
-                case .updraft:
-                    openmeteo_sdk_WeatherCurrent.add(updraft: v, &fbb)
-                case .winddirection_100m:
-                    openmeteo_sdk_WeatherCurrent.add(winddirection100m: v, &fbb)
-                case .winddirection_150m:
-                    openmeteo_sdk_WeatherCurrent.add(winddirection150m: v, &fbb)
-                case .winddirection_200m:
-                    openmeteo_sdk_WeatherCurrent.add(winddirection200m: v, &fbb)
-                case .winddirection_20m:
-                    openmeteo_sdk_WeatherCurrent.add(winddirection20m: v, &fbb)
-                case .winddirection_40m:
-                    openmeteo_sdk_WeatherCurrent.add(winddirection40m: v, &fbb)
-                case .winddirection_50m:
-                    openmeteo_sdk_WeatherCurrent.add(winddirection50m: v, &fbb)
-                case .windspeed_100m:
-                    openmeteo_sdk_WeatherCurrent.add(windspeed100m: v, &fbb)
-                case .windspeed_150m:
-                    openmeteo_sdk_WeatherCurrent.add(windspeed150m: v, &fbb)
-                case .windspeed_200m:
-                    openmeteo_sdk_WeatherCurrent.add(windspeed200m: v, &fbb)
-                case .windspeed_20m:
-                    openmeteo_sdk_WeatherCurrent.add(windspeed20m: v, &fbb)
-                case .windspeed_40m:
-                    openmeteo_sdk_WeatherCurrent.add(windspeed40m: v, &fbb)
-                case .windspeed_50m:
-                    openmeteo_sdk_WeatherCurrent.add(windspeed50m: v, &fbb)
-                case .temperature:
-                    openmeteo_sdk_WeatherCurrent.add(temperature2m: v, &fbb)
-                case .windspeed:
-                    openmeteo_sdk_WeatherCurrent.add(windspeed10m: v, &fbb)
-                case .winddirection:
-                    openmeteo_sdk_WeatherCurrent.add(winddirection10m: v, &fbb)
-                case .temperature_100m:
-                    openmeteo_sdk_WeatherCurrent.add(temperature100m: v, &fbb)
-                case .temperature_150m:
-                    openmeteo_sdk_WeatherCurrent.add(temperature150m: v, &fbb)
-                case .temperature_20m:
-                    openmeteo_sdk_WeatherCurrent.add(temperature20m: v, &fbb)
-                case .temperature_200m:
-                    openmeteo_sdk_WeatherCurrent.add(temperature200m: v, &fbb)
-                case .lifted_index:
-                    openmeteo_sdk_WeatherCurrent.add(liftedIndex: v, &fbb)
-                case .temperature_50m:
-                    openmeteo_sdk_WeatherCurrent.add(temperature50m: v, &fbb)
-                case .wet_bulb_temperature_2m:
-                    openmeteo_sdk_WeatherCurrent.add(wetBulbTemperature2m: v, &fbb)
-                }
-            case .pressure(_):
-                throw ForecastapiError.generic(message: "Pressure level variables currently not supported for flatbuffers encoding in current block")
-            }
-        }
-        return openmeteo_sdk_WeatherCurrent.endWeatherCurrent(&fbb, start: start)
-    }
-    
-    static func encodeDaily(section: ApiSection<DailyVariable>, _ fbb: inout FlatBufferBuilder) -> Offset {
-        let offsets = ForecastapiResult<Self>.encode(section: section, &fbb)
-        let start = openmeteo_sdk_WeatherDaily.startWeatherDaily(&fbb)
-        openmeteo_sdk_WeatherDaily.add(time: section.timeFlatBuffers(), &fbb)
-        for (variable, offset) in zip(section.columns, offsets) {
-            switch variable.variable {
-            case .temperature_2m_max:
-                openmeteo_sdk_WeatherDaily.add(temperature2mMax: offset, &fbb)
-            case .temperature_2m_min:
-                openmeteo_sdk_WeatherDaily.add(temperature2mMin: offset, &fbb)
-            case .temperature_2m_mean:
-                openmeteo_sdk_WeatherDaily.add(temperature2mMean: offset, &fbb)
-            case .apparent_temperature_max:
-                openmeteo_sdk_WeatherDaily.add(apparentTemperatureMax: offset, &fbb)
-            case .apparent_temperature_min:
-                openmeteo_sdk_WeatherDaily.add(apparentTemperatureMin: offset, &fbb)
-            case .apparent_temperature_mean:
-                openmeteo_sdk_WeatherDaily.add(apparentTemperatureMean: offset, &fbb)
-            case .precipitation_sum:
-                openmeteo_sdk_WeatherDaily.add(precipitationSum: offset, &fbb)
-            case .precipitation_probability_max:
-                openmeteo_sdk_WeatherDaily.add(precipitationProbabilityMax: offset, &fbb)
-            case .precipitation_probability_min:
-                openmeteo_sdk_WeatherDaily.add(precipitationProbabilityMin: offset, &fbb)
-            case .precipitation_probability_mean:
-                openmeteo_sdk_WeatherDaily.add(precipitationProbabilityMean: offset, &fbb)
-            case .snowfall_sum:
-                openmeteo_sdk_WeatherDaily.add(snowfallSum: offset, &fbb)
-            case .rain_sum:
-                openmeteo_sdk_WeatherDaily.add(rainSum: offset, &fbb)
-            case .showers_sum:
-                openmeteo_sdk_WeatherDaily.add(showersSum: offset, &fbb)
-            case .weathercode:
-                openmeteo_sdk_WeatherDaily.add(weathercode: offset, &fbb)
-            case .shortwave_radiation_sum:
-                openmeteo_sdk_WeatherDaily.add(shortwaveRadiationSum: offset, &fbb)
-            case .windspeed_10m_max:
-                openmeteo_sdk_WeatherDaily.add(windspeed10mMax: offset, &fbb)
-            case .windspeed_10m_min:
-                openmeteo_sdk_WeatherDaily.add(windspeed10mMin: offset, &fbb)
-            case .windspeed_10m_mean:
-                openmeteo_sdk_WeatherDaily.add(windspeed10mMean: offset, &fbb)
-            case .windgusts_10m_max:
-                openmeteo_sdk_WeatherDaily.add(windgusts10mMax: offset, &fbb)
-            case .windgusts_10m_min:
-                openmeteo_sdk_WeatherDaily.add(windgusts10mMin: offset, &fbb)
-            case .windgusts_10m_mean:
-                openmeteo_sdk_WeatherDaily.add(windgusts10mMean: offset, &fbb)
-            case .winddirection_10m_dominant:
-                openmeteo_sdk_WeatherDaily.add(winddirection10mDominant: offset, &fbb)
-            case .precipitation_hours:
-                openmeteo_sdk_WeatherDaily.add(precipitationSum: offset, &fbb)
-            case .sunrise:
-                openmeteo_sdk_WeatherDaily.add(sunrise: offset, &fbb)
-            case .sunset:
-                openmeteo_sdk_WeatherDaily.add(sunset: offset, &fbb)
-            case .et0_fao_evapotranspiration:
-                openmeteo_sdk_WeatherDaily.add(et0FaoEvapotranspiration: offset, &fbb)
-            case .visibility_max:
-                openmeteo_sdk_WeatherDaily.add(visibilityMax: offset, &fbb)
-            case .visibility_min:
-                openmeteo_sdk_WeatherDaily.add(visibilityMin: offset, &fbb)
-            case .visibility_mean:
-                openmeteo_sdk_WeatherDaily.add(visibilityMean: offset, &fbb)
-            case .pressure_msl_max:
-                openmeteo_sdk_WeatherDaily.add(pressureMslMax: offset, &fbb)
-            case .pressure_msl_min:
-                openmeteo_sdk_WeatherDaily.add(pressureMslMin: offset, &fbb)
-            case .pressure_msl_mean:
-                openmeteo_sdk_WeatherDaily.add(pressureMslMean: offset, &fbb)
-            case .surface_pressure_max:
-                openmeteo_sdk_WeatherDaily.add(surfacePressureMax: offset, &fbb)
-            case .surface_pressure_min:
-                openmeteo_sdk_WeatherDaily.add(surfacePressureMin: offset, &fbb)
-            case .surface_pressure_mean:
-                openmeteo_sdk_WeatherDaily.add(surfacePressureMean: offset, &fbb)
-            case .cape_max:
-                openmeteo_sdk_WeatherDaily.add(capeMax: offset, &fbb)
-            case .cape_min:
-                openmeteo_sdk_WeatherDaily.add(capeMin: offset, &fbb)
-            case .cape_mean:
-                openmeteo_sdk_WeatherDaily.add(capeMean: offset, &fbb)
-            case .cloudcover_max:
-                openmeteo_sdk_WeatherDaily.add(cloudcoverMax: offset, &fbb)
-            case .cloudcover_min:
-                openmeteo_sdk_WeatherDaily.add(cloudcoverMin: offset, &fbb)
-            case .cloudcover_mean:
-                openmeteo_sdk_WeatherDaily.add(cloudcoverMean: offset, &fbb)
-            case .uv_index_max:
-                openmeteo_sdk_WeatherDaily.add(uvIndexMax: offset, &fbb)
-            case .uv_index_clear_sky_max:
-                openmeteo_sdk_WeatherDaily.add(uvIndexClearSkyMax: offset, &fbb)
-            case .dewpoint_2m_max:
-                openmeteo_sdk_WeatherDaily.add(dewpoint2mMax: offset, &fbb)
-            case .dewpoint_2m_mean:
-                openmeteo_sdk_WeatherDaily.add(dewpoint2mMean: offset, &fbb)
-            case .dewpoint_2m_min:
-                openmeteo_sdk_WeatherDaily.add(dewpoint2mMin: offset, &fbb)
-            case .et0_fao_evapotranspiration_sum:
-                openmeteo_sdk_WeatherDaily.add(et0FaoEvapotranspirationSum: offset, &fbb)
-            case .growing_degree_days_base_0_limit_50:
-                openmeteo_sdk_WeatherDaily.add(growingDegreeDaysBase0Limit50: offset, &fbb)
-            case .leaf_wetness_probability_mean:
-                openmeteo_sdk_WeatherDaily.add(leafWetnessProbabilityMean: offset, &fbb)
-            case .relative_humidity_2m_max:
-                openmeteo_sdk_WeatherDaily.add(relativeHumidity2mMax: offset, &fbb)
-            case .relative_humidity_2m_mean:
-                openmeteo_sdk_WeatherDaily.add(relativeHumidity2mMean: offset, &fbb)
-            case .relative_humidity_2m_min:
-                openmeteo_sdk_WeatherDaily.add(relativeHumidity2mMin: offset, &fbb)
-            case .snowfall_water_equivalent_sum:
-                openmeteo_sdk_WeatherDaily.add(snowfallWaterEquivalentSum: offset, &fbb)
-            case .soil_moisture_0_to_100cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilMoisture0To100cmMean: offset, &fbb)
-            case .soil_moisture_0_to_10cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilMoisture0To10cmMean: offset, &fbb)
-            case .soil_moisture_0_to_7cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilMoisture0To7cmMean:  offset, &fbb)
-            case .soil_moisture_28_to_100cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilMoisture28To100cmMean: offset, &fbb)
-            case .soil_moisture_7_to_28cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilMoisture7To28cmMean: offset, &fbb)
-            case .soil_moisture_index_0_to_100cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilMoistureIndex0To100cmMean: offset, &fbb)
-            case .soil_moisture_index_0_to_7cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilMoistureIndex0To7cmMean: offset, &fbb)
-            case .soil_moisture_index_100_to_255cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilMoistureIndex100To255cmMean: offset, &fbb)
-            case .soil_moisture_index_28_to_100cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilMoistureIndex28To100cmMean: offset, &fbb)
-            case .soil_moisture_index_7_to_28cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilMoistureIndex7To28cmMean: offset, &fbb)
-            case .soil_temperature_0_to_100cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilTemperature0To100cmMean: offset, &fbb)
-            case .soil_temperature_0_to_7cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilTemperature0To7cmMean: offset, &fbb)
-            case .soil_temperature_28_to_100cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilTemperature28To100cmMean: offset, &fbb)
-            case .soil_temperature_7_to_28cm_mean:
-                openmeteo_sdk_WeatherDaily.add(soilTemperature7To28cmMean: offset, &fbb)
-            case .updraft_max:
-                openmeteo_sdk_WeatherDaily.add(updraftMax: offset, &fbb)
-            case .vapor_pressure_deficit_max:
-                openmeteo_sdk_WeatherDaily.add(vaporPressureDeficitMax: offset, &fbb)
-            case .wet_bulb_temperature_2m_max:
-                openmeteo_sdk_WeatherDaily.add(wetBulbTemperature2mMax: offset, &fbb)
-            case .wet_bulb_temperature_2m_mean:
-                openmeteo_sdk_WeatherDaily.add(wetBulbTemperature2mMean: offset, &fbb)
-            case .wet_bulb_temperature_2m_min:
-                openmeteo_sdk_WeatherDaily.add(wetBulbTemperature2mMin: offset, &fbb)
-            }
-        }
-        return openmeteo_sdk_WeatherDaily.endWeatherDaily(&fbb, start: start)
-    }
-    
-    static func writeToFlatbuffer(section: ForecastapiResult<Self>.PerModel, _ fbb: inout FlatBufferBuilder, timezone: TimezoneWithOffset, fixedGenerationTime: Double?) throws {
-        let generationTimeStart = Date()
-        let hourly = (try section.hourly?()).map { encodeHourly(section: $0, &fbb) } ?? Offset()
-        let minutely15 = (try section.minutely15?()).map { encodeHourly(section: $0, &fbb) } ?? Offset()
-        let sixHourly = (try section.sixHourly?()).map { encodeHourly(section: $0, &fbb) } ?? Offset()
-        let daily = (try section.daily?()).map { encodeDaily(section: $0, &fbb) } ?? Offset()
-        let current = try (try section.current?()).map { try encodeCurrent(section: $0, &fbb) } ?? Offset()
-        let generationTimeMs = fixedGenerationTime ?? (Date().timeIntervalSince(generationTimeStart) * 1000)
-        
-        let result = openmeteo_sdk_WeatherApiResponse.createWeatherApiResponse(
-            &fbb,
-            latitude: section.latitude,
-            longitude: section.longitude,
-            elevation: section.elevation ?? .nan,
-            model: section.model.flatBufferModel,
-            generationtimeMs: Float32(generationTimeMs),
-            utcOffsetSeconds: Int32(timezone.utcOffsetSeconds),
-            timezoneOffset: timezone.identifier == "GMT" ? Offset() : fbb.create(string: timezone.identifier),
-            timezoneAbbreviationOffset: timezone.abbreviation == "GMT" ? Offset() : fbb.create(string: timezone.abbreviation),
-            dailyOffset: daily,
-            hourlyOffset: hourly,
-            sixHourlyOffset: sixHourly,
-            minutely15Offset: minutely15,
-            currentOffset: current
-        )
-        fbb.finish(offset: result, addPrefix: true)
-    }
-    
-    var flatBufferModel: openmeteo_sdk_WeatherModel {
+    var flatBufferModel: openmeteo_sdk_Model {
         switch self {
         case .best_match:
             return .bestMatch

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
@@ -9,9 +9,9 @@ extension ForecastSurfaceVariable: FlatBuffersVariable {
         case .temperature:
             return .init(variable: .temperature, altitude: 2)
         case .windspeed:
-            return .init(variable: .windspeed, altitude: 10)
+            return .init(variable: .windSpeed, altitude: 10)
         case .winddirection:
-            return .init(variable: .winddirection, altitude: 10)
+            return .init(variable: .windDirection, altitude: 10)
         case .wet_bulb_temperature_2m:
             return .init(variable: .wetBulbTemperature, altitude: 2)
         case .apparent_temperature:
@@ -19,15 +19,15 @@ extension ForecastSurfaceVariable: FlatBuffersVariable {
         case .cape:
             return .init(variable: .cape)
         case .cloudcover:
-            return .init(variable: .cloudcover)
+            return .init(variable: .cloudCover)
         case .cloudcover_high:
-            return .init(variable: .cloudcoverHigh)
+            return .init(variable: .cloudCoverHigh)
         case .cloudcover_low:
-            return .init(variable: .cloudcoverLow)
+            return .init(variable: .cloudCoverLow)
         case .cloudcover_mid:
-            return .init(variable: .cloudcoverMid)
+            return .init(variable: .cloudCoverMid)
         case .dewpoint_2m:
-            return .init(variable: .dewpoint, altitude: 2)
+            return .init(variable: .dewPoint, altitude: 2)
         case .diffuse_radiation:
             return .init(variable: .diffuseRadiation)
         case .diffuse_radiation_instant:
@@ -45,13 +45,13 @@ extension ForecastSurfaceVariable: FlatBuffersVariable {
         case .evapotranspiration:
             return .init(variable: .evapotranspiration)
         case .freezinglevel_height:
-            return .init(variable: .freezinglevelHeight)
+            return .init(variable: .freezingLevelHeight)
         case .growing_degree_days_base_0_limit_50:
             return .init(variable: .growingDegreeDays)
         case .is_day:
             return .init(variable: .isDay)
         case .latent_heatflux:
-            return .init(variable: .latentHeatflux)
+            return .init(variable: .latentHeatFlux)
         case .lifted_index:
             return .init(variable: .liftedIndex)
         case .leaf_wetness_probability:
@@ -67,11 +67,11 @@ extension ForecastSurfaceVariable: FlatBuffersVariable {
         case .rain:
             return .init(variable: .rain)
         case .relativehumidity_2m:
-            return .init(variable: .relativehumidity)
+            return .init(variable: .relativeHumidity)
         case .runoff:
             return .init(variable: .runoff)
         case .sensible_heatflux:
-            return .init(variable: .sensibleHeatflux)
+            return .init(variable: .sensibleHeatFlux)
         case .shortwave_radiation:
             return .init(variable: .shortwaveRadiation)
         case .shortwave_radiation_instant:
@@ -203,53 +203,53 @@ extension ForecastSurfaceVariable: FlatBuffersVariable {
         case .uv_index_clear_sky:
             return .init(variable: .uvIndexClearSky)
         case .vapor_pressure_deficit:
-            return .init(variable: .vaporPressureDeficit)
+            return .init(variable: .vapourPressureDeficit)
         case .visibility:
             return .init(variable: .visibility)
         case .weathercode:
-            return .init(variable: .weathercode)
+            return .init(variable: .weatherCode)
         case .winddirection_100m:
-            return .init(variable: .winddirection, altitude: 100)
+            return .init(variable: .windDirection, altitude: 100)
         case .winddirection_10m:
-            return .init(variable: .winddirection, altitude: 10)
+            return .init(variable: .windDirection, altitude: 10)
         case .winddirection_120m:
-            return .init(variable: .winddirection, altitude: 120)
+            return .init(variable: .windDirection, altitude: 120)
         case .winddirection_150m:
-            return .init(variable: .winddirection, altitude: 150)
+            return .init(variable: .windDirection, altitude: 150)
         case .winddirection_180m:
-            return .init(variable: .winddirection, altitude: 180)
+            return .init(variable: .windDirection, altitude: 180)
         case .winddirection_200m:
-            return .init(variable: .winddirection, altitude: 200)
+            return .init(variable: .windDirection, altitude: 200)
         case .winddirection_20m:
-            return .init(variable: .winddirection, altitude: 20)
+            return .init(variable: .windDirection, altitude: 20)
         case .winddirection_40m:
-            return .init(variable: .winddirection, altitude: 40)
+            return .init(variable: .windDirection, altitude: 40)
         case .winddirection_50m:
-            return .init(variable: .winddirection, altitude: 50)
+            return .init(variable: .windDirection, altitude: 50)
         case .winddirection_80m:
-            return .init(variable: .winddirection, altitude: 80)
+            return .init(variable: .windDirection, altitude: 80)
         case .windgusts_10m:
-            return .init(variable: .windgusts, altitude: 10)
+            return .init(variable: .windGusts, altitude: 10)
         case .windspeed_100m:
-            return .init(variable: .windspeed, altitude: 100)
+            return .init(variable: .windSpeed, altitude: 100)
         case .windspeed_10m:
-            return .init(variable: .windspeed, altitude: 10)
+            return .init(variable: .windSpeed, altitude: 10)
         case .windspeed_120m:
-            return .init(variable: .windspeed, altitude: 120)
+            return .init(variable: .windSpeed, altitude: 120)
         case .windspeed_150m:
-            return .init(variable: .windspeed, altitude: 150)
+            return .init(variable: .windSpeed, altitude: 150)
         case .windspeed_180m:
-            return .init(variable: .windspeed, altitude: 180)
+            return .init(variable: .windSpeed, altitude: 180)
         case .windspeed_200m:
-            return .init(variable: .windspeed, altitude: 200)
+            return .init(variable: .windSpeed, altitude: 200)
         case .windspeed_20m:
-            return .init(variable: .windspeed, altitude: 20)
+            return .init(variable: .windSpeed, altitude: 20)
         case .windspeed_40m:
-            return .init(variable: .windspeed, altitude: 40)
+            return .init(variable: .windSpeed, altitude: 40)
         case .windspeed_50m:
-            return .init(variable: .windspeed, altitude: 50)
+            return .init(variable: .windSpeed, altitude: 50)
         case .windspeed_80m:
-            return .init(variable: .windspeed, altitude: 80)
+            return .init(variable: .windSpeed, altitude: 80)
         }
     }
 }
@@ -262,19 +262,19 @@ extension ForecastPressureVariableType: FlatBuffersVariable {
         case .geopotential_height:
             return .init(variable: .geopotentialHeight)
         case .relativehumidity:
-            return .init(variable: .relativehumidity)
+            return .init(variable: .relativeHumidity)
         case .windspeed:
-            return .init(variable: .windspeed)
+            return .init(variable: .windSpeed)
         case .winddirection:
-            return .init(variable: .winddirection)
+            return .init(variable: .windDirection)
         case .dewpoint:
-            return .init(variable: .dewpoint)
+            return .init(variable: .dewPoint)
         case .cloudcover:
-            return .init(variable: .cloudcover)
+            return .init(variable: .cloudCover)
         case .vertical_velocity:
             return .init(variable: .verticalVelocity)
         case .relative_humidity:
-            return .init(variable: .relativehumidity)
+            return .init(variable: .relativeHumidity)
         }
     }
 }
@@ -295,17 +295,17 @@ extension ForecastVariableDaily: FlatBuffersVariable {
         case .cape_min:
             return .init(variable: .cape, aggregation: .minimum)
         case .cloudcover_max:
-            return .init(variable: .cloudcover, aggregation: .maximum)
+            return .init(variable: .cloudCover, aggregation: .maximum)
         case .cloudcover_mean:
-            return .init(variable: .cloudcover, aggregation: .mean)
+            return .init(variable: .cloudCover, aggregation: .mean)
         case .cloudcover_min:
-            return .init(variable: .cloudcover, aggregation: .minimum)
+            return .init(variable: .cloudCover, aggregation: .minimum)
         case .dewpoint_2m_max:
-            return .init(variable: .dewpoint, aggregation: .maximum, altitude: 2)
+            return .init(variable: .dewPoint, aggregation: .maximum, altitude: 2)
         case .dewpoint_2m_mean:
-            return .init(variable: .dewpoint, aggregation: .mean, altitude: 2)
+            return .init(variable: .dewPoint, aggregation: .mean, altitude: 2)
         case .dewpoint_2m_min:
-            return .init(variable: .dewpoint, aggregation: .minimum, altitude: 2)
+            return .init(variable: .dewPoint, aggregation: .minimum, altitude: 2)
         case .et0_fao_evapotranspiration:
             return .init(variable: .et0FaoEvapotranspiration)
         case .et0_fao_evapotranspiration_sum:
@@ -333,11 +333,11 @@ extension ForecastVariableDaily: FlatBuffersVariable {
         case .rain_sum:
             return .init(variable: .rain, aggregation: .sum)
         case .relative_humidity_2m_max:
-            return .init(variable: .relativehumidity, aggregation: .maximum, altitude: 2)
+            return .init(variable: .relativeHumidity, aggregation: .maximum, altitude: 2)
         case .relative_humidity_2m_mean:
-            return .init(variable: .relativehumidity, aggregation: .mean, altitude: 2)
+            return .init(variable: .relativeHumidity, aggregation: .mean, altitude: 2)
         case .relative_humidity_2m_min:
-            return .init(variable: .relativehumidity, aggregation: .minimum, altitude: 2)
+            return .init(variable: .relativeHumidity, aggregation: .minimum, altitude: 2)
         case .shortwave_radiation_sum:
             return .init(variable: .shortwaveRadiation, aggregation: .sum)
         case .showers_sum:
@@ -397,7 +397,7 @@ extension ForecastVariableDaily: FlatBuffersVariable {
         case .uv_index_max:
             return .init(variable: .uvIndex, aggregation: .maximum)
         case .vapor_pressure_deficit_max:
-            return .init(variable: .vaporPressureDeficit, aggregation: .maximum)
+            return .init(variable: .vapourPressureDeficit, aggregation: .maximum)
         case .visibility_max:
             return .init(variable: .visibility, aggregation: .maximum)
         case .visibility_mean:
@@ -405,21 +405,21 @@ extension ForecastVariableDaily: FlatBuffersVariable {
         case .visibility_min:
             return .init(variable: .visibility, aggregation: .minimum)
         case .weathercode:
-            return .init(variable: .weathercode)
+            return .init(variable: .weatherCode)
         case .winddirection_10m_dominant:
-            return .init(variable: .winddirection, aggregation: .dominant, altitude: 10)
+            return .init(variable: .windDirection, aggregation: .dominant, altitude: 10)
         case .windgusts_10m_max:
-            return .init(variable: .windgusts, aggregation: .maximum, altitude: 10)
+            return .init(variable: .windGusts, aggregation: .maximum, altitude: 10)
         case .windgusts_10m_mean:
-            return .init(variable: .windgusts, aggregation: .mean, altitude: 10)
+            return .init(variable: .windGusts, aggregation: .mean, altitude: 10)
         case .windgusts_10m_min:
-            return .init(variable: .windgusts, aggregation: .minimum, altitude: 10)
+            return .init(variable: .windGusts, aggregation: .minimum, altitude: 10)
         case .windspeed_10m_max:
-            return .init(variable: .windspeed, aggregation: .maximum, altitude: 10)
+            return .init(variable: .windSpeed, aggregation: .maximum, altitude: 10)
         case .windspeed_10m_mean:
-            return .init(variable: .windspeed, aggregation: .mean, altitude: 10)
+            return .init(variable: .windSpeed, aggregation: .mean, altitude: 10)
         case .windspeed_10m_min:
-            return .init(variable: .windspeed, aggregation: .minimum, altitude: 10)
+            return .init(variable: .windSpeed, aggregation: .minimum, altitude: 10)
         case .wet_bulb_temperature_2m_max:
             return .init(variable: .wetBulbTemperature, aggregation: .maximum, altitude: 2)
         case .wet_bulb_temperature_2m_mean:

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffersWriter.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffersWriter.swift
@@ -30,7 +30,7 @@ extension ForecastapiResult {
                 //try await b.flushIfRequired()
                 for location in results {
                     for model in location.results {
-                        try Model.writeToFlatbuffer(section: model, &fbb, timezone: location.timezone, fixedGenerationTime: fixedGenerationTime)
+                        try model.writeToFlatbuffer(&fbb, timezone: location.timezone, fixedGenerationTime: fixedGenerationTime)
                         b.buffer.writeBytes(fbb.buffer.unsafeRawBufferPointer)
                         fbb.clear()
                         try await b.flushIfRequired()
@@ -52,116 +52,133 @@ fileprivate extension FlatBuffers.ByteBuffer {
     }
 }
 
-extension ForecastapiResult {
-    /// Encodes daily data to eigher `ValuesAndUnit` or `ValuesInt64AndUnit` for timestamps (e.g. sunrise/set)
-    static func encode(section: ApiSection<Model.DailyVariable>, _ fbb: inout FlatBufferBuilder) -> [Offset] {
-        let offsets: [Offset] = section.columns.map { v in
-            switch v.variables[0] {
-            case .float(let float):
-                return openmeteo_sdk_ValuesAndUnit.createValuesAndUnit(&fbb, valuesVectorOffset: fbb.createVector(float), unit: v.unit)
-            case .timestamp(let time):
-                return openmeteo_sdk_ValuesInt64AndUnit.createValuesInt64AndUnit(&fbb, valuesVectorOffset: fbb.createVector(time.map({$0.timeIntervalSince1970})), unit: v.unit)
-            }
-        }
-        return offsets
+/// Encode meta data for flatbuffer variables
+struct FlatBufferVariableMeta {
+    let variable: openmeteo_sdk_Variable
+    let aggregation: openmeteo_sdk_Aggregation
+    let altitude: Int16
+    let pressureLevel: Int16
+    let depth: Int16
+    let depthTo: Int16
+    
+    init(variable: openmeteo_sdk_Variable, aggregation: openmeteo_sdk_Aggregation = .none_, altitude: Int16 = 0, pressureLevel: Int16 = 0, depth: Int16 = 0, depthTo: Int16 = 0) {
+        self.variable = variable
+        self.aggregation = aggregation
+        self.altitude = altitude
+        self.pressureLevel = pressureLevel
+        self.depth = depth
+        self.depthTo = depthTo
     }
     
-    /// Encodes hourly/minutely data
-    static func encode(section: ApiSection<SurfaceAndPressureVariable>, _ fbb: inout FlatBufferBuilder) -> (surface: [(variable: Model.HourlyVariable, offset: Offset)], pressure: [(variable: Model.HourlyPressureType, offset: Offset)]) {
-        var surfaces = [(variable: Model.HourlyVariable, offset: Offset)]()
-        surfaces.reserveCapacity(section.columns.count)
-        var pressures = [(variable: Model.HourlyPressureType, unit: SiUnit, offsets: [Offset])]()
-        
-        for v in section.columns {
-            switch v.variable {
-            case .surface(let surface):
-                let offset = openmeteo_sdk_ValuesAndUnit.createValuesAndUnit(&fbb, valuesVectorOffset: v.variables[0].expectFloatArray(&fbb), unit: v.unit)
-                surfaces.append((surface, offset))
-            case .pressure(let pressure):
-                let offset = openmeteo_sdk_ValuesAndLevel.createValuesAndLevel(&fbb, level: Int32(pressure.level), valuesVectorOffset: v.variables[0].expectFloatArray(&fbb))
-                if let pos = pressures.firstIndex(where: {$0.variable == pressure.variable}) {
-                    pressures[pos].offsets.append(offset)
-                } else {
-                    pressures.append((pressure.variable, v.unit, [offset]))
-                }
-            }
-        }
-        
-        let pressureVectors: [(variable: Model.HourlyPressureType, offset: Offset)] = pressures.map { (variable, unit, offsets) in
-            return (variable, openmeteo_sdk_ValuesUnitPressureLevel.createValuesUnitPressureLevel(&fbb, unit: unit, valuesVectorOffset: fbb.createVector(ofOffsets: offsets)))
-        }
-        
-        return (surfaces, pressureVectors)
+    fileprivate func encodeToFlatBuffers(_ fbb: inout FlatBufferBuilder) {
+        openmeteo_sdk_Series.add(variable: variable, &fbb)
+        openmeteo_sdk_Series.add(aggregation: aggregation, &fbb)
+        openmeteo_sdk_Series.add(altitude: altitude, &fbb)
+        openmeteo_sdk_Series.add(pressureLevel: pressureLevel, &fbb)
+        openmeteo_sdk_Series.add(depth: depth, &fbb)
+        openmeteo_sdk_Series.add(depthTo: depthTo, &fbb)
     }
-    
-    /// Encode hourly variable for surface and pressure variables
-    static func encodeEnsemble(section: ApiSection<SurfaceAndPressureVariable>, _ fbb: inout FlatBufferBuilder) -> (surface: [(variable: Model.HourlyVariable, offset: Offset)], pressure: [(variable: Model.HourlyPressureType, offset: Offset)]) {
-        var surfaces = [(variable: Model.HourlyVariable, offset: Offset)]()
-        surfaces.reserveCapacity(section.columns.count)
-        var pressures = [(variable: Model.HourlyPressureType, unit: SiUnit, offsets: [Offset])]()
-        
-        for v in section.columns {
-            switch v.variable {
-            case .surface(let surface):
-                let oo = v.variables.enumerated().map { (member, data) in
-                    return openmeteo_sdk_ValuesAndMember.createValuesAndMember(&fbb, member: Int32(member + Model.memberOffset), valuesVectorOffset: data.expectFloatArray(&fbb))
-                }
-                let offset = openmeteo_sdk_ValuesUnitAndMember.createValuesUnitAndMember(&fbb, unit: v.unit, valuesVectorOffset: fbb.createVector(ofOffsets: oo))
-                surfaces.append((surface, offset))
-            case .pressure(let pressure):
-                let oo = v.variables.enumerated().map { (member, data) in
-                    return openmeteo_sdk_ValuesAndMember.createValuesAndMember(&fbb, member: Int32(member + Model.memberOffset), valuesVectorOffset: data.expectFloatArray(&fbb))
-                }
-                let offset = openmeteo_sdk_ValuesAndLevelAndMember.createValuesAndLevelAndMember(&fbb, level: Int32(pressure.level), valuesVectorOffset: fbb.createVector(ofOffsets: oo))
-                if let pos = pressures.firstIndex(where: {$0.variable == pressure.variable}) {
-                    pressures[pos].offsets.append(offset)
-                } else {
-                    pressures.append((pressure.variable, v.unit, [offset]))
-                }
-            }
+}
+
+extension VariableOrDerived: FlatBuffersVariable where Raw: FlatBuffersVariable, Derived: FlatBuffersVariable {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+        switch self {
+        case .raw(let raw):
+            return raw.getFlatBuffersMeta()
+        case .derived(let derived):
+            return derived.getFlatBuffersMeta()
         }
-        
-        let pressureVectors: [(variable: Model.HourlyPressureType, offset: Offset)] = pressures.map { (variable, unit, offsets) in
-            return (variable, openmeteo_sdk_ValuesUnitPressureLevelAndMember.createValuesUnitPressureLevelAndMember(&fbb, unit: unit, valuesVectorOffset: fbb.createVector(ofOffsets: offsets)))
-        }
-        
-        return (surfaces, pressureVectors)
-    }
-    
-    /// Encodes daily data to eigher `ValuesAndUnit` or just plain `int64` for timestamps (e.g. sunrise/set)
-    static func encodeEnsemble(section: ApiSection<Model.DailyVariable>, _ fbb: inout FlatBufferBuilder) -> [Offset] {
-        let offsets: [Offset] = section.columns.map { v in
-            let oo = v.variables.enumerated().map { (member, array) in
-                switch array {
-                case .float(let float):
-                    return openmeteo_sdk_ValuesAndMember.createValuesAndMember(&fbb, member: Int32(member + Model.memberOffset), valuesVectorOffset: fbb.createVector(float))
-                case .timestamp(let time):
-                    return fbb.createVector(time.map({$0.timeIntervalSince1970}))
-                }
-            }
-            return openmeteo_sdk_ValuesUnitAndMember.createValuesUnitAndMember(&fbb, unit: v.unit, valuesVectorOffset: fbb.createVector(ofOffsets: oo))
-        }
-        return offsets
     }
 }
 
 extension ApiArray {
-    func expectFloatArray(_ fbb: inout FlatBuffers.FlatBufferBuilder) -> Offset {
+    func encodeFlatBuffers(_ fbb: inout FlatBufferBuilder) -> Offset {
         switch self {
-        case .float(let array):
-            return fbb.createVector(array)
-        case .timestamp(_):
-            fatalError("Expected float array and not timestamps")
+        case .float(let values):
+            return fbb.createVector(values)
+        case .timestamp(let values):
+            return fbb.createVector(values.map({Int64($0.timeIntervalSince1970)}))
         }
     }
 }
 
-extension ApiSection {
-    func timeFlatBuffers() -> openmeteo_sdk_TimeRange {
-        return .init(
+extension ApiSection where Variable: FlatBuffersVariable {
+    func encodeFlatBuffers(_ fbb: inout FlatBufferBuilder, memberOffset: Int) -> Offset {
+        let offsets = fbb.createVector(ofOffsets: self.columns.flatMap { c -> [Offset] in
+            return c.variables.enumerated().map { (member,v) in
+                let data = v.encodeFlatBuffers(&fbb)
+                let series = openmeteo_sdk_Series.startSeries(&fbb)
+                c.variable.getFlatBuffersMeta().encodeToFlatBuffers(&fbb)
+                openmeteo_sdk_Series.add(unit: c.unit, &fbb)
+                if c.variables.count > 1 {
+                    openmeteo_sdk_Series.add(ensembleMember: Int16(member + memberOffset), &fbb)
+                }
+                switch v {
+                case .float(_):
+                    openmeteo_sdk_Series.addVectorOf(values: data, &fbb)
+                case .timestamp(_):
+                    openmeteo_sdk_Series.addVectorOf(valuesInt64: data, &fbb)
+                }
+                return openmeteo_sdk_Series.endSeries(&fbb, start: series)
+            }
+        })
+        return openmeteo_sdk_SeriesAndTime.createSeriesAndTime(
+            &fbb,
             start: Int64(time.range.lowerBound.timeIntervalSince1970),
             end: Int64(time.range.upperBound.timeIntervalSince1970),
-            interval: Int32(Int64(time.dtSeconds))
+            interval: Int32(time.dtSeconds), 
+            seriesVectorOffset: offsets
         )
     }
 }
+
+extension ApiSectionSingle where Variable: FlatBuffersVariable {
+    func encodeFlatBuffers(_ fbb: inout FlatBufferBuilder) -> Offset {
+        let offsets = fbb.createVector(ofOffsets: self.columns.map { c -> Offset in
+            let series = openmeteo_sdk_Series.startSeries(&fbb)
+            c.variable.getFlatBuffersMeta().encodeToFlatBuffers(&fbb)
+            openmeteo_sdk_Series.add(unit: c.unit, &fbb)
+            openmeteo_sdk_Series.add(value: c.value, &fbb)
+            return openmeteo_sdk_Series.endSeries(&fbb, start: series)
+        })
+        return openmeteo_sdk_SeriesAndTime.createSeriesAndTime(
+            &fbb,
+            start: Int64(time.timeIntervalSince1970),
+            end: Int64(time.timeIntervalSince1970 + dtSeconds),
+            interval: Int32(dtSeconds),
+            seriesVectorOffset: offsets
+        )
+    }
+}
+
+extension ForecastapiResult.PerModel {
+    func writeToFlatbuffer(_ fbb: inout FlatBufferBuilder, timezone: TimezoneWithOffset, fixedGenerationTime: Double?) throws {
+        let generationTimeStart = Date()
+        let hourly = (try hourly?()).map { $0.encodeFlatBuffers(&fbb, memberOffset: Model.memberOffset) } ?? Offset()
+        let minutely15 = (try minutely15?()).map { $0.encodeFlatBuffers(&fbb, memberOffset: Model.memberOffset) } ?? Offset()
+        let sixHourly = (try sixHourly?()).map { $0.encodeFlatBuffers(&fbb, memberOffset: Model.memberOffset) } ?? Offset()
+        let daily = (try daily?()).map { $0.encodeFlatBuffers(&fbb, memberOffset: Model.memberOffset) } ?? Offset()
+        let current = (try current?()).map { $0.encodeFlatBuffers(&fbb) } ?? Offset()
+        let generationTimeMs = fixedGenerationTime ?? (Date().timeIntervalSince(generationTimeStart) * 1000)
+        
+        let result = openmeteo_sdk_ApiResponse.createApiResponse (
+            &fbb,
+            latitude: latitude,
+            longitude: longitude,
+            elevation: elevation ?? .nan,
+            model: model.flatBufferModel,
+            generationtimeMs: Float32(generationTimeMs),
+            utcOffsetSeconds: Int32(timezone.utcOffsetSeconds),
+            timezoneOffset: timezone.identifier == "GMT" ? Offset() : fbb.create(string: timezone.identifier),
+            timezoneAbbreviationOffset: timezone.abbreviation == "GMT" ? Offset() : fbb.create(string: timezone.abbreviation),
+            currentOffset: current, 
+            dailyOffset: daily,
+            hourlyOffset: hourly,
+            sixHourlyOffset: sixHourly,
+            minutely15Offset: minutely15
+        )
+        fbb.finish(offset: result, addPrefix: true)
+    }
+}
+
+

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffersWriter.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffersWriter.swift
@@ -166,16 +166,15 @@ extension ForecastapiResult.PerModel {
             latitude: latitude,
             longitude: longitude,
             elevation: elevation ?? .nan,
+            generationTimeMilliseconds: Float32(generationTimeMs),
             model: model.flatBufferModel,
-            generationtimeMs: Float32(generationTimeMs),
             utcOffsetSeconds: Int32(timezone.utcOffsetSeconds),
             timezoneOffset: timezone.identifier == "GMT" ? Offset() : fbb.create(string: timezone.identifier),
             timezoneAbbreviationOffset: timezone.abbreviation == "GMT" ? Offset() : fbb.create(string: timezone.abbreviation),
             currentOffset: current, 
             dailyOffset: daily,
             hourlyOffset: hourly,
-            sixHourlyOffset: sixHourly,
-            minutely15Offset: minutely15
+            minutely15Offset: minutely15, sixHourlyOffset: sixHourly
         )
         fbb.finish(offset: result, addPrefix: true)
     }

--- a/Sources/App/Helper/ForecastapiQuery.swift
+++ b/Sources/App/Helper/ForecastapiQuery.swift
@@ -311,7 +311,7 @@ enum Timeformat: String, Codable {
         case .iso8601:
             return .iso8601
         case .unixtime:
-            return .unixtime
+            return .unixTime
         }
     }
 }

--- a/Sources/App/Helper/ForecastapiQuery.swift
+++ b/Sources/App/Helper/ForecastapiQuery.swift
@@ -18,6 +18,7 @@ struct ApiQueryParameter: Content, ApiUnitsSelectable {
     let timezone: [String]?
     let temperature_unit: TemperatureUnit?
     let windspeed_unit: WindspeedUnit?
+    let wind_speed_unit: WindspeedUnit?
     let precipitation_unit: PrecipitationUnit?
     let length_unit: LengthUnit?
     let timeformat: Timeformat?

--- a/Sources/App/Helper/ForecastapiQuery.swift
+++ b/Sources/App/Helper/ForecastapiQuery.swift
@@ -15,6 +15,7 @@ struct ApiQueryParameter: Content, ApiUnitsSelectable {
     let six_hourly: [String]?
     let current_weather: Bool?
     let elevation: [String]?
+    let location_id: [String]?
     let timezone: [String]?
     let temperature_unit: TemperatureUnit?
     let windspeed_unit: WindspeedUnit?
@@ -146,19 +147,35 @@ struct ApiQueryParameter: Content, ApiUnitsSelectable {
         let latitude = try Float.load(commaSeparated: self.latitude)
         let longitude = try Float.load(commaSeparated: self.longitude)
         let elevation = try Float.load(commaSeparatedOptional: self.elevation)
+        let locationIds = try Int.load(commaSeparatedOptional: self.location_id)
         guard latitude.count == longitude.count else {
             throw ForecastapiError.latitudeAndLongitudeCountMustBeTheSame
+        }
+        if let locationIds {
+            guard locationIds.count == longitude.count else {
+                throw ForecastapiError.latitudeAndLongitudeCountMustBeTheSame
+            }
         }
         if let elevation {
             guard elevation.count == longitude.count else {
                 throw ForecastapiError.coordinatesAndElevationCountMustBeTheSame
             }
-            return try zip(latitude, zip(longitude, elevation)).map({
-                try CoordinatesAndElevation(latitude: $0.0, longitude: $0.1.0, elevation: $0.1.1)
+            return try zip(latitude, zip(longitude, elevation)).enumerated().map({
+                try CoordinatesAndElevation(
+                    latitude: $0.element.0,
+                    longitude: $0.element.1.0,
+                    locationId: locationIds?[$0.offset] ?? $0.offset,
+                    elevation: $0.element.1.1
+                )
             })
         }
-        return try zip(latitude, longitude).map({
-            try CoordinatesAndElevation(latitude: $0.0, longitude: $0.1, elevation: nil)
+        return try zip(latitude, longitude).enumerated().map({
+            try CoordinatesAndElevation(
+                latitude: $0.element.0,
+                longitude: $0.element.1,
+                locationId: locationIds?[$0.offset] ?? $0.offset,
+                elevation: nil
+            )
         })
     }
     
@@ -217,6 +234,7 @@ enum ForecastapiError: Error {
     case latitudeAndLongitudeNotEmpty
     case latitudeAndLongitudeMaximum(max: Int)
     case latitudeAndLongitudeCountMustBeTheSame
+    case locationIdCountMustBeTheSame
     case startAndEndDateCountMustBeTheSame
     case coordinatesAndStartEndDatesCountMustBeTheSame
     case coordinatesAndElevationCountMustBeTheSame
@@ -262,6 +280,8 @@ extension ForecastapiError: AbortError {
             return "Parameter 'latitude' and 'longitude' must not exceed \(max) coordinates."
         case .latitudeAndLongitudeCountMustBeTheSame:
             return "Parameter 'latitude' and 'longitude' must have the same number of elements"
+        case .locationIdCountMustBeTheSame:
+            return "Parameter 'location_id' and coordinates must have the same number of elements"
         case .noDataAvilableForThisLocation:
             return "No data is available for this location"
         case .startAndEndDateCountMustBeTheSame:
@@ -282,9 +302,10 @@ struct CoordinatesAndElevation {
     let latitude: Float
     let longitude: Float
     let elevation: Float
+    let locationId: Int
     
     /// If elevation is `nil` it will resolve it from DEM. If `NaN` it stays `NaN`.
-    init(latitude: Float, longitude: Float, elevation: Float? = .nan) throws {
+    init(latitude: Float, longitude: Float, locationId: Int, elevation: Float? = .nan) throws {
         if latitude > 90 || latitude < -90 || latitude.isNaN {
             throw ForecastapiError.latitudeMustBeInRangeOfMinus90to90(given: latitude)
         }
@@ -294,6 +315,7 @@ struct CoordinatesAndElevation {
         self.latitude = latitude
         self.longitude = longitude
         self.elevation = try elevation ?? Dem90.read(lat: latitude, lon: longitude)
+        self.locationId = locationId
     }
 }
 

--- a/Sources/App/Helper/GenericDailyCalculator.swift
+++ b/Sources/App/Helper/GenericDailyCalculator.swift
@@ -85,7 +85,7 @@ extension GenericReaderMulti {
                 return nil
             }
             // 3600s only for hourly data of source
-            return DataAndUnit(data.data.map({$0*0.0036}).sum(by: 24).round(digits: 2), .megaJoulesPerSquareMeter)
+            return DataAndUnit(data.data.map({$0*0.0036}).sum(by: 24).round(digits: 2), .megajoulePerSquareMetre)
         case .precipitationHours(let variable):
             guard let data = try get(variable: variable, time: time)?.convertAndRound(params: params) else {
                 return nil

--- a/Sources/App/Helper/Intrinsics/Enums.swift
+++ b/Sources/App/Helper/Intrinsics/Enums.swift
@@ -81,3 +81,25 @@ extension Float {
         return try load(commaSeparated: commaSeparatedOptional)
     }
 }
+
+extension Int {
+    /// Initialise from string array and also decode comas
+    static func load(commaSeparated: [String]) throws -> [Int] {
+        return try commaSeparated.flatMap({ s in
+            try s.split(separator: ",").map {
+                guard let v = Int($0) else {
+                    throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Cannot initialize \(Self.self) from invalid String value \(s)", underlyingError: nil))
+                }
+                return v
+            }
+        })
+    }
+    
+    /// Initialise from string array and also decode comas
+    static func load(commaSeparatedOptional: [String]?) throws -> [Self]? {
+        guard let commaSeparatedOptional else {
+            return nil
+        }
+        return try load(commaSeparated: commaSeparatedOptional)
+    }
+}

--- a/Sources/App/Helper/Reader/GenericReader.swift
+++ b/Sources/App/Helper/Reader/GenericReader.swift
@@ -94,7 +94,7 @@ struct GenericReader<Domain: GenericDomain, Variable: GenericVariable>: GenericR
         
         /// Scale pascal to hecto pasal. Case in era5
         if variable.unit == .pascal {
-            return DataAndUnit(data.map({$0 / 100}), .hectoPascal)
+            return DataAndUnit(data.map({$0 / 100}), .hectopascal)
         }
         
         if variable.isElevationCorrectable && variable.unit == .celsius && !modelElevation.numeric.isNaN && !targetElevation.isNaN && targetElevation != modelElevation.numeric {

--- a/Sources/App/Helper/SiUnit.swift
+++ b/Sources/App/Helper/SiUnit.swift
@@ -64,37 +64,37 @@ struct DataAndUnit {
             }
             unit = .fahrenheit
         }
-        if unit == .ms && windspeedUnit == .kmh {
+        if unit == .metrePerSecond && windspeedUnit == .kmh {
             for i in data.indices {
                 data[i] *= 3.6
             }
-            unit = .kmh
+            unit = .kilometresPerHour
         }
-        if unit == .ms && windspeedUnit == .mph {
+        if unit == .metrePerSecond && windspeedUnit == .mph {
             for i in data.indices {
                 data[i] *= 2.237
             }
-            unit = .mph
+            unit = .milesPerHour
         }
-        if unit == .ms && windspeedUnit == .kn {
+        if unit == .metrePerSecond && windspeedUnit == .kn {
             for i in data.indices {
                 data[i] *= 1.94384
             }
             unit = .knots
         }
-        if unit == .millimeter && precipitationUnit == .inch {
+        if unit == .millimetre && precipitationUnit == .inch {
             for i in data.indices {
                 data[i] /= 25.4
             }
             unit = .inch
         }
-        if unit == .centimeter && precipitationUnit == .inch {
+        if unit == .centimetre && precipitationUnit == .inch {
             for i in data.indices {
                 data[i] /= 2.54
             }
             unit = .inch
         }
-        if unit == .meter && precipitationUnit == .inch {
+        if unit == .metre && precipitationUnit == .inch {
             for i in data.indices {
                 data[i] *= 3.280839895
             }

--- a/Sources/App/Helper/SiUnit.swift
+++ b/Sources/App/Helper/SiUnit.swift
@@ -28,6 +28,7 @@ enum LengthUnit: String, Codable {
 struct ApiUnits: ApiUnitsSelectable {
     let temperature_unit: TemperatureUnit?
     let windspeed_unit: WindspeedUnit?
+    let wind_speed_unit: WindspeedUnit?
     let precipitation_unit: PrecipitationUnit?
     let length_unit: LengthUnit?
 }
@@ -35,6 +36,7 @@ struct ApiUnits: ApiUnitsSelectable {
 protocol ApiUnitsSelectable {
     var temperature_unit: TemperatureUnit? { get }
     var windspeed_unit: WindspeedUnit? { get }
+    var wind_speed_unit: WindspeedUnit? { get }
     var precipitation_unit: PrecipitationUnit? { get }
     var length_unit: LengthUnit? { get }
 }
@@ -54,7 +56,7 @@ struct DataAndUnit {
         var data = self.data
         var unit = self.unit
         
-        let windspeedUnit = params.windspeed_unit ?? .kmh
+        let windspeedUnit = params.windspeed_unit ?? params.wind_speed_unit ?? .kmh
         let temperatureUnit = params.temperature_unit
         let precipitationUnit = params.precipitation_unit ?? (params.length_unit == .imperial ? .inch : nil)
         if unit == .celsius && temperatureUnit == .fahrenheit {

--- a/Sources/App/Helper/SiUnit.swift
+++ b/Sources/App/Helper/SiUnit.swift
@@ -1,7 +1,7 @@
 import Foundation
-import enum OpenMeteoSdk.openmeteo_sdk_SiUnit
+import enum OpenMeteoSdk.openmeteo_sdk_Unit
 
-typealias SiUnit = openmeteo_sdk_SiUnit
+typealias SiUnit = openmeteo_sdk_Unit
 
 enum TemperatureUnit: String, Codable {
     case celsius

--- a/Sources/App/Helper/Writer/ForecastapiResult.swift
+++ b/Sources/App/Helper/Writer/ForecastapiResult.swift
@@ -2,17 +2,21 @@
 import Foundation
 import Vapor
 import FlatBuffers
+import OpenMeteoSdk
+
+protocol FlatBuffersVariable: RawRepresentableString {
+    func getFlatBuffersMeta() -> FlatBufferVariableMeta
+}
 
 protocol ModelFlatbufferSerialisable: RawRepresentableString {
-    associatedtype HourlyVariable: RawRepresentableString
-    associatedtype HourlyPressureType: RawRepresentableString, RawRepresentable, Equatable
-    associatedtype DailyVariable: RawRepresentableString
-    
-    //var rawValue: String { get }
-    static func writeToFlatbuffer(section: ForecastapiResult<Self>.PerModel, _ fbb: inout FlatBufferBuilder, timezone: TimezoneWithOffset, fixedGenerationTime: Double?) throws
+    associatedtype HourlyVariable: FlatBuffersVariable
+    associatedtype HourlyPressureType: FlatBuffersVariable, RawRepresentable, Equatable
+    associatedtype DailyVariable: FlatBuffersVariable
     
     /// 0=all members start at control, 1=Members start at `member01` (Used in CFSv2)
     static var memberOffset: Int { get }
+    
+    var flatBufferModel: openmeteo_sdk_Model { get }
 }
 
 extension ModelFlatbufferSerialisable {
@@ -158,7 +162,7 @@ struct ForecastapiResult<Model: ModelFlatbufferSerialisable> {
     }
 
     /// Enum with surface and pressure variable
-    enum SurfaceAndPressureVariable: RawRepresentableString {
+    enum SurfaceAndPressureVariable: RawRepresentableString, FlatBuffersVariable {
         init?(rawValue: String) {
             fatalError()
         }
@@ -174,6 +178,23 @@ struct ForecastapiResult<Model: ModelFlatbufferSerialisable> {
         
         case surface(Model.HourlyVariable)
         case pressure(PressureVariableAndLevel)
+        
+        func getFlatBuffersMeta() -> FlatBufferVariableMeta {
+            switch self {
+            case .surface(let hourlyVariable):
+                return hourlyVariable.getFlatBuffersMeta()
+            case .pressure(let pressureVariableAndLevel):
+                let meta = pressureVariableAndLevel.variable.getFlatBuffersMeta()
+                return FlatBufferVariableMeta(
+                    variable: meta.variable,
+                    aggregation: meta.aggregation,
+                    altitude: meta.altitude,
+                    pressureLevel: Int16(pressureVariableAndLevel.level),
+                    depth: meta.depth,
+                    depthTo: meta.depthTo
+                )
+            }
+        }
     }
     
     /// Output the given result set with a specified format

--- a/Sources/App/Helper/Writer/ForecastapiResult.swift
+++ b/Sources/App/Helper/Writer/ForecastapiResult.swift
@@ -58,6 +58,7 @@ struct ForecastapiResult<Model: ModelFlatbufferSerialisable> {
     struct PerLocation {
         let timezone: TimezoneWithOffset
         let time: TimerangeLocal
+        let locationId: Int
         let results: [PerModel]
         
         var utc_offset_seconds: Int {

--- a/Sources/App/Helper/Writer/JsonWriter.swift
+++ b/Sources/App/Helper/Writer/JsonWriter.swift
@@ -79,7 +79,7 @@ extension ForecastapiResult.PerLocation {
             case .iso8601:
                 b.buffer.writeString("\"time\":\"\(SiUnit.iso8601.abbreviation)\"")
             case .unixtime:
-                b.buffer.writeString("\"time\":\"\(SiUnit.unixtime.abbreviation)\"")
+                b.buffer.writeString("\"time\":\"\(SiUnit.unixTime.abbreviation)\"")
             }
             b.buffer.writeString(",\"interval\":\"seconds\"")
             for e in current.columns {
@@ -109,7 +109,7 @@ extension ForecastapiResult.PerLocation {
             case .iso8601:
                 b.buffer.writeString("\"time\":\"\(SiUnit.iso8601.abbreviation)\"")
             case .unixtime:
-                b.buffer.writeString("\"time\":\"\(SiUnit.unixtime.abbreviation)\"")
+                b.buffer.writeString("\"time\":\"\(SiUnit.unixTime.abbreviation)\"")
             }
             for e in section.columns {
                 b.buffer.writeString(",\"\(e.variable)\":\"\(e.unit.abbreviation)\"")

--- a/Sources/App/Helper/Writer/XlsxWriter.swift
+++ b/Sources/App/Helper/Writer/XlsxWriter.swift
@@ -22,13 +22,13 @@ extension ForecastapiResult {
         sheet.write("timezone_abbreviation")
         sheet.endRow()
         
-        for (i, location) in results.enumerated() {
+        for location in results {
             sheet.startRow()
             guard let first = location.results.first else {
                 continue
             }
             if multiLocation {
-                sheet.write(i+1)
+                sheet.write(location.locationId)
             }
             sheet.write(first.latitude, significantDigits: 4)
             sheet.write(first.longitude, significantDigits: 4)
@@ -38,20 +38,20 @@ extension ForecastapiResult {
             sheet.write(location.timezone.abbreviation)
             sheet.endRow()
         }
-        for (i, location) in results.enumerated() {
-            try location.current?().writeXlsx(into: sheet, utc_offset_seconds: location.utc_offset_seconds, location_id: multiLocation ? i : nil)
+        for location in results {
+            try location.current?().writeXlsx(into: sheet, utc_offset_seconds: location.utc_offset_seconds, location_id: multiLocation ? location.locationId : nil)
         }
-        for (i, location) in results.enumerated() {
-            try location.minutely15?().writeXlsx(into: sheet, utc_offset_seconds: location.utc_offset_seconds, location_id: multiLocation ? i : nil)
+        for location in results {
+            try location.minutely15?().writeXlsx(into: sheet, utc_offset_seconds: location.utc_offset_seconds, location_id: multiLocation ? location.locationId : nil)
         }
-        for (i, location) in results.enumerated() {
-            try location.hourly?().writeXlsx(into: sheet, utc_offset_seconds: location.utc_offset_seconds, location_id: multiLocation ? i : nil)
+        for location in results {
+            try location.hourly?().writeXlsx(into: sheet, utc_offset_seconds: location.utc_offset_seconds, location_id: multiLocation ? location.locationId : nil)
         }
-        for (i, location) in results.enumerated() {
-            try location.sixHourly?().writeXlsx(into: sheet, utc_offset_seconds: location.utc_offset_seconds, location_id: multiLocation ? i : nil)
+        for location in results {
+            try location.sixHourly?().writeXlsx(into: sheet, utc_offset_seconds: location.utc_offset_seconds, location_id: multiLocation ? location.locationId : nil)
         }
-        for (i, location) in results.enumerated() {
-            try location.daily?().writeXlsx(into: sheet, utc_offset_seconds: location.utc_offset_seconds, location_id: multiLocation ? i : nil)
+        for location in results {
+            try location.daily?().writeXlsx(into: sheet, utc_offset_seconds: location.utc_offset_seconds, location_id: multiLocation ? location.locationId : nil)
         }
         
         let data = sheet.write(timestamp: timestamp)
@@ -81,7 +81,7 @@ extension ApiSectionString {
         for (i, time) in time.enumerated() {
             sheet.startRow()
             if let location_id {
-                sheet.write(location_id + 1)
+                sheet.write(location_id)
             }
             sheet.writeTimestamp(time.add(utc_offset_seconds))
             for e in columns {
@@ -115,7 +115,7 @@ extension ApiSectionSingle {
 
         sheet.startRow()
         if let location_id {
-            sheet.write(location_id + 1)
+            sheet.write(location_id)
         }
         sheet.writeTimestamp(time.add(utc_offset_seconds))
         for e in columns {

--- a/Sources/App/Icon/IconController.swift
+++ b/Sources/App/Icon/IconController.swift
@@ -40,6 +40,11 @@ enum IconPressureVariableDerivedType: String, CaseIterable {
     case winddirection
     case dewpoint
     case cloudcover
+    case wind_speed
+    case wind_direction
+    case dew_point
+    case cloud_cover
+    case relative_humidity
 }
 
 /**
@@ -58,8 +63,9 @@ typealias IconVariableDerived = SurfaceAndPressureVariable<IconSurfaceVariableDe
 
 enum IconSurfaceVariableDerived: String, CaseIterable, GenericVariableMixable {
     case apparent_temperature
-    case relativehumidity_2m
+    case relative_humidity_2m
     case dewpoint_2m
+    case dew_point_2m
     case windspeed_10m
     case winddirection_10m
     case windspeed_80m
@@ -68,9 +74,18 @@ enum IconSurfaceVariableDerived: String, CaseIterable, GenericVariableMixable {
     case winddirection_120m
     case windspeed_180m
     case winddirection_180m
+    case wind_speed_10m
+    case wind_direction_10m
+    case wind_speed_80m
+    case wind_direction_80m
+    case wind_speed_120m
+    case wind_direction_120m
+    case wind_speed_180m
+    case wind_direction_180m
     case direct_normal_irradiance
     case evapotranspiration
     case et0_fao_evapotranspiration
+    case vapour_pressure_deficit
     case vapor_pressure_deficit
     case shortwave_radiation
     case snow_height
@@ -89,6 +104,15 @@ enum IconSurfaceVariableDerived: String, CaseIterable, GenericVariableMixable {
     case soil_moisture_9_to_27cm
     case soil_moisture_27_to_81cm
     case wet_bulb_temperature_2m
+    case cloud_cover
+    case cloud_cover_low
+    case cloud_cover_mid
+    case cloud_cover_high
+    case weather_code
+    case sensible_heat_flux
+    case latent_heat_flux
+    case wind_gusts_10m
+    case freezing_level_height
     
     var requiresOffsetCorrectionForMixing: Bool {
         return self == .snow_height

--- a/Sources/App/Icon/IconReader.swift
+++ b/Sources/App/Icon/IconReader.swift
@@ -231,32 +231,46 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(raw: .relativehumidity_2m, member: member, time: time)
                 try prefetchData(raw: .direct_radiation, member: member, time: time)
                 try prefetchData(raw: .diffuse_radiation, member: member, time: time)
-            case .relativehumidity_2m:
+            case .relative_humidity_2m:
                 try prefetchData(raw: .relativehumidity_2m, member: member, time: time)
+            case .dew_point_2m:
+                fallthrough
             case .dewpoint_2m:
                 try prefetchData(raw: .relativehumidity_2m, member: member, time: time)
                 try prefetchData(raw: .temperature_2m, member: member, time: time)
+            case .wind_speed_10m:
+                fallthrough
             case .windspeed_10m:
-                try prefetchData(raw: .wind_u_component_10m, member: member, time: time)
-                try prefetchData(raw: .wind_v_component_10m, member: member, time: time)
+                fallthrough
+            case .wind_direction_10m:
+                fallthrough
             case .winddirection_10m:
                 try prefetchData(raw: .wind_u_component_10m, member: member, time: time)
                 try prefetchData(raw: .wind_v_component_10m, member: member, time: time)
+            case .wind_speed_80m:
+                fallthrough
             case .windspeed_80m:
-                try prefetchData(raw: .wind_u_component_80m, member: member, time: time)
-                try prefetchData(raw: .wind_v_component_80m, member: member, time: time)
+                fallthrough
+            case .wind_direction_80m:
+                fallthrough
             case .winddirection_80m:
                 try prefetchData(raw: .wind_u_component_80m, member: member, time: time)
                 try prefetchData(raw: .wind_v_component_80m, member: member, time: time)
+            case .wind_speed_120m:
+                fallthrough
             case .windspeed_120m:
-                try prefetchData(raw: .wind_u_component_120m, member: member, time: time)
-                try prefetchData(raw: .wind_v_component_120m, member: member, time: time)
+                fallthrough
+            case .wind_direction_120m:
+                fallthrough
             case .winddirection_120m:
                 try prefetchData(raw: .wind_u_component_120m, member: member, time: time)
                 try prefetchData(raw: .wind_v_component_120m, member: member, time: time)
+            case .wind_speed_180m:
+                fallthrough
             case .windspeed_180m:
-                try prefetchData(raw: .wind_u_component_180m, member: member, time: time)
-                try prefetchData(raw: .wind_v_component_180m, member: member, time: time)
+                fallthrough
+            case .wind_direction_180m:
+                fallthrough
             case .winddirection_180m:
                 try prefetchData(raw: .wind_u_component_180m, member: member, time: time)
                 try prefetchData(raw: .wind_v_component_180m, member: member, time: time)
@@ -269,6 +283,8 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(raw: .direct_radiation, member: member, time: time)
             case .evapotranspiration:
                 try prefetchData(raw: .latent_heatflux, member: member, time: time)
+            case .vapour_pressure_deficit:
+                fallthrough
             case .vapor_pressure_deficit:
                 try prefetchData(raw: .temperature_2m, member: member, time: time)
                 try prefetchData(raw: .relativehumidity_2m, member: member, time: time)
@@ -318,19 +334,47 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
             case .wet_bulb_temperature_2m:
                 try prefetchData(raw: .temperature_2m, member: member, time: time)
                 try prefetchData(raw: .relativehumidity_2m, member: member, time: time)
+            case .cloud_cover:
+                try prefetchData(raw: .cloudcover, member: member, time: time)
+            case .cloud_cover_low:
+                try prefetchData(raw: .cloudcover_low, member: member, time: time)
+            case .cloud_cover_mid:
+                try prefetchData(raw: .cloudcover_mid, member: member, time: time)
+            case .cloud_cover_high:
+                try prefetchData(raw: .cloudcover_high, member: member, time: time)
+            case .weather_code:
+                try prefetchData(raw: .weathercode, member: member, time: time)
+            case .sensible_heat_flux:
+                try prefetchData(raw: .sensible_heatflux, member: member, time: time)
+            case .latent_heat_flux:
+                try prefetchData(raw: .latent_heatflux, member: member, time: time)
+            case .wind_gusts_10m:
+                try prefetchData(raw: .windgusts_10m, member: member, time: time)
+            case .freezing_level_height:
+                try prefetchData(raw: .freezinglevel_height, member: member, time: time)
             }
         case .pressure(let variable):
             let level = variable.level
             switch variable.variable {
+            case .wind_speed:
+                fallthrough
             case .windspeed:
+                fallthrough
+            case .wind_direction:
                 fallthrough
             case .winddirection:
                 try prefetchData(raw: IconPressureVariable(variable: .wind_u_component, level: level), member: member, time: time)
                 try prefetchData(raw: IconPressureVariable(variable: .wind_v_component, level: level), member: member, time: time)
+            case .dew_point:
+                fallthrough
             case .dewpoint:
                 try prefetchData(raw: IconPressureVariable(variable: .temperature, level: level), member: member, time: time)
                 try prefetchData(raw: IconPressureVariable(variable: .relativehumidity, level: level), member: member, time: time)
+            case .cloud_cover:
+                fallthrough
             case .cloudcover:
+                try prefetchData(raw: IconPressureVariable(variable: .relativehumidity, level: level), member: member, time: time)
+            case .relative_humidity:
                 try prefetchData(raw: IconPressureVariable(variable: .relativehumidity, level: level), member: member, time: time)
             }
         }
@@ -342,41 +386,57 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
         switch derived.variable {
         case .surface(let variable):
             switch variable {
+            case .wind_speed_10m:
+                fallthrough
             case .windspeed_10m:
                 let u = try get(raw: .wind_u_component_10m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_10m, member: member, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
+            case .wind_direction_10m:
+                fallthrough
             case .winddirection_10m:
                 let u = try get(raw: .wind_u_component_10m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_10m, member: member, time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
+            case .wind_speed_80m:
+                fallthrough
             case .windspeed_80m:
                 let u = try get(raw: .wind_u_component_80m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_80m, member: member, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
+            case .wind_direction_80m:
+                fallthrough
             case .winddirection_80m:
                 let u = try get(raw: .wind_u_component_80m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_80m, member: member, time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
+            case .wind_speed_120m:
+                fallthrough
             case .windspeed_120m:
                 let u = try get(raw: .wind_u_component_120m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_120m, member: member, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
+            case .wind_direction_120m:
+                fallthrough
             case .winddirection_120m:
                 let u = try get(raw: .wind_u_component_120m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_120m, member: member, time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
+            case .wind_speed_180m:
+                fallthrough
             case .windspeed_180m:
                 let u = try get(raw: .wind_u_component_180m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_180m, member: member, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
+            case .wind_direction_180m:
+                fallthrough
             case .winddirection_180m:
                 let u = try get(raw: .wind_u_component_180m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_180m, member: member, time: time).data
@@ -387,7 +447,7 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
             case .apparent_temperature:
                 let windspeed = try get(derived: .init(.surface(.windspeed_10m), member), time: time).data
                 let temperature = try get(raw: .temperature_2m, member: member, time: time).data
-                let relhum = try get(derived: .init(.surface(.relativehumidity_2m), member), time: time).data
+                let relhum = try get(derived: .init(.surface(.relative_humidity_2m), member), time: time).data
                 let radiation = try get(derived: .init(.surface(.shortwave_radiation), member), time: time).data
                 return DataAndUnit(Meteorology.apparentTemperature(temperature_2m: temperature, relativehumidity_2m: relhum, windspeed_10m: windspeed, shortware_radiation: radiation), .celsius)
             case .shortwave_radiation:
@@ -399,6 +459,8 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 let latent = try get(raw: .latent_heatflux, member: member, time: time).data
                 let evapotranspiration = latent.map(Meteorology.evapotranspiration)
                 return DataAndUnit(evapotranspiration, .millimetre)
+            case .vapour_pressure_deficit:
+                fallthrough
             case .vapor_pressure_deficit:
                 let temperature = try get(raw: .temperature_2m, member: member, time: time).data
                 let rh = try get(raw: .relativehumidity_2m, member: member, time: time).data
@@ -436,8 +498,10 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                     ($0 + $1) * 0.7
                 })
                 return DataAndUnit(snowfall, SiUnit.centimetre)
-            case .relativehumidity_2m:
+            case .relative_humidity_2m:
                 return try get(raw: .relativehumidity_2m, member: member, time: time)
+            case .dew_point_2m:
+                fallthrough
             case .dewpoint_2m:
                 let temperature = try get(raw: .temperature_2m, member: member, time: time)
                 let rh = try get(raw: .relativehumidity_2m, member: member, time: time)
@@ -470,11 +534,6 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 let direct = try get(derived: .init(.surface(.direct_radiation_instant), member), time: time)
                 let dni = Zensun.calculateInstantDNI(directRadiation: direct.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
                 return DataAndUnit(dni, direct.unit)
-                
-                // because DNI is divided by cos(zenith), the approach below was not work
-                //let dni = try get(variable: .direct_normal_irradiance)
-                //let factor = Zensun.backwardsAveragedToInstantFactor(time: mixer.time, latitude: mixer.modelLat, longitude: mixer.modelLon)
-                //return DataAndUnit(zip(dni.data, factor).map(*), dni.unit)
             case .is_day:
                 return DataAndUnit(Zensun.calculateIsDay(timeRange: time, lat: reader.modelLat, lon: reader.modelLon), .dimensionlessInteger)
             case .soil_moisture_0_to_1cm:
@@ -491,27 +550,55 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 let temperature = try get(raw: .temperature_2m, member: member, time: time)
                 let rh = try get(raw: .relativehumidity_2m, member: member, time: time).data
                 return DataAndUnit(zip(temperature.data, rh).map(Meteorology.wetBulbTemperature), temperature.unit)
+            case .cloud_cover:
+                return try get(raw: .cloudcover, member: member, time: time)
+            case .cloud_cover_low:
+                return try get(raw: .cloudcover_low, member: member, time: time)
+            case .cloud_cover_mid:
+                return try get(raw: .cloudcover_mid, member: member, time: time)
+            case .cloud_cover_high:
+                return try get(raw: .cloudcover_high, member: member, time: time)
+            case .weather_code:
+                return try get(raw: .weathercode, member: member, time: time)
+            case .sensible_heat_flux:
+                return try get(raw: .sensible_heatflux, member: member, time: time)
+            case .latent_heat_flux:
+                return try get(raw: .latent_heatflux, member: member, time: time)
+            case .wind_gusts_10m:
+                return try get(raw: .windgusts_10m, member: member, time: time)
+            case .freezing_level_height:
+                return try get(raw: .freezinglevel_height, member: member, time: time)
             }
         case .pressure(let variable):
             let level = variable.level
             switch variable.variable {
+            case .wind_speed:
+                fallthrough
             case .windspeed:
                 let u = try get(raw: IconPressureVariable(variable: .wind_u_component, level: level), member: member, time: time)
                 let v = try get(raw: IconPressureVariable(variable: .wind_v_component, level: level), member: member, time: time)
                 let speed = zip(u.data,v.data).map(Meteorology.windspeed)
                 return DataAndUnit(speed, u.unit)
+            case .wind_direction:
+                fallthrough
             case .winddirection:
                 let u = try get(raw: IconPressureVariable(variable: .wind_u_component, level: level), member: member, time: time).data
                 let v = try get(raw: IconPressureVariable(variable: .wind_v_component, level: level), member: member, time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
+            case .dew_point:
+                fallthrough
             case .dewpoint:
                 let temperature = try get(raw: IconPressureVariable(variable: .temperature, level: level), member: member, time: time)
                 let rh = try get(raw: IconPressureVariable(variable: .relativehumidity, level: level), member: member, time: time)
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+            case .cloud_cover:
+                fallthrough
             case .cloudcover:
                 let rh = try get(raw: IconPressureVariable(variable: .relativehumidity, level: level), member: member, time: time)
                 return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: Float(level))}), .percentage)
+            case .relative_humidity:
+                return try get(raw: IconPressureVariable(variable: .relativehumidity, level: level), member: member, time: time)
             }
         }
     }

--- a/Sources/App/Icon/IconReader.swift
+++ b/Sources/App/Icon/IconReader.swift
@@ -55,14 +55,14 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 let precipitation = try get(raw: .precipitation, member: member, time: time).data
                 let snow_gsp = try get(raw: .snowfall_water_equivalent, member: member, time: time).data
                 let snow_con = try get(raw: .snowfall_convective_water_equivalent, member: member, time: time).data
-                return DataAndUnit(zip(precipitation, zip(snow_con, snow_gsp)).map({$0 - $1.0 - $1.1}), .millimeter)
+                return DataAndUnit(zip(precipitation, zip(snow_con, snow_gsp)).map({$0 - $1.0 - $1.1}), .millimetre)
             }
             
             // no dedicated rain field in ICON EPS and no snow, use temperautre
             if reader.domain == .iconEps, surface == .rain {
                 let precipitation = try get(raw: .precipitation, member: member, time: time).data
                 let temperature = try get(raw: .temperature_2m, member: member, time: time).data
-                return DataAndUnit(zip(precipitation, temperature).map({$0 * ($1 <= 0 ? 0 : 1)}), .millimeter)
+                return DataAndUnit(zip(precipitation, temperature).map({$0 * ($1 <= 0 ? 0 : 1)}), .millimetre)
             }
             
             // EPS models do not have weather codes
@@ -346,7 +346,7 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 let u = try get(raw: .wind_u_component_10m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_10m, member: member, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
-                return DataAndUnit(speed, .ms)
+                return DataAndUnit(speed, .metrePerSecond)
             case .winddirection_10m:
                 let u = try get(raw: .wind_u_component_10m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_10m, member: member, time: time).data
@@ -356,7 +356,7 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 let u = try get(raw: .wind_u_component_80m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_80m, member: member, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
-                return DataAndUnit(speed, .ms)
+                return DataAndUnit(speed, .metrePerSecond)
             case .winddirection_80m:
                 let u = try get(raw: .wind_u_component_80m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_80m, member: member, time: time).data
@@ -366,7 +366,7 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 let u = try get(raw: .wind_u_component_120m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_120m, member: member, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
-                return DataAndUnit(speed, .ms)
+                return DataAndUnit(speed, .metrePerSecond)
             case .winddirection_120m:
                 let u = try get(raw: .wind_u_component_120m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_120m, member: member, time: time).data
@@ -376,7 +376,7 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 let u = try get(raw: .wind_u_component_180m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_180m, member: member, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
-                return DataAndUnit(speed, .ms)
+                return DataAndUnit(speed, .metrePerSecond)
             case .winddirection_180m:
                 let u = try get(raw: .wind_u_component_180m, member: member, time: time).data
                 let v = try get(raw: .wind_v_component_180m, member: member, time: time).data
@@ -394,20 +394,20 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 let direct = try get(raw: .direct_radiation, member: member, time: time).data
                 let diffuse = try get(raw: .diffuse_radiation, member: member, time: time).data
                 let total = zip(direct, diffuse).map(+)
-                return DataAndUnit(total, .wattPerSquareMeter)
+                return DataAndUnit(total, .wattPerSquareMetre)
             case .evapotranspiration:
                 let latent = try get(raw: .latent_heatflux, member: member, time: time).data
                 let evapotranspiration = latent.map(Meteorology.evapotranspiration)
-                return DataAndUnit(evapotranspiration, .millimeter)
+                return DataAndUnit(evapotranspiration, .millimetre)
             case .vapor_pressure_deficit:
                 let temperature = try get(raw: .temperature_2m, member: member, time: time).data
                 let rh = try get(raw: .relativehumidity_2m, member: member, time: time).data
                 let dewpoint = zip(temperature,rh).map(Meteorology.dewpoint)
-                return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kiloPascal)
+                return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kilopascal)
             case .direct_normal_irradiance:
                 let dhi = try get(raw: .direct_radiation, member: member, time: time).data
                 let dni = Zensun.calculateBackwardsDNI(directRadiation: dhi, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-                return DataAndUnit(dni, .wattPerSquareMeter)
+                return DataAndUnit(dni, .wattPerSquareMetre)
             case .et0_fao_evapotranspiration:
                 let exrad = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
                 let swrad = try get(derived: .init(.surface(.shortwave_radiation),  member), time: time).data
@@ -419,7 +419,7 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 let et0 = swrad.indices.map { i in
                     return Meteorology.et0Evapotranspiration(temperature2mCelsius: temperature[i], windspeed10mMeterPerSecond: windspeed[i], dewpointCelsius: dewpoint[i], shortwaveRadiationWatts: swrad[i], elevation: reader.targetElevation, extraTerrestrialRadiation: exrad[i], dtSeconds: 3600)
                 }
-                return DataAndUnit(et0, .millimeter)
+                return DataAndUnit(et0, .millimetre)
             case .snowfall:
                 if reader.domain == .iconEps {
                     let precipitation = try get(raw: .precipitation, member: member, time: time).data
@@ -428,14 +428,14 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                     let snowfall = zip(precipitation, temperature).map({
                         $0 * ($1 < 0 ? 0.7 : 0)
                     })
-                    return DataAndUnit(snowfall, SiUnit.centimeter)
+                    return DataAndUnit(snowfall, SiUnit.centimetre)
                 }
                 let snow_gsp = try get(raw: .snowfall_water_equivalent, member: member, time: time).data
                 let snow_con = try get(raw: .snowfall_convective_water_equivalent, member: member, time: time).data
                 let snowfall = zip(snow_gsp, snow_con).map({
                     ($0 + $1) * 0.7
                 })
-                return DataAndUnit(snowfall, SiUnit.centimeter)
+                return DataAndUnit(snowfall, SiUnit.centimetre)
             case .relativehumidity_2m:
                 return try get(raw: .relativehumidity_2m, member: member, time: time)
             case .dewpoint_2m:
@@ -449,11 +449,11 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
             case .terrestrial_radiation:
                 /// Use center averaged
                 let solar = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-                return DataAndUnit(solar, .wattPerSquareMeter)
+                return DataAndUnit(solar, .wattPerSquareMetre)
             case .terrestrial_radiation_instant:
                 /// Use center averaged
                 let solar = Zensun.extraTerrestrialRadiationInstant(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-                return DataAndUnit(solar, .wattPerSquareMeter)
+                return DataAndUnit(solar, .wattPerSquareMetre)
             case .shortwave_radiation_instant:
                 let sw = try get(derived: .init(.surface(.shortwave_radiation), member), time: time)
                 let factor = Zensun.backwardsAveragedToInstantFactor(time: time, latitude: reader.modelLat, longitude: reader.modelLon)
@@ -511,7 +511,7 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
             case .cloudcover:
                 let rh = try get(raw: IconPressureVariable(variable: .relativehumidity, level: level), member: member, time: time)
-                return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: Float(level))}), .percent)
+                return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: Float(level))}), .percentage)
             }
         }
     }

--- a/Sources/App/Icon/IconVariable.swift
+++ b/Sources/App/Icon/IconVariable.swift
@@ -61,15 +61,15 @@ struct IconPressureVariable: PressureVariableRespresentable, Hashable, GenericVa
         case .temperature:
             return .celsius
         case .wind_u_component:
-            return .ms
+            return .metrePerSecond
         case .wind_v_component:
-            return .ms
+            return .metrePerSecond
         case .geopotential_height:
-            return .meter
+            return .metre
         //case .cloudcover:
-        //    return .percent
+        //    return .percentage
         case .relativehumidity:
-            return .percent
+            return .percentage
         }
     }
     
@@ -251,42 +251,42 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
     var unit: SiUnit {
         switch self {
         case .temperature_2m: return .celsius
-        case .cloudcover: return .percent
-        case .cloudcover_low: return .percent
-        case .cloudcover_mid: return .percent
-        case .cloudcover_high: return .percent
-        case .precipitation: return .millimeter
+        case .cloudcover: return .percentage
+        case .cloudcover_low: return .percentage
+        case .cloudcover_mid: return .percentage
+        case .cloudcover_high: return .percentage
+        case .precipitation: return .millimetre
         case .weathercode: return .wmoCode
-        case .wind_v_component_10m: return .ms
-        case .wind_u_component_10m: return .ms
-        case .wind_v_component_80m: return .ms
-        case .wind_u_component_80m: return .ms
-        case .wind_v_component_120m: return .ms
-        case .wind_u_component_120m: return .ms
-        case .wind_v_component_180m: return .ms
-        case .wind_u_component_180m: return .ms
+        case .wind_v_component_10m: return .metrePerSecond
+        case .wind_u_component_10m: return .metrePerSecond
+        case .wind_v_component_80m: return .metrePerSecond
+        case .wind_u_component_80m: return .metrePerSecond
+        case .wind_v_component_120m: return .metrePerSecond
+        case .wind_u_component_120m: return .metrePerSecond
+        case .wind_v_component_180m: return .metrePerSecond
+        case .wind_u_component_180m: return .metrePerSecond
         case .soil_temperature_0cm: return .celsius
         case .soil_temperature_6cm: return .celsius
         case .soil_temperature_18cm: return .celsius
         case .soil_temperature_54cm: return .celsius
-        case .soil_moisture_0_1cm: return .qubicMeterPerQubicMeter
-        case .soil_moisture_1_3cm: return .qubicMeterPerQubicMeter
-        case .soil_moisture_3_9cm: return .qubicMeterPerQubicMeter
-        case .soil_moisture_9_27cm: return .qubicMeterPerQubicMeter
-        case .soil_moisture_27_81cm: return .qubicMeterPerQubicMeter
-        case .snow_depth: return .meter
-        case .sensible_heatflux: return .wattPerSquareMeter
-        case .latent_heatflux: return .wattPerSquareMeter
-        case .showers: return .millimeter
-        case .rain: return .millimeter
-        case .windgusts_10m: return .ms
-        case .freezinglevel_height: return .meter
-        case .relativehumidity_2m: return .percent
-        case .diffuse_radiation: return .wattPerSquareMeter
-        case .snowfall_convective_water_equivalent: return .millimeter
-        case .snowfall_water_equivalent: return .millimeter
-        case .direct_radiation: return .wattPerSquareMeter
-        case .pressure_msl: return .hectoPascal
+        case .soil_moisture_0_1cm: return .cubicMetrePerCubicMetre
+        case .soil_moisture_1_3cm: return .cubicMetrePerCubicMetre
+        case .soil_moisture_3_9cm: return .cubicMetrePerCubicMetre
+        case .soil_moisture_9_27cm: return .cubicMetrePerCubicMetre
+        case .soil_moisture_27_81cm: return .cubicMetrePerCubicMetre
+        case .snow_depth: return .metre
+        case .sensible_heatflux: return .wattPerSquareMetre
+        case .latent_heatflux: return .wattPerSquareMetre
+        case .showers: return .millimetre
+        case .rain: return .millimetre
+        case .windgusts_10m: return .metrePerSecond
+        case .freezinglevel_height: return .metre
+        case .relativehumidity_2m: return .percentage
+        case .diffuse_radiation: return .wattPerSquareMetre
+        case .snowfall_convective_water_equivalent: return .millimetre
+        case .snowfall_water_equivalent: return .millimetre
+        case .direct_radiation: return .wattPerSquareMetre
+        case .pressure_msl: return .hectopascal
         case .temperature_80m:
             return .celsius
         case .temperature_120m:
@@ -294,13 +294,13 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
         case .temperature_180m:
             return .celsius
         case .cape:
-            return .joulesPerKilogram
+            return .joulePerKilogram
         case .lightning_potential:
-            return .joulesPerKilogram
+            return .joulePerKilogram
         case .snowfall_height:
-            return .meter
+            return .metre
         case .updraft:
-            return .msNotUnitConverted
+            return .metrePerSecondNotUnitConverted
         }
     }
     

--- a/Sources/App/IconWave/IconWaveController.swift
+++ b/Sources/App/IconWave/IconWaveController.swift
@@ -97,7 +97,7 @@ struct IconWaveController {
             guard !readers.isEmpty else {
                 throw ForecastapiError.noDataAvilableForThisLocation
             }
-            return .init(timezone: timezone, time: time, results: readers)
+            return .init(timezone: timezone, time: time, locationId: coordinates.locationId, results: readers)
         }
         let result = ForecastapiResult<IconWaveDomainApi>(timeformat: params.timeformatOrDefault, results: locations)
         req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))

--- a/Sources/App/IconWave/IconWaveDomain.swift
+++ b/Sources/App/IconWave/IconWaveDomain.swift
@@ -141,29 +141,29 @@ enum IconWaveVariable: String, CaseIterable, GenericVariable, GenericVariableMix
     var unit: SiUnit {
         switch self {
         /*case .windspeed_10m:
-            return .ms
+            return .metrePerSecond
         case .winddirection_10m:
             return .degreeDirection*/
         case .wave_height:
-            return .meter
+            return .metre
         case .wave_period:
-            return .second
+            return .seconds
         case .wave_direction:
             return .degreeDirection
         case .wind_wave_height:
-            return .meter
+            return .metre
         case .wind_wave_period:
-            return .second
+            return .seconds
         case .wind_wave_peak_period:
-            return .second
+            return .seconds
         case .wind_wave_direction:
             return .degreeDirection
         case .swell_wave_height:
-            return .meter
+            return .metre
         case .swell_wave_period:
-            return .second
+            return .seconds
         case .swell_wave_peak_period:
-            return .second
+            return .seconds
         case .swell_wave_direction:
             return .degreeDirection
         }

--- a/Sources/App/JMA/JmaController.swift
+++ b/Sources/App/JMA/JmaController.swift
@@ -170,7 +170,7 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 let u = try get(raw: .wind_u_component_10m, time: time).data
                 let v = try get(raw: .wind_v_component_10m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
-                return DataAndUnit(speed, .ms)
+                return DataAndUnit(speed, .metrePerSecond)
             case .winddirection_10m:
                 let u = try get(raw: .wind_u_component_10m, time: time).data
                 let v = try get(raw: .wind_v_component_10m, time: time).data
@@ -186,7 +186,7 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 let temperature = try get(raw: .temperature_2m, time: time).data
                 let rh = try get(raw: .relativehumidity_2m, time: time).data
                 let dewpoint = zip(temperature,rh).map(Meteorology.dewpoint)
-                return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kiloPascal)
+                return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kilopascal)
             case .et0_fao_evapotranspiration:
                 let exrad = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
                 let swrad = try get(raw: .shortwave_radiation, time: time).data
@@ -198,7 +198,7 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 let et0 = swrad.indices.map { i in
                     return Meteorology.et0Evapotranspiration(temperature2mCelsius: temperature[i], windspeed10mMeterPerSecond: windspeed[i], dewpointCelsius: dewpoint[i], shortwaveRadiationWatts: swrad[i], elevation: reader.targetElevation, extraTerrestrialRadiation: exrad[i], dtSeconds: 3600)
                 }
-                return DataAndUnit(et0, .millimeter)
+                return DataAndUnit(et0, .millimetre)
             case .relativehumitidy_2m:
                 return try get(raw: .relativehumidity_2m, time: time)
             case .surface_pressure:
@@ -208,11 +208,11 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             case .terrestrial_radiation:
                 /// Use center averaged
                 let solar = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-                return DataAndUnit(solar, .wattPerSquareMeter)
+                return DataAndUnit(solar, .wattPerSquareMetre)
             case .terrestrial_radiation_instant:
                 /// Use center averaged
                 let solar = Zensun.extraTerrestrialRadiationInstant(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-                return DataAndUnit(solar, .wattPerSquareMeter)
+                return DataAndUnit(solar, .wattPerSquareMetre)
             case .dewpoint_2m:
                 let temperature = try get(raw: .temperature_2m, time: time)
                 let rh = try get(raw: .relativehumidity_2m, time: time)
@@ -224,7 +224,7 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             case .direct_normal_irradiance:
                 let dhi = try get(derived: .surface(.direct_radiation), time: time).data
                 let dni = Zensun.calculateBackwardsDNI(directRadiation: dhi, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-                return DataAndUnit(dni, .wattPerSquareMeter)
+                return DataAndUnit(dni, .wattPerSquareMetre)
             case .direct_normal_irradiance_instant:
                 let direct = try get(derived: .surface(.direct_radiation_instant), time: time)
                 let dni = Zensun.calculateInstantDNI(directRadiation: direct.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
@@ -264,7 +264,7 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             case .snowfall:
                 let temperature = try get(raw: .temperature_2m, time: time)
                 let precipitation = try get(raw: .precipitation, time: time)
-                return DataAndUnit(zip(temperature.data, precipitation.data).map({ $1 * ($0 >= 0 ? 0 : 0.7) }), .centimeter)
+                return DataAndUnit(zip(temperature.data, precipitation.data).map({ $1 * ($0 >= 0 ? 0 : 0.7) }), .centimetre)
             case .is_day:
                 return DataAndUnit(Zensun.calculateIsDay(timeRange: time, lat: reader.modelLat, lon: reader.modelLon), .dimensionlessInteger)
             case .wet_bulb_temperature_2m:
@@ -290,7 +290,7 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
             case .cloudcover:
                 let rh = try get(raw: .pressure(JmaPressureVariable(variable: .relativehumidity, level: v.level)), time: time)
-                return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: Float(v.level))}), .percent)
+                return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: Float(v.level))}), .percentage)
             }
         }
     }

--- a/Sources/App/JMA/JmaController.swift
+++ b/Sources/App/JMA/JmaController.swift
@@ -4,10 +4,13 @@ import Vapor
 
 enum JmaVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case apparent_temperature
-    case relativehumitidy_2m
+    case relative_humidity_2m
     case dewpoint_2m
+    case dew_point_2m
     case windspeed_10m
+    case wind_speed_10m
     case winddirection_10m
+    case wind_direction_10m
     case direct_normal_irradiance
     case direct_normal_irradiance_instant
     case direct_radiation
@@ -16,14 +19,20 @@ enum JmaVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case diffuse_radiation
     case shortwave_radiation_instant
     case et0_fao_evapotranspiration
+    case vapour_pressure_deficit
     case vapor_pressure_deficit
     case surface_pressure
     case terrestrial_radiation
     case terrestrial_radiation_instant
     case weathercode
+    case weather_code
     case snowfall
     case is_day
     case wet_bulb_temperature_2m
+    case cloud_cover
+    case cloud_cover_low
+    case cloud_cover_mid
+    case cloud_cover_high
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false
@@ -38,6 +47,11 @@ enum JmaPressureVariableDerivedType: String, CaseIterable {
     case winddirection
     case dewpoint
     case cloudcover
+    case wind_speed
+    case wind_direction
+    case dew_point
+    case cloud_cover
+    case relative_humidity
 }
 
 /**
@@ -92,14 +106,19 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 try prefetchData(raw: .wind_v_component_10m, time: time)
                 try prefetchData(raw: .relativehumidity_2m, time: time)
                 try prefetchData(raw: .shortwave_radiation, time: time)
-            case .relativehumitidy_2m:
+            case .relative_humidity_2m:
                 try prefetchData(raw: .relativehumidity_2m, time: time)
+            case .wind_speed_10m:
+                fallthrough
             case .windspeed_10m:
-                try prefetchData(raw: .wind_u_component_10m, time: time)
-                try prefetchData(raw: .wind_v_component_10m, time: time)
+                fallthrough
+            case .wind_direction_10m:
+                fallthrough
             case .winddirection_10m:
                 try prefetchData(raw: .wind_u_component_10m, time: time)
                 try prefetchData(raw: .wind_v_component_10m, time: time)
+            case .vapour_pressure_deficit:
+                fallthrough
             case .vapor_pressure_deficit:
                 try prefetchData(raw: .temperature_2m, time: time)
                 try prefetchData(raw: .relativehumidity_2m, time: time)
@@ -116,6 +135,8 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 break
             case .terrestrial_radiation_instant:
                 break
+            case .dew_point_2m:
+                fallthrough
             case .dewpoint_2m:
                 try prefetchData(raw: .temperature_2m, time: time)
                 try prefetchData(raw: .relativehumidity_2m, time: time)
@@ -133,6 +154,8 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 fallthrough
             case .shortwave_radiation_instant:
                 try prefetchData(raw: .shortwave_radiation, time: time)
+            case .weather_code:
+                fallthrough
             case .weathercode:
                 try prefetchData(raw: .cloudcover, time: time)
                 try prefetchData(variable: .derived(.surface(.snowfall)), time: time)
@@ -145,18 +168,36 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             case .wet_bulb_temperature_2m:
                 try prefetchData(raw: .temperature_2m, time: time)
                 try prefetchData(raw: .relativehumidity_2m, time: time)
+            case .cloud_cover:
+                try prefetchData(raw: .cloudcover, time: time)
+            case .cloud_cover_low:
+                try prefetchData(raw: .cloudcover_low, time: time)
+            case .cloud_cover_mid:
+                try prefetchData(raw: .cloudcover_mid, time: time)
+            case .cloud_cover_high:
+                try prefetchData(raw: .cloudcover_high, time: time)
             }
         case .pressure(let v):
             switch v.variable {
+            case .wind_speed:
+                fallthrough
             case .windspeed:
+                fallthrough
+            case .wind_direction:
                 fallthrough
             case .winddirection:
                 try prefetchData(raw: .pressure(JmaPressureVariable(variable: .wind_u_component, level: v.level)), time: time)
                 try prefetchData(raw: .pressure(JmaPressureVariable(variable: .wind_v_component, level: v.level)), time: time)
+            case .dew_point:
+                fallthrough
             case .dewpoint:
                 try prefetchData(raw: .pressure(JmaPressureVariable(variable: .temperature, level: v.level)), time: time)
                 try prefetchData(raw: .pressure(JmaPressureVariable(variable: .relativehumidity, level: v.level)), time: time)
+            case .cloud_cover:
+                fallthrough
             case .cloudcover:
+                fallthrough
+            case .relative_humidity:
                 try prefetchData(raw: .pressure(JmaPressureVariable(variable: .relativehumidity, level: v.level)), time: time)
             }
         }
@@ -166,11 +207,15 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
         switch derived {
         case .surface(let variableDerivedSurface):
             switch variableDerivedSurface {
+            case .wind_speed_10m:
+                fallthrough
             case .windspeed_10m:
                 let u = try get(raw: .wind_u_component_10m, time: time).data
                 let v = try get(raw: .wind_v_component_10m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
+            case .wind_direction_10m:
+                fallthrough
             case .winddirection_10m:
                 let u = try get(raw: .wind_u_component_10m, time: time).data
                 let v = try get(raw: .wind_v_component_10m, time: time).data
@@ -182,6 +227,8 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 let relhum = try get(raw: .relativehumidity_2m, time: time).data
                 let radiation = try get(raw: .shortwave_radiation, time: time).data
                 return DataAndUnit(Meteorology.apparentTemperature(temperature_2m: temperature, relativehumidity_2m: relhum, windspeed_10m: windspeed, shortware_radiation: radiation), .celsius)
+            case .vapour_pressure_deficit:
+                fallthrough
             case .vapor_pressure_deficit:
                 let temperature = try get(raw: .temperature_2m, time: time).data
                 let rh = try get(raw: .relativehumidity_2m, time: time).data
@@ -199,7 +246,7 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                     return Meteorology.et0Evapotranspiration(temperature2mCelsius: temperature[i], windspeed10mMeterPerSecond: windspeed[i], dewpointCelsius: dewpoint[i], shortwaveRadiationWatts: swrad[i], elevation: reader.targetElevation, extraTerrestrialRadiation: exrad[i], dtSeconds: 3600)
                 }
                 return DataAndUnit(et0, .millimetre)
-            case .relativehumitidy_2m:
+            case .relative_humidity_2m:
                 return try get(raw: .relativehumidity_2m, time: time)
             case .surface_pressure:
                 let temperature = try get(raw: .temperature_2m, time: time).data
@@ -213,6 +260,8 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 /// Use center averaged
                 let solar = Zensun.extraTerrestrialRadiationInstant(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
                 return DataAndUnit(solar, .wattPerSquareMetre)
+            case .dew_point_2m:
+                fallthrough
             case .dewpoint_2m:
                 let temperature = try get(raw: .temperature_2m, time: time)
                 let rh = try get(raw: .relativehumidity_2m, time: time)
@@ -245,6 +294,8 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 let diff = try get(derived: .surface(.diffuse_radiation), time: time)
                 let factor = Zensun.backwardsAveragedToInstantFactor(time: time, latitude: reader.modelLat, longitude: reader.modelLon)
                 return DataAndUnit(zip(diff.data, factor).map(*), diff.unit)
+            case .weather_code:
+                fallthrough
             case .weathercode:
                 let cloudcover = try get(raw: .cloudcover, time: time).data
                 let precipitation = try get(raw: .precipitation, time: time).data
@@ -271,26 +322,44 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 let temperature = try get(raw: .temperature_2m, time: time)
                 let rh = try get(raw: .relativehumidity_2m, time: time)
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.wetBulbTemperature), temperature.unit)
+            case .cloud_cover:
+                return try get(raw: .cloudcover, time: time)
+            case .cloud_cover_low:
+                return try get(raw: .cloudcover_low, time: time)
+            case .cloud_cover_mid:
+                return try get(raw: .cloudcover_mid, time: time)
+            case .cloud_cover_high:
+                return try get(raw: .cloudcover_high, time: time)
             }
         case .pressure(let v):
             switch v.variable {
+            case .wind_speed:
+                fallthrough
             case .windspeed:
                 let u = try get(raw: .pressure(JmaPressureVariable(variable: .wind_u_component, level: v.level)), time: time)
                 let v = try get(raw: .pressure(JmaPressureVariable(variable: .wind_v_component, level: v.level)), time: time)
                 let speed = zip(u.data,v.data).map(Meteorology.windspeed)
                 return DataAndUnit(speed, u.unit)
+            case .wind_direction:
+                fallthrough
             case .winddirection:
                 let u = try get(raw: .pressure(JmaPressureVariable(variable: .wind_u_component, level: v.level)), time: time).data
                 let v = try get(raw: .pressure(JmaPressureVariable(variable: .wind_v_component, level: v.level)), time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
+            case .dew_point:
+                fallthrough
             case .dewpoint:
                 let temperature = try get(raw: .pressure(JmaPressureVariable(variable: .temperature, level: v.level)), time: time)
                 let rh = try get(raw: .pressure(JmaPressureVariable(variable: .relativehumidity, level: v.level)), time: time)
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+            case .cloud_cover:
+                fallthrough
             case .cloudcover:
                 let rh = try get(raw: .pressure(JmaPressureVariable(variable: .relativehumidity, level: v.level)), time: time)
                 return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: Float(v.level))}), .percentage)
+            case .relative_humidity:
+                return try get(raw: .pressure(JmaPressureVariable(variable: .relativehumidity, level: v.level)), time: time)
             }
         }
     }

--- a/Sources/App/JMA/JmaDownloader.swift
+++ b/Sources/App/JMA/JmaDownloader.swift
@@ -344,25 +344,25 @@ enum JmaSurfaceVariable: String, CaseIterable, JmaVariableDownloadable, GenericV
         case .temperature_2m:
             return .celsius
         case .cloudcover:
-            return .percent
+            return .percentage
         case .cloudcover_low:
-            return .percent
+            return .percentage
         case .cloudcover_mid:
-            return .percent
+            return .percentage
         case .cloudcover_high:
-            return .percent
+            return .percentage
         case .relativehumidity_2m:
-            return .percent
+            return .percentage
         case .precipitation:
-            return .millimeter
+            return .millimetre
         case .pressure_msl:
-            return .hectoPascal
+            return .hectopascal
         case .wind_v_component_10m:
-            return .ms
+            return .metrePerSecond
         case .wind_u_component_10m:
-            return .ms
+            return .metrePerSecond
         case .shortwave_radiation:
-            return .wattPerSquareMeter
+            return .wattPerSquareMetre
         }
     }
     
@@ -469,15 +469,15 @@ struct JmaPressureVariable: PressureVariableRespresentable, JmaVariableDownloada
         case .temperature:
             return .celsius
         case .wind_u_component:
-            return .ms
+            return .metrePerSecond
         case .wind_v_component:
-            return .ms
+            return .metrePerSecond
         case .geopotential_height:
-            return .meter
+            return .metre
         case .vertical_velocity:
-            return .ms
+            return .metrePerSecond
         case .relativehumidity:
-            return .percent
+            return .percentage
         }
     }
     

--- a/Sources/App/MetNo/MetNoController.swift
+++ b/Sources/App/MetNo/MetNoController.swift
@@ -97,7 +97,7 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let temperature = try get(raw: .temperature_2m, time: time).data
             let rh = try get(raw: .relativehumidity_2m, time: time).data
             let dewpoint = zip(temperature,rh).map(Meteorology.dewpoint)
-            return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kiloPascal)
+            return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kilopascal)
         case .et0_fao_evapotranspiration:
             let exrad = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
             let swrad = try get(raw: .shortwave_radiation, time: time).data
@@ -109,7 +109,7 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let et0 = swrad.indices.map { i in
                 return Meteorology.et0Evapotranspiration(temperature2mCelsius: temperature[i], windspeed10mMeterPerSecond: windspeed[i], dewpointCelsius: dewpoint[i], shortwaveRadiationWatts: swrad[i], elevation: reader.targetElevation, extraTerrestrialRadiation: exrad[i], dtSeconds: 3600)
             }
-            return DataAndUnit(et0, .millimeter)
+            return DataAndUnit(et0, .millimetre)
         case .surface_pressure:
             let temperature = try get(raw: .temperature_2m, time: time).data
             let pressure = try get(raw: .pressure_msl, time: time)
@@ -117,11 +117,11 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
         case .terrestrial_radiation:
             /// Use center averaged
             let solar = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-            return DataAndUnit(solar, .wattPerSquareMeter)
+            return DataAndUnit(solar, .wattPerSquareMetre)
         case .terrestrial_radiation_instant:
             /// Use center averaged
             let solar = Zensun.extraTerrestrialRadiationInstant(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-            return DataAndUnit(solar, .wattPerSquareMeter)
+            return DataAndUnit(solar, .wattPerSquareMetre)
         case .dewpoint_2m:
             let temperature = try get(raw: .temperature_2m, time: time)
             let rh = try get(raw: .relativehumidity_2m, time: time)
@@ -133,7 +133,7 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
         case .direct_normal_irradiance:
             let dhi = try get(derived: .direct_radiation, time: time).data
             let dni = Zensun.calculateBackwardsDNI(directRadiation: dhi, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-            return DataAndUnit(dni, .wattPerSquareMeter)
+            return DataAndUnit(dni, .wattPerSquareMetre)
         case .direct_normal_irradiance_instant:
             let direct = try get(derived: .direct_radiation_instant, time: time)
             let dni = Zensun.calculateInstantDNI(directRadiation: direct.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
@@ -163,7 +163,7 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
         case .snowfall:
             let temperature = try get(raw: .temperature_2m, time: time)
             let precipitation = try get(raw: .precipitation, time: time)
-            return DataAndUnit(zip(temperature.data, precipitation.data).map({ $1 * ($0 >= 0 ? 0 : 0.7) }), .centimeter)
+            return DataAndUnit(zip(temperature.data, precipitation.data).map({ $1 * ($0 >= 0 ? 0 : 0.7) }), .centimetre)
         case .weathercode:
             let cloudcover = try get(raw: .cloudcover, time: time).data
             let precipitation = try get(raw: .precipitation, time: time).data

--- a/Sources/App/MetNo/MetNoController.swift
+++ b/Sources/App/MetNo/MetNoController.swift
@@ -26,7 +26,7 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             try prefetchData(raw: .windspeed_10m, time: time)
             try prefetchData(raw: .relativehumidity_2m, time: time)
             try prefetchData(raw: .shortwave_radiation, time: time)
-        case .vapor_pressure_deficit:
+        case .vapor_pressure_deficit, .vapour_pressure_deficit:
             try prefetchData(raw: .temperature_2m, time: time)
             try prefetchData(raw: .relativehumidity_2m, time: time)
         case .et0_fao_evapotranspiration:
@@ -41,7 +41,7 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             break
         case .terrestrial_radiation_instant:
             break
-        case .dewpoint_2m:
+        case .dewpoint_2m, .dew_point_2m:
             try prefetchData(raw: .temperature_2m, time: time)
             try prefetchData(raw: .relativehumidity_2m, time: time)
         case .diffuse_radiation:
@@ -67,7 +67,7 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
         case .snowfall:
             try prefetchData(raw: .temperature_2m, time: time)
             try prefetchData(raw: .precipitation, time: time)
-        case .weathercode:
+        case .weathercode, .weather_code:
             try prefetchData(raw: .cloudcover, time: time)
             try prefetchData(variable: .derived(.snowfall), time: time)
             try prefetchData(raw: .precipitation, time: time)
@@ -82,6 +82,16 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
         case .wet_bulb_temperature_2m:
             try prefetchData(raw: .temperature_2m, time: time)
             try prefetchData(raw: .relativehumidity_2m, time: time)
+        case .cloud_cover:
+            try prefetchData(raw: .cloudcover, time: time)
+        case .relative_humidity_2m:
+            try prefetchData(raw: .relativehumidity_2m, time: time)
+        case .wind_speed_10m:
+            try prefetchData(raw: .windspeed_10m, time: time)
+        case .wind_direction_10m:
+            try prefetchData(raw: .winddirection_10m, time: time)
+        case .wind_gusts_10m:
+            try prefetchData(raw: .windgusts_10m, time: time)
         }
     }
     
@@ -93,7 +103,7 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let relhum = try get(raw: .relativehumidity_2m, time: time).data
             let radiation = try get(raw: .shortwave_radiation, time: time).data
             return DataAndUnit(Meteorology.apparentTemperature(temperature_2m: temperature, relativehumidity_2m: relhum, windspeed_10m: windspeed, shortware_radiation: radiation), .celsius)
-        case .vapor_pressure_deficit:
+        case .vapor_pressure_deficit, .vapour_pressure_deficit:
             let temperature = try get(raw: .temperature_2m, time: time).data
             let rh = try get(raw: .relativehumidity_2m, time: time).data
             let dewpoint = zip(temperature,rh).map(Meteorology.dewpoint)
@@ -122,7 +132,7 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             /// Use center averaged
             let solar = Zensun.extraTerrestrialRadiationInstant(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
             return DataAndUnit(solar, .wattPerSquareMetre)
-        case .dewpoint_2m:
+        case .dewpoint_2m, .dew_point_2m:
             let temperature = try get(raw: .temperature_2m, time: time)
             let rh = try get(raw: .relativehumidity_2m, time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
@@ -164,7 +174,7 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let temperature = try get(raw: .temperature_2m, time: time)
             let precipitation = try get(raw: .precipitation, time: time)
             return DataAndUnit(zip(temperature.data, precipitation.data).map({ $1 * ($0 >= 0 ? 0 : 0.7) }), .centimetre)
-        case .weathercode:
+        case .weathercode, .weather_code:
             let cloudcover = try get(raw: .cloudcover, time: time).data
             let precipitation = try get(raw: .precipitation, time: time).data
             let snowfall = try get(derived: .snowfall, time: time).data
@@ -195,6 +205,16 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             let temperature = try get(raw: .temperature_2m, time: time)
             let rh = try get(raw: .relativehumidity_2m, time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.wetBulbTemperature), temperature.unit)
+        case .cloud_cover:
+            return try get(raw: .cloudcover, time: time)
+        case .relative_humidity_2m:
+            return try get(raw: .relativehumidity_2m, time: time)
+        case .wind_speed_10m:
+            return try get(raw: .windspeed_10m, time: time)
+        case .wind_direction_10m:
+            return try get(raw: .winddirection_10m, time: time)
+        case .wind_gusts_10m:
+            return try get(raw: .windgusts_10m, time: time)
         }
     }
 }
@@ -207,6 +227,7 @@ enum MetNoVariableDerived: String, GenericVariableMixable {
     
     case apparent_temperature
     case dewpoint_2m
+    case dew_point_2m
     case direct_normal_irradiance
     case direct_normal_irradiance_instant
     case direct_radiation
@@ -215,16 +236,23 @@ enum MetNoVariableDerived: String, GenericVariableMixable {
     case diffuse_radiation
     case shortwave_radiation_instant
     case et0_fao_evapotranspiration
+    case vapour_pressure_deficit
     case vapor_pressure_deficit
     case surface_pressure
     case terrestrial_radiation
     case terrestrial_radiation_instant
     case snowfall
+    case weather_code
     case weathercode
     case is_day
     case rain
     case showers
     case wet_bulb_temperature_2m
+    case cloud_cover
+    case relative_humidity_2m
+    case wind_speed_10m
+    case wind_direction_10m
+    case wind_gusts_10m
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false

--- a/Sources/App/MetNo/MetNoDomain.swift
+++ b/Sources/App/MetNo/MetNoDomain.swift
@@ -132,19 +132,19 @@ enum MetNoVariable: String, CaseIterable, GenericVariable, GenericVariableMixabl
         case .temperature_2m:
             return .celsius
         case .cloudcover:
-            return .percent
+            return .percentage
         case .relativehumidity_2m:
-            return .percent
+            return .percentage
         case .precipitation:
-            return .millimeter
+            return .millimetre
         case .windgusts_10m:
-            return .ms
+            return .metrePerSecond
         case .pressure_msl:
-            return .hectoPascal
+            return .hectopascal
         case .shortwave_radiation:
-            return .wattPerSquareMeter
+            return .wattPerSquareMetre
         case .windspeed_10m:
-            return .ms
+            return .metrePerSecond
         case .winddirection_10m:
             return .degreeDirection
         }

--- a/Sources/App/MeteoFrance/MeteoFranceController.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceController.swift
@@ -106,7 +106,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
         /// AROME France domain has no cloud cover for pressure levels, calculate from RH
         if reader.domain == .arome_france, case let .pressure(pressure) = raw, pressure.variable == .cloudcover {
             let rh = try get(raw: .pressure(MeteoFrancePressureVariable(variable: .relativehumidity, level: pressure.level)), time: time)
-            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: Float(pressure.level))}), .percent)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: Float(pressure.level))}), .percentage)
         }
         
         return try reader.get(variable: raw, time: time)
@@ -306,7 +306,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 let u = try get(raw: .wind_u_component_10m, time: time).data
                 let v = try get(raw: .wind_v_component_10m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
-                return DataAndUnit(speed, .ms)
+                return DataAndUnit(speed, .metrePerSecond)
             case .winddirection_10m:
                 let u = try get(raw: .wind_u_component_10m, time: time).data
                 let v = try get(raw: .wind_v_component_10m, time: time).data
@@ -322,7 +322,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 let temperature = try get(raw: .temperature_2m, time: time).data
                 let rh = try get(raw: .relativehumidity_2m, time: time).data
                 let dewpoint = zip(temperature,rh).map(Meteorology.dewpoint)
-                return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kiloPascal)
+                return DataAndUnit(zip(temperature,dewpoint).map(Meteorology.vaporPressureDeficit), .kilopascal)
             case .et0_fao_evapotranspiration:
                 let exrad = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
                 let swrad = try get(raw: .shortwave_radiation, time: time).data
@@ -334,11 +334,11 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 let et0 = swrad.indices.map { i in
                     return Meteorology.et0Evapotranspiration(temperature2mCelsius: temperature[i], windspeed10mMeterPerSecond: windspeed[i], dewpointCelsius: dewpoint[i], shortwaveRadiationWatts: swrad[i], elevation: reader.targetElevation, extraTerrestrialRadiation: exrad[i], dtSeconds: 3600)
                 }
-                return DataAndUnit(et0, .millimeter)
+                return DataAndUnit(et0, .millimetre)
             case .snowfall:
                 let snowfall_water_equivalent = try get(raw: .snowfall_water_equivalent, time: time).data
                 let snowfall = snowfall_water_equivalent.map({$0 * 0.7})
-                return DataAndUnit(snowfall, SiUnit.centimeter)
+                return DataAndUnit(snowfall, SiUnit.centimetre)
             case .relativehumitidy_2m:
                 return try get(raw: .relativehumidity_2m, time: time)
             case .surface_pressure:
@@ -348,11 +348,11 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
             case .terrestrial_radiation:
                 /// Use center averaged
                 let solar = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-                return DataAndUnit(solar, .wattPerSquareMeter)
+                return DataAndUnit(solar, .wattPerSquareMetre)
             case .terrestrial_radiation_instant:
                 /// Use center averaged
                 let solar = Zensun.extraTerrestrialRadiationInstant(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-                return DataAndUnit(solar, .wattPerSquareMeter)
+                return DataAndUnit(solar, .wattPerSquareMetre)
             case .dewpoint_2m:
                 let temperature = try get(raw: .temperature_2m, time: time)
                 let rh = try get(raw: .relativehumidity_2m, time: time)
@@ -364,7 +364,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
             case .direct_normal_irradiance:
                 let dhi = try get(derived: .surface(.direct_radiation), time: time).data
                 let dni = Zensun.calculateBackwardsDNI(directRadiation: dhi, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
-                return DataAndUnit(dni, .wattPerSquareMeter)
+                return DataAndUnit(dni, .wattPerSquareMetre)
             case .direct_normal_irradiance_instant:
                 let direct = try get(derived: .surface(.direct_radiation_instant), time: time)
                 let dni = Zensun.calculateInstantDNI(directRadiation: direct.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
@@ -409,7 +409,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 let u = try get(raw: .wind_u_component_20m, time: time).data
                 let v = try get(raw: .wind_v_component_20m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
-                return DataAndUnit(speed, .ms)
+                return DataAndUnit(speed, .metrePerSecond)
             case .winddirection_20m:
                 let u = try get(raw: .wind_u_component_20m, time: time).data
                 let v = try get(raw: .wind_v_component_20m, time: time).data
@@ -419,7 +419,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 let u = try get(raw: .wind_u_component_50m, time: time).data
                 let v = try get(raw: .wind_v_component_50m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
-                return DataAndUnit(speed, .ms)
+                return DataAndUnit(speed, .metrePerSecond)
             case .winddirection_50m:
                 let u = try get(raw: .wind_u_component_50m, time: time).data
                 let v = try get(raw: .wind_v_component_50m, time: time).data
@@ -431,7 +431,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 let u = try get(raw: .wind_u_component_100m, time: time).data
                 let v = try get(raw: .wind_v_component_100m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
-                return DataAndUnit(speed, .ms)
+                return DataAndUnit(speed, .metrePerSecond)
             case .winddirection_80m:
                 fallthrough
             case .winddirection_100m:
@@ -445,7 +445,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 let u = try get(raw: .wind_u_component_150m, time: time).data
                 let v = try get(raw: .wind_v_component_150m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
-                return DataAndUnit(speed, .ms)
+                return DataAndUnit(speed, .metrePerSecond)
             case .winddirection_120m:
                 fallthrough
             case .winddirection_150m:
@@ -459,7 +459,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 let u = try get(raw: .wind_u_component_200m, time: time).data
                 let v = try get(raw: .wind_v_component_200m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
-                return DataAndUnit(speed, .ms)
+                return DataAndUnit(speed, .metrePerSecond)
             case .winddirection_180m:
                 fallthrough
             case .winddirection_200m:

--- a/Sources/App/MeteoFrance/MeteoFranceController.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceController.swift
@@ -4,8 +4,9 @@ import Vapor
 
 enum MeteoFranceVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case apparent_temperature
-    case relativehumitidy_2m
+    case relative_humidity_2m
     case dewpoint_2m
+    case dew_point_2m
     case windspeed_10m
     case winddirection_10m
     case windspeed_20m
@@ -27,6 +28,27 @@ enum MeteoFranceVariableDerivedSurface: String, CaseIterable, GenericVariableMix
     /// Is using 200m wind
     case windspeed_180m
     case winddirection_180m
+    case wind_speed_10m
+    case wind_direction_10m
+    case wind_speed_20m
+    case wind_direction_20m
+    case wind_speed_50m
+    case wind_direction_50m
+    case wind_speed_100m
+    case wind_direction_100m
+    case wind_speed_150m
+    case wind_direction_150m
+    case wind_speed_200m
+    case wind_direction_200m
+    /// Is using 100m wind
+    case wind_speed_80m
+    case wind_direction_80m
+    /// Is using 150m wind
+    case wind_speed_120m
+    case wind_direction_120m
+    /// Is using 200m wind
+    case wind_speed_180m
+    case wind_direction_180m
     case temperature_80m
     case temperature_120m
     case temperature_180m
@@ -39,15 +61,22 @@ enum MeteoFranceVariableDerivedSurface: String, CaseIterable, GenericVariableMix
     case shortwave_radiation_instant
     //case evapotranspiration
     case et0_fao_evapotranspiration
+    case vapour_pressure_deficit
     case vapor_pressure_deficit
     case snowfall
     case surface_pressure
     case terrestrial_radiation
     case terrestrial_radiation_instant
     case weathercode
+    case weather_code
     case is_day
     case showers
     case wet_bulb_temperature_2m
+    case cloud_cover
+    case cloud_cover_low
+    case cloud_cover_mid
+    case cloud_cover_high
+    case wind_gusts_10m
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false
@@ -61,6 +90,11 @@ enum MeteoFrancePressureVariableDerivedType: String, CaseIterable {
     case windspeed
     case winddirection
     case dewpoint
+    case wind_speed
+    case wind_direction
+    case dew_point
+    case cloud_cover
+    case relative_humidity
 }
 
 /**
@@ -184,15 +218,12 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(variable: .wind_v_component_10m, time: time)
                 try prefetchData(variable: .relativehumidity_2m, time: time)
                 try prefetchData(variable: .shortwave_radiation, time: time)
-            case .relativehumitidy_2m:
+            case .relative_humidity_2m:
                 try prefetchData(variable: .relativehumidity_2m, time: time)
-            case .windspeed_10m:
+            case .wind_speed_10m, .windspeed_10m, .wind_direction_10m, .winddirection_10m:
                 try prefetchData(variable: .wind_u_component_10m, time: time)
                 try prefetchData(variable: .wind_v_component_10m, time: time)
-            case .winddirection_10m:
-                try prefetchData(variable: .wind_u_component_10m, time: time)
-                try prefetchData(variable: .wind_v_component_10m, time: time)
-            case .vapor_pressure_deficit:
+            case .vapor_pressure_deficit, .vapour_pressure_deficit:
                 try prefetchData(variable: .temperature_2m, time: time)
                 try prefetchData(variable: .relativehumidity_2m, time: time)
             case .et0_fao_evapotranspiration:
@@ -206,28 +237,14 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
             case .surface_pressure:
                 try prefetchData(variable: .pressure_msl, time: time)
                 try prefetchData(variable: .temperature_2m, time: time)
-            case .terrestrial_radiation:
+            case .terrestrial_radiation, .terrestrial_radiation_instant:
                 break
-            case .terrestrial_radiation_instant:
-                break
-            case .dewpoint_2m:
+            case .dew_point_2m, .dewpoint_2m:
                 try prefetchData(variable: .temperature_2m, time: time)
                 try prefetchData(variable: .relativehumidity_2m, time: time)
-            case .diffuse_radiation:
-                fallthrough
-            case .diffuse_radiation_instant:
-                fallthrough
-            case .direct_normal_irradiance:
-                fallthrough
-            case .direct_normal_irradiance_instant:
-                fallthrough
-            case .direct_radiation:
-                fallthrough
-            case .direct_radiation_instant:
-                fallthrough
-            case .shortwave_radiation_instant:
+            case .diffuse_radiation, .diffuse_radiation_instant, .direct_normal_irradiance, .direct_normal_irradiance_instant, .direct_radiation, .direct_radiation_instant, .shortwave_radiation_instant:
                 try prefetchData(variable: .shortwave_radiation, time: time)
-            case .weathercode:
+            case .weather_code, .weathercode:
                 try prefetchData(variable: .cloudcover, time: time)
                 try prefetchData(variable: .precipitation, time: time)
                 try prefetchData(derived: .surface(.snowfall), time: time)
@@ -235,41 +252,19 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(variable: .windgusts_10m, time: time)
             case .is_day:
                 break
-            case .windspeed_20m:
-                fallthrough
-            case .winddirection_20m:
+            case .wind_speed_20m, .windspeed_20m, .wind_direction_20m, .winddirection_20m:
                 try prefetchData(variable: .wind_u_component_20m, time: time)
                 try prefetchData(variable: .wind_v_component_20m, time: time)
-            case .windspeed_50m:
-                fallthrough
-            case .winddirection_50m:
+            case .windspeed_50m, .wind_speed_50m, .winddirection_50m, .wind_direction_50m:
                 try prefetchData(variable: .wind_u_component_50m, time: time)
                 try prefetchData(variable: .wind_v_component_50m, time: time)
-            case .windspeed_80m:
-                fallthrough
-            case .winddirection_80m:
-                fallthrough
-            case .windspeed_100m:
-                fallthrough
-            case .winddirection_100m:
+            case .windspeed_80m, .wind_speed_80m, .winddirection_80m, .wind_direction_80m, .windspeed_100m, .wind_speed_100m, .winddirection_100m, .wind_direction_100m:
                 try prefetchData(variable: .wind_u_component_100m, time: time)
                 try prefetchData(variable: .wind_v_component_100m, time: time)
-            case .windspeed_120m:
-                fallthrough
-            case .winddirection_120m:
-                fallthrough
-            case .windspeed_150m:
-                fallthrough
-            case .winddirection_150m:
+            case .windspeed_120m, .wind_speed_120m, .winddirection_120m, .wind_direction_120m, .windspeed_150m, .wind_speed_150m, .winddirection_150m, .wind_direction_150m:
                 try prefetchData(variable: .wind_u_component_150m, time: time)
                 try prefetchData(variable: .wind_v_component_150m, time: time)
-            case .windspeed_180m:
-                fallthrough
-            case .winddirection_180m:
-                fallthrough
-            case .windspeed_200m:
-                fallthrough
-            case .winddirection_200m:
+            case .windspeed_180m, .wind_speed_180m, .winddirection_180m, .wind_direction_180m, .windspeed_200m, .wind_speed_200m, .winddirection_200m, .wind_direction_200m:
                 try prefetchData(variable: .wind_u_component_200m, time: time)
                 try prefetchData(variable: .wind_v_component_200m, time: time)
             case .temperature_80m:
@@ -283,17 +278,29 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
             case .wet_bulb_temperature_2m:
                 try prefetchData(variable: .temperature_2m, time: time)
                 try prefetchData(variable: .relativehumidity_2m, time: time)
+            case .cloud_cover:
+                try prefetchData(variable: .cloudcover, time: time)
+            case .cloud_cover_low:
+                try prefetchData(variable: .cloudcover_low, time: time)
+            case .cloud_cover_mid:
+                try prefetchData(variable: .cloudcover_mid, time: time)
+            case .cloud_cover_high:
+                try prefetchData(variable: .cloudcover_high, time: time)
+            case .wind_gusts_10m:
+                try prefetchData(variable: .windgusts_10m, time: time)
             }
         case .pressure(let v):
             switch v.variable {
-            case .windspeed:
+            case .windspeed, .wind_speed:
                 fallthrough
-            case .winddirection:
+            case .winddirection, .wind_direction:
                 try prefetchData(raw: .pressure(MeteoFrancePressureVariable(variable: .wind_u_component, level: v.level)), time: time)
                 try prefetchData(raw: .pressure(MeteoFrancePressureVariable(variable: .wind_v_component, level: v.level)), time: time)
-            case .dewpoint:
+            case .dewpoint, .dew_point, .relative_humidity:
                 try prefetchData(raw: .pressure(MeteoFrancePressureVariable(variable: .temperature, level: v.level)), time: time)
                 try prefetchData(raw: .pressure(MeteoFrancePressureVariable(variable: .relativehumidity, level: v.level)), time: time)
+            case .cloud_cover:
+                try prefetchData(raw: .pressure(MeteoFrancePressureVariable(variable: .cloudcover, level: v.level)), time: time)
             }
         }
     }
@@ -302,12 +309,12 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
         switch derived {
         case .surface(let variableDerivedSurface):
             switch variableDerivedSurface {
-            case .windspeed_10m:
+            case .windspeed_10m, .wind_speed_10m:
                 let u = try get(raw: .wind_u_component_10m, time: time).data
                 let v = try get(raw: .wind_v_component_10m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
-            case .winddirection_10m:
+            case .winddirection_10m, .wind_direction_10m:
                 let u = try get(raw: .wind_u_component_10m, time: time).data
                 let v = try get(raw: .wind_v_component_10m, time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
@@ -318,7 +325,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 let relhum = try get(raw: .relativehumidity_2m, time: time).data
                 let radiation = try get(raw: .shortwave_radiation, time: time).data
                 return DataAndUnit(Meteorology.apparentTemperature(temperature_2m: temperature, relativehumidity_2m: relhum, windspeed_10m: windspeed, shortware_radiation: radiation), .celsius)
-            case .vapor_pressure_deficit:
+            case .vapor_pressure_deficit, .vapour_pressure_deficit:
                 let temperature = try get(raw: .temperature_2m, time: time).data
                 let rh = try get(raw: .relativehumidity_2m, time: time).data
                 let dewpoint = zip(temperature,rh).map(Meteorology.dewpoint)
@@ -339,7 +346,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 let snowfall_water_equivalent = try get(raw: .snowfall_water_equivalent, time: time).data
                 let snowfall = snowfall_water_equivalent.map({$0 * 0.7})
                 return DataAndUnit(snowfall, SiUnit.centimetre)
-            case .relativehumitidy_2m:
+            case .relative_humidity_2m:
                 return try get(raw: .relativehumidity_2m, time: time)
             case .surface_pressure:
                 let temperature = try get(raw: .temperature_2m, time: time).data
@@ -353,7 +360,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 /// Use center averaged
                 let solar = Zensun.extraTerrestrialRadiationInstant(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
                 return DataAndUnit(solar, .wattPerSquareMetre)
-            case .dewpoint_2m:
+            case .dewpoint_2m, .dew_point_2m:
                 let temperature = try get(raw: .temperature_2m, time: time)
                 let rh = try get(raw: .relativehumidity_2m, time: time)
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
@@ -385,7 +392,7 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 let diff = try get(derived: .surface(.diffuse_radiation), time: time)
                 let factor = Zensun.backwardsAveragedToInstantFactor(time: time, latitude: reader.modelLat, longitude: reader.modelLon)
                 return DataAndUnit(zip(diff.data, factor).map(*), diff.unit)
-            case .weathercode:
+            case .weathercode, .weather_code:
                 let cloudcover = try get(raw: .cloudcover, time: time).data
                 let precipitation = try get(raw: .precipitation, time: time).data
                 let snowfall = try get(derived: .surface(.snowfall), time: time).data
@@ -405,64 +412,79 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 )
             case .is_day:
                 return DataAndUnit(Zensun.calculateIsDay(timeRange: time, lat: reader.modelLat, lon: reader.modelLon), .dimensionlessInteger)
-            case .windspeed_20m:
+            case .windspeed_20m, .wind_speed_20m:
                 let u = try get(raw: .wind_u_component_20m, time: time).data
                 let v = try get(raw: .wind_v_component_20m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
-            case .winddirection_20m:
+            case .winddirection_20m, .wind_direction_20m:
                 let u = try get(raw: .wind_u_component_20m, time: time).data
                 let v = try get(raw: .wind_v_component_20m, time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
-            case .windspeed_50m:
+            case .windspeed_50m, .wind_speed_50m:
                 let u = try get(raw: .wind_u_component_50m, time: time).data
                 let v = try get(raw: .wind_v_component_50m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
-            case .winddirection_50m:
+            case .winddirection_50m, .wind_direction_50m:
                 let u = try get(raw: .wind_u_component_50m, time: time).data
                 let v = try get(raw: .wind_v_component_50m, time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
-            case .windspeed_80m:
-                fallthrough
-            case .windspeed_100m:
+            case .windspeed_80m, .wind_speed_80m:
+                let u = try get(raw: .wind_u_component_100m, time: time).data
+                let v = try get(raw: .wind_v_component_100m, time: time).data
+                let scalefactor = Meteorology.scaleWindFactor(from: 100, to: 80)
+                var speed = zip(u,v).map(Meteorology.windspeed)
+                speed.multiplyAdd(multiply: scalefactor, add: 0)
+                return DataAndUnit(speed, .metrePerSecond)
+            case .windspeed_100m, .wind_speed_100m:
                 let u = try get(raw: .wind_u_component_100m, time: time).data
                 let v = try get(raw: .wind_v_component_100m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
-            case .winddirection_80m:
+            case .winddirection_80m, .wind_direction_80m:
                 fallthrough
-            case .winddirection_100m:
+            case .winddirection_100m, .wind_direction_100m:
                 let u = try get(raw: .wind_u_component_100m, time: time).data
                 let v = try get(raw: .wind_v_component_100m, time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
-            case .windspeed_120m:
-                fallthrough
-            case .windspeed_150m:
+            case .windspeed_120m, .wind_speed_120m:
+                let u = try get(raw: .wind_u_component_150m, time: time).data
+                let v = try get(raw: .wind_v_component_150m, time: time).data
+                let scalefactor = Meteorology.scaleWindFactor(from: 150, to: 120)
+                var speed = zip(u,v).map(Meteorology.windspeed)
+                speed.multiplyAdd(multiply: scalefactor, add: 0)
+                return DataAndUnit(speed, .metrePerSecond)
+            case .windspeed_150m, .wind_speed_150m:
                 let u = try get(raw: .wind_u_component_150m, time: time).data
                 let v = try get(raw: .wind_v_component_150m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
-            case .winddirection_120m:
+            case .winddirection_120m, .wind_direction_120m:
                 fallthrough
-            case .winddirection_150m:
+            case .winddirection_150m, .wind_direction_150m:
                 let u = try get(raw: .wind_u_component_150m, time: time).data
                 let v = try get(raw: .wind_v_component_150m, time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
-            case .windspeed_180m:
-                fallthrough
-            case .windspeed_200m:
+            case .windspeed_180m, .wind_speed_180m:
+                let u = try get(raw: .wind_u_component_200m, time: time).data
+                let v = try get(raw: .wind_v_component_200m, time: time).data
+                let scalefactor = Meteorology.scaleWindFactor(from: 200, to: 180)
+                var speed = zip(u,v).map(Meteorology.windspeed)
+                speed.multiplyAdd(multiply: scalefactor, add: 0)
+                return DataAndUnit(speed, .metrePerSecond)
+            case .windspeed_200m, .wind_speed_200m:
                 let u = try get(raw: .wind_u_component_200m, time: time).data
                 let v = try get(raw: .wind_v_component_200m, time: time).data
                 let speed = zip(u,v).map(Meteorology.windspeed)
                 return DataAndUnit(speed, .metrePerSecond)
-            case .winddirection_180m:
+            case .winddirection_180m, .wind_direction_180m:
                 fallthrough
-            case .winddirection_200m:
+            case .winddirection_200m, .wind_direction_200m:
                 let u = try get(raw: .wind_u_component_200m, time: time).data
                 let v = try get(raw: .wind_v_component_200m, time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
@@ -480,23 +502,37 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 let temperature = try get(raw: .temperature_2m, time: time)
                 let rh = try get(raw: .relativehumidity_2m, time: time)
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.wetBulbTemperature), temperature.unit)
+            case .cloud_cover:
+                return try get(raw: .cloudcover, time: time)
+            case .cloud_cover_low:
+                return try get(raw: .cloudcover_low, time: time)
+            case .cloud_cover_mid:
+                return try get(raw: .cloudcover_mid, time: time)
+            case .cloud_cover_high:
+                return try get(raw: .cloudcover_high, time: time)
+            case .wind_gusts_10m:
+                return try get(raw: .windgusts_10m, time: time)
             }
         case .pressure(let v):
             switch v.variable {
-            case .windspeed:
+            case .windspeed, .wind_speed:
                 let u = try get(raw: .pressure(MeteoFrancePressureVariable(variable: .wind_u_component, level: v.level)), time: time)
                 let v = try get(raw: .pressure(MeteoFrancePressureVariable(variable: .wind_v_component, level: v.level)), time: time)
                 let speed = zip(u.data,v.data).map(Meteorology.windspeed)
                 return DataAndUnit(speed, u.unit)
-            case .winddirection:
+            case .winddirection, .wind_direction:
                 let u = try get(raw: .pressure(MeteoFrancePressureVariable(variable: .wind_u_component, level: v.level)), time: time).data
                 let v = try get(raw: .pressure(MeteoFrancePressureVariable(variable: .wind_v_component, level: v.level)), time: time).data
                 let direction = Meteorology.windirectionFast(u: u, v: v)
                 return DataAndUnit(direction, .degreeDirection)
-            case .dewpoint:
+            case .dewpoint, .dew_point:
                 let temperature = try get(raw: .pressure(MeteoFrancePressureVariable(variable: .temperature, level: v.level)), time: time)
                 let rh = try get(raw: .pressure(MeteoFrancePressureVariable(variable: .relativehumidity, level: v.level)), time: time)
                 return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+            case .cloud_cover:
+                return try get(raw: .pressure(MeteoFrancePressureVariable(variable: .cloudcover, level: v.level)), time: time)
+            case .relative_humidity:
+                return try get(raw: .pressure(MeteoFrancePressureVariable(variable: .relativehumidity, level: v.level)), time: time)
             }
         }
     }

--- a/Sources/App/MeteoFrance/MeteoFranceDomain.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDomain.swift
@@ -385,31 +385,31 @@ enum MeteoFranceSurfaceVariable: String, CaseIterable, GenericVariable, GenericV
         case .temperature_2m:
             return .celsius
         case .cloudcover:
-            return .percent
+            return .percentage
         case .cloudcover_low:
-            return .percent
+            return .percentage
         case .cloudcover_mid:
-            return .percent
+            return .percentage
         case .cloudcover_high:
-            return .percent
+            return .percentage
         case .relativehumidity_2m:
-            return .percent
+            return .percentage
         case .precipitation:
-            return .millimeter
+            return .millimetre
         case .windgusts_10m:
-            return .ms
+            return .metrePerSecond
         case .pressure_msl:
-            return .hectoPascal
+            return .hectopascal
         case .shortwave_radiation:
-            return .wattPerSquareMeter
+            return .wattPerSquareMetre
         case .cape:
-            return .joulesPerKilogram
+            return .joulePerKilogram
         case .snowfall_water_equivalent:
-            return .millimeter
+            return .millimetre
         case .wind_v_component_10m:
-            return .ms
+            return .metrePerSecond
         case .wind_u_component_10m:
-            return .ms
+            return .metrePerSecond
         case .wind_v_component_20m:
             fallthrough
         case .wind_u_component_20m:
@@ -429,7 +429,7 @@ enum MeteoFranceSurfaceVariable: String, CaseIterable, GenericVariable, GenericV
         case .wind_v_component_200m:
             fallthrough
         case .wind_u_component_200m:
-            return .ms
+            return .metrePerSecond
         case .temperature_20m:
             fallthrough
         case .temperature_50m:
@@ -533,15 +533,15 @@ struct MeteoFrancePressureVariable: PressureVariableRespresentable, GenericVaria
         case .temperature:
             return .celsius
         case .wind_u_component:
-            return .ms
+            return .metrePerSecond
         case .wind_v_component:
-            return .ms
+            return .metrePerSecond
         case .geopotential_height:
-            return .meter
+            return .metre
         case .cloudcover:
-            return .percent
+            return .percentage
         case .relativehumidity:
-            return .percent
+            return .percentage
         }
     }
     

--- a/Sources/App/Satellite/SatelliteDownloader.swift
+++ b/Sources/App/Satellite/SatelliteDownloader.swift
@@ -140,7 +140,7 @@ struct SatelliteDownloadCommand: AsyncCommandFix {
             let year = time.toComponents().year
             let month = time.toComponents().month.zeroPadded(len: 2)
             let yyyymmdd = time.format_YYYYMMdd
-            let openDap = "https://gpm1.gesdisc.eosdis.nasa.gov/opendap/GPM_L3/GPM_3IMERGDL.06/\(year)/\(month)/3B-DAY-L.MS.MRG.3IMERG.\(yyyymmdd)-S000000-E235959.V06.nc4"
+            let openDap = "https://gpm1.gesdisc.eosdis.nasa.gov/opendap/GPM_L3/GPM_3IMERGDL.06/\(year)/\(month)/3B-DAY-L.metrePerSecond.MRG.3IMERG.\(yyyymmdd)-S000000-E235959.V06.nc4"
             let destination = "\(domain.downloadDirectory)precipitation_\(yyyymmdd).om"
             let domain = SatelliteDomain.imerg_daily
             
@@ -202,7 +202,7 @@ enum SatelliteVariable: String, CaseIterable, GenericVariableMixable, GenericVar
     var unit: SiUnit {
         switch self {
         case .precipitation_sum:
-            return .millimeter
+            return .millimetre
         }
     }
     

--- a/Sources/App/SeasonalForecast/SeasonalForecastController.swift
+++ b/Sources/App/SeasonalForecast/SeasonalForecastController.swift
@@ -238,7 +238,7 @@ struct SeasonalForecastController {
             guard !readers.isEmpty else {
                 throw ForecastapiError.noDataAvilableForThisLocation
             }
-            return .init(timezone: timezone, time: time, results: readers)
+            return .init(timezone: timezone, time: time, locationId: coordinates.locationId, results: readers)
         }
         let result = ForecastapiResult<SeasonalForecastDomainApi>(timeformat: params.timeformatOrDefault, results: locations)
         req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))

--- a/Sources/App/SeasonalForecast/SeasonalForecastController.swift
+++ b/Sources/App/SeasonalForecast/SeasonalForecastController.swift
@@ -110,7 +110,7 @@ extension SeasonalForecastReader {
         case .shortwave_radiation_sum:
             let data = try get(variable: VariableAndMember(.shortwave_radiation, member), time: time).convertAndRound(params: params)
             // for 6h data
-            return DataAndUnit(data.data.sum(by: 4).map({$0*0.0036 * 6}).round(digits: 2), .megaJoulesPerSquareMeter)
+            return DataAndUnit(data.data.sum(by: 4).map({$0*0.0036 * 6}).round(digits: 2), .megajoulePerSquareMetre)
         case .windspeed_10m_max:
             let data = try get(variable: .derived(.windspeed_10m), member: member, time: time).convertAndRound(params: params)
             return DataAndUnit(data.data.max(by: 4), data.unit)

--- a/Sources/App/SeasonalForecast/SeasonalForecastController.swift
+++ b/Sources/App/SeasonalForecast/SeasonalForecastController.swift
@@ -19,6 +19,10 @@ enum SeasonalForecastDomainApi: String, RawRepresentableString, CaseIterable {
 enum CfsVariableDerived: String, RawRepresentableString {
     case windspeed_10m
     case winddirection_10m
+    case wind_speed_10m
+    case wind_direction_10m
+    case cloud_cover
+    case relative_humidity_2m
 }
 
 enum DailyCfsVariable: String, RawRepresentableString {
@@ -30,6 +34,8 @@ enum DailyCfsVariable: String, RawRepresentableString {
     case shortwave_radiation_sum
     case windspeed_10m_max
     case winddirection_10m_dominant
+    case wind_speed_10m_max
+    case wind_direction_10m_dominant
     case precipitation_hours
 }
 
@@ -40,11 +46,15 @@ extension SeasonalForecastReader {
             try prefetchData(variable: VariableAndMember(variable, member), time: time)
         case .derived(let variable):
             switch variable {
-            case .windspeed_10m:
+            case .windspeed_10m, .wind_speed_10m:
                 fallthrough
-            case .winddirection_10m:
+            case .winddirection_10m, .wind_direction_10m:
                 try prefetchData(variable: VariableAndMember(.wind_u_component_10m, member), time: time)
                 try prefetchData(variable: VariableAndMember(.wind_v_component_10m, member), time: time)
+            case .cloud_cover:
+                try prefetchData(variable: VariableAndMember(.cloudcover, member), time: time)
+            case .relative_humidity_2m:
+                try prefetchData(variable: VariableAndMember(.relativehumidity_2m, member), time: time)
             }
         }
     }
@@ -55,16 +65,20 @@ extension SeasonalForecastReader {
             return try get(variable: VariableAndMember(variable, member), time: time)
         case .derived(let variable):
             switch variable {
-            case .windspeed_10m:
+            case .windspeed_10m, .wind_speed_10m:
                 let u = try get(variable: VariableAndMember(.wind_u_component_10m, member), time: time)
                 let v = try get(variable: VariableAndMember(.wind_v_component_10m, member), time: time)
                 let speed = zip(u.data,v.data).map(Meteorology.windspeed)
                 return DataAndUnit(speed, u.unit)
-            case .winddirection_10m:
+            case .winddirection_10m, .wind_direction_10m:
                 let u = try get(variable: VariableAndMember(.wind_u_component_10m, member), time: time)
                 let v = try get(variable: VariableAndMember(.wind_v_component_10m, member), time: time)
                 let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
                 return DataAndUnit(direction, .degreeDirection)
+            case .cloud_cover:
+                return try get(variable: VariableAndMember(.cloudcover, member), time: time)
+            case .relative_humidity_2m:
+                return try get(variable: VariableAndMember(.relativehumidity_2m, member), time: time)
             }
         }
     }
@@ -82,9 +96,9 @@ extension SeasonalForecastReader {
             try prefetchData(variable: VariableAndMember(.showers, member), time: time)
         case .shortwave_radiation_sum:
             try prefetchData(variable: VariableAndMember(.shortwave_radiation, member), time: time)
-        case .windspeed_10m_max:
+        case .windspeed_10m_max, .wind_speed_10m_max:
             fallthrough
-        case .winddirection_10m_dominant:
+        case .winddirection_10m_dominant, .wind_direction_10m_dominant:
             try prefetchData(variable: VariableAndMember(.wind_u_component_10m, member), time: time)
             try prefetchData(variable: VariableAndMember(.wind_v_component_10m, member), time: time)
         case .precipitation_hours:
@@ -111,10 +125,10 @@ extension SeasonalForecastReader {
             let data = try get(variable: VariableAndMember(.shortwave_radiation, member), time: time).convertAndRound(params: params)
             // for 6h data
             return DataAndUnit(data.data.sum(by: 4).map({$0*0.0036 * 6}).round(digits: 2), .megajoulePerSquareMetre)
-        case .windspeed_10m_max:
+        case .windspeed_10m_max, .wind_speed_10m_max:
             let data = try get(variable: .derived(.windspeed_10m), member: member, time: time).convertAndRound(params: params)
             return DataAndUnit(data.data.max(by: 4), data.unit)
-        case .winddirection_10m_dominant:
+        case .winddirection_10m_dominant, .wind_direction_10m_dominant:
             let u = try get(variable: VariableAndMember(.wind_u_component_10m, member), time: time).data.sum(by: 4)
             let v = try get(variable: VariableAndMember(.wind_v_component_10m, member), time: time).data.sum(by: 4)
             let direction = Meteorology.windirectionFast(u: u, v: v)

--- a/Sources/App/SeasonalForecast/SeasonalForecastDomains.swift
+++ b/Sources/App/SeasonalForecast/SeasonalForecastDomains.swift
@@ -279,31 +279,31 @@ enum CfsVariable: String, CaseIterable, GenericVariable {
         case .temperature_2m_min:
             return .celsius
         case .soil_moisture_0_to_10cm:
-            return .qubicMeterPerQubicMeter
+            return .cubicMetrePerCubicMetre
         case .soil_moisture_10_to_40cm:
-            return .qubicMeterPerQubicMeter
+            return .cubicMetrePerCubicMetre
         case .soil_moisture_40_to_100cm:
-            return .qubicMeterPerQubicMeter
+            return .cubicMetrePerCubicMetre
         case .soil_moisture_100_to_200cm:
-            return .qubicMeterPerQubicMeter
+            return .cubicMetrePerCubicMetre
         case .soil_temperature_0_to_10cm:
             return .celsius
         case .shortwave_radiation:
-            return .wattPerSquareMeter
+            return .wattPerSquareMetre
         case .cloudcover:
-            return .percent
+            return .percentage
         case .wind_u_component_10m:
-            return .ms
+            return .metrePerSecond
         case .wind_v_component_10m:
-            return .ms
+            return .metrePerSecond
         case .precipitation:
-            return .millimeter
+            return .millimetre
         case .showers:
-            return .millimeter
+            return .millimetre
         case .relativehumidity_2m:
-            return .percent
+            return .percentage
         case .pressure_msl:
-            return .hectoPascal
+            return .hectopascal
         }
     }
 }

--- a/Tests/AppTests/OutputformatTests.swift
+++ b/Tests/AppTests/OutputformatTests.swift
@@ -124,17 +124,17 @@ final class OutputformatTests: XCTestCase {
         
         let daily = ApiSection<ForecastVariableDaily>(name: "daily", time: TimerangeDt(start: Timestamp(2022,7,12,0), nTime: 2, dtSeconds: 86400), columns: [
             ApiColumn(variable: .temperature_2m_mean, unit: .celsius, variables: [.float(.init(repeating: 20, count: 2))]),
-            ApiColumn(variable: .windspeed_10m_mean, unit: .kmh, variables: [.float(.init(repeating: 10, count: 2))]),
+            ApiColumn(variable: .windspeed_10m_mean, unit: .kilometresPerHour, variables: [.float(.init(repeating: 10, count: 2))]),
         ])
         
         let hourly = ApiSection<ForecastapiResult<MultiDomains>.SurfaceAndPressureVariable>(name: "hourly", time: TimerangeDt(start: Timestamp(2022,7,12,0), nTime: 48, dtSeconds: 3600), columns: [
             ApiColumn(variable: .surface(.temperature_2m), unit: .celsius, variables: [.float(.init(repeating: 20, count: 48))]),
-            ApiColumn(variable: .surface(.windspeed_10m), unit: .kmh, variables: [.float(.init(repeating: 10, count: 48))]),
+            ApiColumn(variable: .surface(.windspeed_10m), unit: .kilometresPerHour, variables: [.float(.init(repeating: 10, count: 48))]),
         ])
         
         let currentSection = ApiSectionSingle<ForecastapiResult<MultiDomains>.SurfaceAndPressureVariable>(name: "current_weather", time: Timestamp(2022,7,12,1,15), dtSeconds: 3600/4, columns: [
             ApiColumnSingle(variable: .surface(.temperature_20m), unit: .celsius, value: 20),
-            ApiColumnSingle(variable: .surface(.windspeed_100m), unit: .kmh, value: 10),
+            ApiColumnSingle(variable: .surface(.windspeed_100m), unit: .kilometresPerHour, value: 10),
         ])
         
         let res = ForecastapiResult<MultiDomains>.PerModel(
@@ -323,17 +323,17 @@ final class OutputformatTests: XCTestCase {
         
         let daily = ApiSection<ForecastVariableDaily>(name: "daily", time: TimerangeDt(start: Timestamp(2022,7,12,0), nTime: 2, dtSeconds: 86400), columns: [
             ApiColumn(variable: .temperature_2m_mean, unit: .celsius, variables: [.float(.init(repeating: 20, count: 2))]),
-            ApiColumn(variable: .windspeed_10m_mean, unit: .kmh, variables: [.float(.init(repeating: 10, count: 2))]),
+            ApiColumn(variable: .windspeed_10m_mean, unit: .kilometresPerHour, variables: [.float(.init(repeating: 10, count: 2))]),
         ])
         
         let hourly = ApiSection<ForecastapiResult<MultiDomains>.SurfaceAndPressureVariable>(name: "hourly", time: TimerangeDt(start: Timestamp(2022,7,12,0), nTime: 48, dtSeconds: 3600), columns: [
             ApiColumn(variable: .surface(.temperature_2m), unit: .celsius, variables: [.float(.init(repeating: 20, count: 48))]),
-            ApiColumn(variable: .surface(.windspeed_10m), unit: .kmh, variables: [.float(.init(repeating: 10, count: 48))]),
+            ApiColumn(variable: .surface(.windspeed_10m), unit: .kilometresPerHour, variables: [.float(.init(repeating: 10, count: 48))]),
         ])
         
         let currentSection = ApiSectionSingle<ForecastapiResult<MultiDomains>.SurfaceAndPressureVariable>(name: "current_weather", time: Timestamp(2022,7,12,1,15), dtSeconds: 3600/4, columns: [
             ApiColumnSingle(variable: .surface(.temperature_20m), unit: .celsius, value: 20),
-            ApiColumnSingle(variable: .surface(.windspeed_100m), unit: .kmh, value: 10),
+            ApiColumnSingle(variable: .surface(.windspeed_100m), unit: .kilometresPerHour, value: 10),
         ])
         
         let res = ForecastapiResult<MultiDomains>.PerModel(

--- a/Tests/AppTests/OutputformatTests.swift
+++ b/Tests/AppTests/OutputformatTests.swift
@@ -56,14 +56,14 @@ final class OutputformatTests: XCTestCase {
             sixHourly: nil,
             minutely15: nil
         )
-        let location20year = ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: Timestamp(2000, 1, 1)..<Timestamp(2021, 1, 1), utcOffsetSeconds: 3600), results: [dataContainer])
+        let location20year = ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: Timestamp(2000, 1, 1)..<Timestamp(2021, 1, 1), utcOffsetSeconds: 3600), locationId: 0, results: [dataContainer])
         let result20year = ForecastapiResult<MultiDomains>(timeformat: .iso8601, results: [location20year])
         // 20 year data, one location, one variable
         XCTAssertEqual(result20year.calculateQueryWeight(nVariablesModels: 1), 54.79286)
         // 20 year data, one location, two variables
         XCTAssertEqual(result20year.calculateQueryWeight(nVariablesModels: 2), 109.58572)
         
-        let location7day = ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: Timestamp(2000, 1, 1)..<Timestamp(2000, 1, 8), utcOffsetSeconds: 3600), results: [dataContainer])
+        let location7day = ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: Timestamp(2000, 1, 1)..<Timestamp(2000, 1, 8), utcOffsetSeconds: 3600), locationId: 0, results: [dataContainer])
         
         let result7day = ForecastapiResult<MultiDomains>(timeformat: .iso8601, results: [location7day])
         // 7 day data, one location, one variable
@@ -75,7 +75,7 @@ final class OutputformatTests: XCTestCase {
         // 7 day data, one location, 30 variables
         XCTAssertEqual(result7day.calculateQueryWeight(nVariablesModels: 30), 3)
         
-        let location1month = ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: Timestamp(2000, 1, 1)..<Timestamp(2000, 2, 1), utcOffsetSeconds: 3600), results: [dataContainer])
+        let location1month = ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: Timestamp(2000, 1, 1)..<Timestamp(2000, 2, 1), utcOffsetSeconds: 3600), locationId: 0, results: [dataContainer])
         
         let result1month = ForecastapiResult<MultiDomains>(timeformat: .iso8601, results: [location1month, location1month])
         // 1 month data, two locations, one variable
@@ -153,7 +153,7 @@ final class OutputformatTests: XCTestCase {
             sixHourly: nil,
             minutely15: nil
         )
-        let data = ForecastapiResult<MultiDomains>(timeformat: .iso8601, results: [ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: daily.time.range, utcOffsetSeconds: 0), results: [res])])
+        let data = ForecastapiResult<MultiDomains>(timeformat: .iso8601, results: [ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: daily.time.range, utcOffsetSeconds: 0), locationId: 0, results: [res])])
         
         XCTAssertEqual(data.calculateQueryWeight(nVariablesModels: 2), 1)
         XCTAssertEqual(data.calculateQueryWeight(nVariablesModels: 15), 1.5)
@@ -164,7 +164,7 @@ final class OutputformatTests: XCTestCase {
             {"latitude":41.0,"longitude":2.0,"generationtime_ms":12.0,"utc_offset_seconds":3600,"timezone":"GMT","timezone_abbreviation":"GMT","current_weather_units":{"time":"iso8601","interval":"seconds","temperature_20m":"°C","windspeed_100m":"km/h"},"current_weather":{"time":"2022-07-12T02:15","interval":900,"temperature_20m":20.0,"windspeed_100m":10.0},"hourly_units":{"time":"iso8601","temperature_2m":"°C","windspeed_10m":"km/h"},"hourly":{"time":["2022-07-12T01:00","2022-07-12T02:00","2022-07-12T03:00","2022-07-12T04:00","2022-07-12T05:00","2022-07-12T06:00","2022-07-12T07:00","2022-07-12T08:00","2022-07-12T09:00","2022-07-12T10:00","2022-07-12T11:00","2022-07-12T12:00","2022-07-12T13:00","2022-07-12T14:00","2022-07-12T15:00","2022-07-12T16:00","2022-07-12T17:00","2022-07-12T18:00","2022-07-12T19:00","2022-07-12T20:00","2022-07-12T21:00","2022-07-12T22:00","2022-07-12T23:00","2022-07-13T00:00","2022-07-13T01:00","2022-07-13T02:00","2022-07-13T03:00","2022-07-13T04:00","2022-07-13T05:00","2022-07-13T06:00","2022-07-13T07:00","2022-07-13T08:00","2022-07-13T09:00","2022-07-13T10:00","2022-07-13T11:00","2022-07-13T12:00","2022-07-13T13:00","2022-07-13T14:00","2022-07-13T15:00","2022-07-13T16:00","2022-07-13T17:00","2022-07-13T18:00","2022-07-13T19:00","2022-07-13T20:00","2022-07-13T21:00","2022-07-13T22:00","2022-07-13T23:00","2022-07-14T00:00"],"temperature_2m":[20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0],"windspeed_10m":[10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0]},"daily_units":{"time":"iso8601","temperature_2m_mean":"°C","windspeed_10m_mean":"km/h"},"daily":{"time":["2022-07-12","2022-07-13"],"temperature_2m_mean":[20.0,20.0],"windspeed_10m_mean":[10.0,10.0]}}
             """)
         
-        let dataUnix = ForecastapiResult<MultiDomains>(timeformat: .unixtime, results: [ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: daily.time.range, utcOffsetSeconds: 0), results: [res])])
+        let dataUnix = ForecastapiResult<MultiDomains>(timeformat: .unixtime, results: [ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: daily.time.range, utcOffsetSeconds: 0), locationId: 0, results: [res])])
         
         let jsonUnix = drainString(dataUnix.response(format: .json, fixedGenerationTime: 12))
         XCTAssertEqual(jsonUnix, """
@@ -304,7 +304,7 @@ final class OutputformatTests: XCTestCase {
         XCTAssertEqual(xlsx, "fe097d32e320d1d122a1f391400e8cdb718d41c23bab8b976fdf8ad3db491024")
         
         let flatbuffers = drainData(data.response(format: .flatbuffers, fixedGenerationTime: 12)).sha256
-        XCTAssertEqual(flatbuffers, "8b9deedff8e1401ef0cb8a6296af8dbe7ee6bf875bb81d56b8a5972df358f131")
+        XCTAssertEqual(flatbuffers, "a1dadac11cfff2adbc09ff15355c9fa87f2671f16477d77312ef60e916a7c683")
     }
     
     /// Test output formats for 2 locations
@@ -352,8 +352,9 @@ final class OutputformatTests: XCTestCase {
             sixHourly: nil,
             minutely15: nil
         )
-        let location = ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: daily.time.range, utcOffsetSeconds: 0), results: [res])
-        let data = ForecastapiResult<MultiDomains>(timeformat: .iso8601, results: [location, location])
+        let location1 = ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: daily.time.range, utcOffsetSeconds: 0), locationId: 0, results: [res])
+        let location2 = ForecastapiResult<MultiDomains>.PerLocation(timezone: .init(utcOffsetSeconds: 3600, identifier: "GMT", abbreviation: "GMT"), time: TimerangeLocal(range: daily.time.range, utcOffsetSeconds: 0), locationId: 1, results: [res])
+        let data = ForecastapiResult<MultiDomains>(timeformat: .iso8601, results: [location1, location2])
         
         XCTAssertEqual(data.calculateQueryWeight(nVariablesModels: 2), 2)
         XCTAssertEqual(data.calculateQueryWeight(nVariablesModels: 15), 3)
@@ -364,7 +365,7 @@ final class OutputformatTests: XCTestCase {
             [{"latitude":41.0,"longitude":2.0,"generationtime_ms":12.0,"utc_offset_seconds":3600,"timezone":"GMT","timezone_abbreviation":"GMT","current_weather_units":{"time":"iso8601","interval":"seconds","temperature_20m":"°C","windspeed_100m":"km/h"},"current_weather":{"time":"2022-07-12T02:15","interval":900,"temperature_20m":20.0,"windspeed_100m":10.0},"hourly_units":{"time":"iso8601","temperature_2m":"°C","windspeed_10m":"km/h"},"hourly":{"time":["2022-07-12T01:00","2022-07-12T02:00","2022-07-12T03:00","2022-07-12T04:00","2022-07-12T05:00","2022-07-12T06:00","2022-07-12T07:00","2022-07-12T08:00","2022-07-12T09:00","2022-07-12T10:00","2022-07-12T11:00","2022-07-12T12:00","2022-07-12T13:00","2022-07-12T14:00","2022-07-12T15:00","2022-07-12T16:00","2022-07-12T17:00","2022-07-12T18:00","2022-07-12T19:00","2022-07-12T20:00","2022-07-12T21:00","2022-07-12T22:00","2022-07-12T23:00","2022-07-13T00:00","2022-07-13T01:00","2022-07-13T02:00","2022-07-13T03:00","2022-07-13T04:00","2022-07-13T05:00","2022-07-13T06:00","2022-07-13T07:00","2022-07-13T08:00","2022-07-13T09:00","2022-07-13T10:00","2022-07-13T11:00","2022-07-13T12:00","2022-07-13T13:00","2022-07-13T14:00","2022-07-13T15:00","2022-07-13T16:00","2022-07-13T17:00","2022-07-13T18:00","2022-07-13T19:00","2022-07-13T20:00","2022-07-13T21:00","2022-07-13T22:00","2022-07-13T23:00","2022-07-14T00:00"],"temperature_2m":[20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0],"windspeed_10m":[10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0]},"daily_units":{"time":"iso8601","temperature_2m_mean":"°C","windspeed_10m_mean":"km/h"},"daily":{"time":["2022-07-12","2022-07-13"],"temperature_2m_mean":[20.0,20.0],"windspeed_10m_mean":[10.0,10.0]}},{"latitude":41.0,"longitude":2.0,"generationtime_ms":12.0,"utc_offset_seconds":3600,"timezone":"GMT","timezone_abbreviation":"GMT","current_weather_units":{"time":"iso8601","interval":"seconds","temperature_20m":"°C","windspeed_100m":"km/h"},"current_weather":{"time":"2022-07-12T02:15","interval":900,"temperature_20m":20.0,"windspeed_100m":10.0},"hourly_units":{"time":"iso8601","temperature_2m":"°C","windspeed_10m":"km/h"},"hourly":{"time":["2022-07-12T01:00","2022-07-12T02:00","2022-07-12T03:00","2022-07-12T04:00","2022-07-12T05:00","2022-07-12T06:00","2022-07-12T07:00","2022-07-12T08:00","2022-07-12T09:00","2022-07-12T10:00","2022-07-12T11:00","2022-07-12T12:00","2022-07-12T13:00","2022-07-12T14:00","2022-07-12T15:00","2022-07-12T16:00","2022-07-12T17:00","2022-07-12T18:00","2022-07-12T19:00","2022-07-12T20:00","2022-07-12T21:00","2022-07-12T22:00","2022-07-12T23:00","2022-07-13T00:00","2022-07-13T01:00","2022-07-13T02:00","2022-07-13T03:00","2022-07-13T04:00","2022-07-13T05:00","2022-07-13T06:00","2022-07-13T07:00","2022-07-13T08:00","2022-07-13T09:00","2022-07-13T10:00","2022-07-13T11:00","2022-07-13T12:00","2022-07-13T13:00","2022-07-13T14:00","2022-07-13T15:00","2022-07-13T16:00","2022-07-13T17:00","2022-07-13T18:00","2022-07-13T19:00","2022-07-13T20:00","2022-07-13T21:00","2022-07-13T22:00","2022-07-13T23:00","2022-07-14T00:00"],"temperature_2m":[20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0],"windspeed_10m":[10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0]},"daily_units":{"time":"iso8601","temperature_2m_mean":"°C","windspeed_10m_mean":"km/h"},"daily":{"time":["2022-07-12","2022-07-13"],"temperature_2m_mean":[20.0,20.0],"windspeed_10m_mean":[10.0,10.0]}}]
             """)
         
-        let dataUnix = ForecastapiResult<MultiDomains>(timeformat: .unixtime, results: [location, location])
+        let dataUnix = ForecastapiResult<MultiDomains>(timeformat: .unixtime, results: [location1, location2])
         
         let jsonUnix = drainString(dataUnix.response(format: .json, fixedGenerationTime: 12))
         XCTAssertEqual(jsonUnix, """
@@ -374,14 +375,62 @@ final class OutputformatTests: XCTestCase {
         let csv = drainString(data.response(format: .csv))
         XCTAssertEqual(csv, """
             location_id,latitude,longitude,elevation,utc_offset_seconds,timezone,timezone_abbreviation
+            0,41.0,2.0,NaN,3600,GMT,GMT
             1,41.0,2.0,NaN,3600,GMT,GMT
-            2,41.0,2.0,NaN,3600,GMT,GMT
             
             location_id,time,temperature_20m (°C),windspeed_100m (km/h)
+            0,2022-07-12T02:15,20.0,10.0
             1,2022-07-12T02:15,20.0,10.0
-            2,2022-07-12T02:15,20.0,10.0
 
             location_id,time,temperature_2m (°C),windspeed_10m (km/h)
+            0,2022-07-12T01:00,20.0,10.0
+            0,2022-07-12T02:00,20.0,10.0
+            0,2022-07-12T03:00,20.0,10.0
+            0,2022-07-12T04:00,20.0,10.0
+            0,2022-07-12T05:00,20.0,10.0
+            0,2022-07-12T06:00,20.0,10.0
+            0,2022-07-12T07:00,20.0,10.0
+            0,2022-07-12T08:00,20.0,10.0
+            0,2022-07-12T09:00,20.0,10.0
+            0,2022-07-12T10:00,20.0,10.0
+            0,2022-07-12T11:00,20.0,10.0
+            0,2022-07-12T12:00,20.0,10.0
+            0,2022-07-12T13:00,20.0,10.0
+            0,2022-07-12T14:00,20.0,10.0
+            0,2022-07-12T15:00,20.0,10.0
+            0,2022-07-12T16:00,20.0,10.0
+            0,2022-07-12T17:00,20.0,10.0
+            0,2022-07-12T18:00,20.0,10.0
+            0,2022-07-12T19:00,20.0,10.0
+            0,2022-07-12T20:00,20.0,10.0
+            0,2022-07-12T21:00,20.0,10.0
+            0,2022-07-12T22:00,20.0,10.0
+            0,2022-07-12T23:00,20.0,10.0
+            0,2022-07-13T00:00,20.0,10.0
+            0,2022-07-13T01:00,20.0,10.0
+            0,2022-07-13T02:00,20.0,10.0
+            0,2022-07-13T03:00,20.0,10.0
+            0,2022-07-13T04:00,20.0,10.0
+            0,2022-07-13T05:00,20.0,10.0
+            0,2022-07-13T06:00,20.0,10.0
+            0,2022-07-13T07:00,20.0,10.0
+            0,2022-07-13T08:00,20.0,10.0
+            0,2022-07-13T09:00,20.0,10.0
+            0,2022-07-13T10:00,20.0,10.0
+            0,2022-07-13T11:00,20.0,10.0
+            0,2022-07-13T12:00,20.0,10.0
+            0,2022-07-13T13:00,20.0,10.0
+            0,2022-07-13T14:00,20.0,10.0
+            0,2022-07-13T15:00,20.0,10.0
+            0,2022-07-13T16:00,20.0,10.0
+            0,2022-07-13T17:00,20.0,10.0
+            0,2022-07-13T18:00,20.0,10.0
+            0,2022-07-13T19:00,20.0,10.0
+            0,2022-07-13T20:00,20.0,10.0
+            0,2022-07-13T21:00,20.0,10.0
+            0,2022-07-13T22:00,20.0,10.0
+            0,2022-07-13T23:00,20.0,10.0
+            0,2022-07-14T00:00,20.0,10.0
             1,2022-07-12T01:00,20.0,10.0
             1,2022-07-12T02:00,20.0,10.0
             1,2022-07-12T03:00,20.0,10.0
@@ -430,74 +479,74 @@ final class OutputformatTests: XCTestCase {
             1,2022-07-13T22:00,20.0,10.0
             1,2022-07-13T23:00,20.0,10.0
             1,2022-07-14T00:00,20.0,10.0
-            2,2022-07-12T01:00,20.0,10.0
-            2,2022-07-12T02:00,20.0,10.0
-            2,2022-07-12T03:00,20.0,10.0
-            2,2022-07-12T04:00,20.0,10.0
-            2,2022-07-12T05:00,20.0,10.0
-            2,2022-07-12T06:00,20.0,10.0
-            2,2022-07-12T07:00,20.0,10.0
-            2,2022-07-12T08:00,20.0,10.0
-            2,2022-07-12T09:00,20.0,10.0
-            2,2022-07-12T10:00,20.0,10.0
-            2,2022-07-12T11:00,20.0,10.0
-            2,2022-07-12T12:00,20.0,10.0
-            2,2022-07-12T13:00,20.0,10.0
-            2,2022-07-12T14:00,20.0,10.0
-            2,2022-07-12T15:00,20.0,10.0
-            2,2022-07-12T16:00,20.0,10.0
-            2,2022-07-12T17:00,20.0,10.0
-            2,2022-07-12T18:00,20.0,10.0
-            2,2022-07-12T19:00,20.0,10.0
-            2,2022-07-12T20:00,20.0,10.0
-            2,2022-07-12T21:00,20.0,10.0
-            2,2022-07-12T22:00,20.0,10.0
-            2,2022-07-12T23:00,20.0,10.0
-            2,2022-07-13T00:00,20.0,10.0
-            2,2022-07-13T01:00,20.0,10.0
-            2,2022-07-13T02:00,20.0,10.0
-            2,2022-07-13T03:00,20.0,10.0
-            2,2022-07-13T04:00,20.0,10.0
-            2,2022-07-13T05:00,20.0,10.0
-            2,2022-07-13T06:00,20.0,10.0
-            2,2022-07-13T07:00,20.0,10.0
-            2,2022-07-13T08:00,20.0,10.0
-            2,2022-07-13T09:00,20.0,10.0
-            2,2022-07-13T10:00,20.0,10.0
-            2,2022-07-13T11:00,20.0,10.0
-            2,2022-07-13T12:00,20.0,10.0
-            2,2022-07-13T13:00,20.0,10.0
-            2,2022-07-13T14:00,20.0,10.0
-            2,2022-07-13T15:00,20.0,10.0
-            2,2022-07-13T16:00,20.0,10.0
-            2,2022-07-13T17:00,20.0,10.0
-            2,2022-07-13T18:00,20.0,10.0
-            2,2022-07-13T19:00,20.0,10.0
-            2,2022-07-13T20:00,20.0,10.0
-            2,2022-07-13T21:00,20.0,10.0
-            2,2022-07-13T22:00,20.0,10.0
-            2,2022-07-13T23:00,20.0,10.0
-            2,2022-07-14T00:00,20.0,10.0
 
             location_id,time,temperature_2m_mean (°C),windspeed_10m_mean (km/h)
+            0,2022-07-12,20.0,10.0
+            0,2022-07-13,20.0,10.0
             1,2022-07-12,20.0,10.0
             1,2022-07-13,20.0,10.0
-            2,2022-07-12,20.0,10.0
-            2,2022-07-13,20.0,10.0
 
             """)
         
         let csvUnix = drainString(dataUnix.response(format: .csv))
         XCTAssertEqual(csvUnix, """
             location_id,latitude,longitude,elevation,utc_offset_seconds,timezone,timezone_abbreviation
+            0,41.0,2.0,NaN,3600,GMT,GMT
             1,41.0,2.0,NaN,3600,GMT,GMT
-            2,41.0,2.0,NaN,3600,GMT,GMT
             
             location_id,time,temperature_20m (°C),windspeed_100m (km/h)
+            0,1657588500,20.0,10.0
             1,1657588500,20.0,10.0
-            2,1657588500,20.0,10.0
 
             location_id,time,temperature_2m (°C),windspeed_10m (km/h)
+            0,1657584000,20.0,10.0
+            0,1657587600,20.0,10.0
+            0,1657591200,20.0,10.0
+            0,1657594800,20.0,10.0
+            0,1657598400,20.0,10.0
+            0,1657602000,20.0,10.0
+            0,1657605600,20.0,10.0
+            0,1657609200,20.0,10.0
+            0,1657612800,20.0,10.0
+            0,1657616400,20.0,10.0
+            0,1657620000,20.0,10.0
+            0,1657623600,20.0,10.0
+            0,1657627200,20.0,10.0
+            0,1657630800,20.0,10.0
+            0,1657634400,20.0,10.0
+            0,1657638000,20.0,10.0
+            0,1657641600,20.0,10.0
+            0,1657645200,20.0,10.0
+            0,1657648800,20.0,10.0
+            0,1657652400,20.0,10.0
+            0,1657656000,20.0,10.0
+            0,1657659600,20.0,10.0
+            0,1657663200,20.0,10.0
+            0,1657666800,20.0,10.0
+            0,1657670400,20.0,10.0
+            0,1657674000,20.0,10.0
+            0,1657677600,20.0,10.0
+            0,1657681200,20.0,10.0
+            0,1657684800,20.0,10.0
+            0,1657688400,20.0,10.0
+            0,1657692000,20.0,10.0
+            0,1657695600,20.0,10.0
+            0,1657699200,20.0,10.0
+            0,1657702800,20.0,10.0
+            0,1657706400,20.0,10.0
+            0,1657710000,20.0,10.0
+            0,1657713600,20.0,10.0
+            0,1657717200,20.0,10.0
+            0,1657720800,20.0,10.0
+            0,1657724400,20.0,10.0
+            0,1657728000,20.0,10.0
+            0,1657731600,20.0,10.0
+            0,1657735200,20.0,10.0
+            0,1657738800,20.0,10.0
+            0,1657742400,20.0,10.0
+            0,1657746000,20.0,10.0
+            0,1657749600,20.0,10.0
+            0,1657753200,20.0,10.0
             1,1657584000,20.0,10.0
             1,1657587600,20.0,10.0
             1,1657591200,20.0,10.0
@@ -546,69 +595,21 @@ final class OutputformatTests: XCTestCase {
             1,1657746000,20.0,10.0
             1,1657749600,20.0,10.0
             1,1657753200,20.0,10.0
-            2,1657584000,20.0,10.0
-            2,1657587600,20.0,10.0
-            2,1657591200,20.0,10.0
-            2,1657594800,20.0,10.0
-            2,1657598400,20.0,10.0
-            2,1657602000,20.0,10.0
-            2,1657605600,20.0,10.0
-            2,1657609200,20.0,10.0
-            2,1657612800,20.0,10.0
-            2,1657616400,20.0,10.0
-            2,1657620000,20.0,10.0
-            2,1657623600,20.0,10.0
-            2,1657627200,20.0,10.0
-            2,1657630800,20.0,10.0
-            2,1657634400,20.0,10.0
-            2,1657638000,20.0,10.0
-            2,1657641600,20.0,10.0
-            2,1657645200,20.0,10.0
-            2,1657648800,20.0,10.0
-            2,1657652400,20.0,10.0
-            2,1657656000,20.0,10.0
-            2,1657659600,20.0,10.0
-            2,1657663200,20.0,10.0
-            2,1657666800,20.0,10.0
-            2,1657670400,20.0,10.0
-            2,1657674000,20.0,10.0
-            2,1657677600,20.0,10.0
-            2,1657681200,20.0,10.0
-            2,1657684800,20.0,10.0
-            2,1657688400,20.0,10.0
-            2,1657692000,20.0,10.0
-            2,1657695600,20.0,10.0
-            2,1657699200,20.0,10.0
-            2,1657702800,20.0,10.0
-            2,1657706400,20.0,10.0
-            2,1657710000,20.0,10.0
-            2,1657713600,20.0,10.0
-            2,1657717200,20.0,10.0
-            2,1657720800,20.0,10.0
-            2,1657724400,20.0,10.0
-            2,1657728000,20.0,10.0
-            2,1657731600,20.0,10.0
-            2,1657735200,20.0,10.0
-            2,1657738800,20.0,10.0
-            2,1657742400,20.0,10.0
-            2,1657746000,20.0,10.0
-            2,1657749600,20.0,10.0
-            2,1657753200,20.0,10.0
 
             location_id,time,temperature_2m_mean (°C),windspeed_10m_mean (km/h)
+            0,1657584000,20.0,10.0
+            0,1657670400,20.0,10.0
             1,1657584000,20.0,10.0
             1,1657670400,20.0,10.0
-            2,1657584000,20.0,10.0
-            2,1657670400,20.0,10.0
             
             """)
         
         /// needs to set a timestamp, because of zip compression headers
         let xlsx = drainData(data.response(format: .xlsx, timestamp: Timestamp(2022,7,13))).sha256
-        XCTAssertEqual(xlsx, "cdbeec4c3f64c339c812db4254017d1310a94ec3209ae44119727ea0865034c7")
+        XCTAssertEqual(xlsx, "91e1b562e1a7ef1fafe7894f0a797162405eb30677099a5f8e9665d7b180026b")
         
         let flatbuffers = drainData(data.response(format: .flatbuffers, fixedGenerationTime: 12)).sha256
-        XCTAssertEqual(flatbuffers, "c538f06878fa10f9d2f8d643b6895ca93edf021788ca9b5855eec0a8eaf9f7a8")
+        XCTAssertEqual(flatbuffers, "52899e668476fef0cbc11934eedcd8adafd54e2f413fef3e7774abce1c62f73b")
     }
     
     func testXlsxWriter() throws {

--- a/openapi.yml
+++ b/openapi.yml
@@ -30,33 +30,33 @@ paths:
             type: string
             enum:
             - temperature_2m
-            - relativehumidity_2m
-            - dewpoint_2m
+            - relative_humidity_2m
+            - dew_point_2m
             - apparent_temperature
             - pressure_msl
-            - cloudcover
-            - cloudcover_low
-            - cloudcover_mid
-            - cloudcover_high
-            - windspeed_10m
-            - windspeed_80m
-            - windspeed_120m
-            - windspeed_180m
-            - winddirection_10m
-            - winddirection_80m
-            - winddirection_120m
-            - winddirection_180m
-            - windgusts_10m
+            - cloud_cover
+            - cloud_cover_low
+            - cloud_cover_mid
+            - cloud_cover_high
+            - wind_speed_10m
+            - wind_speed_80m
+            - wind_speed_120m
+            - wind_speed_180m
+            - wind_direction_10m
+            - wind_direction_80m
+            - wind_direction_120m
+            - wind_direction_180m
+            - wind_gusts_10m
             - shortwave_radiation
             - direct_radiation
             - direct_normal_irradiance
             - diffuse_radiation
-            - vapor_pressure_deficit
+            - vapour_pressure_deficit
             - evapotranspiration
             - precipitation
-            - weathercode
+            - weather_code
             - snow_height
-            - freezinglevel_height
+            - freezing_level_height
             - soil_temperature_0cm
             - soil_temperature_6cm
             - soil_temperature_18cm
@@ -79,12 +79,12 @@ paths:
             - apparent_temperature_min
             - precipitation_sum
             - precipitation_hours
-            - weathercode
+            - weather_code
             - sunrise
             - sunset
-            - windspeed_10m_max
-            - windgusts_10m_max
-            - winddirection_10m_dominant
+            - wind_speed_10m_max
+            - wind_gusts_10m_max
+            - wind_direction_10m_dominant
             - shortwave_radiation_sum
             - uv_index_max
             - uv_index_clear_sky_max
@@ -115,7 +115,7 @@ paths:
           enum:
           - celsius
           - fahrenheit
-      - name: windspeed_unit
+      - name: wind_speed_unit
         in: query
         schema:
           type: string
@@ -193,7 +193,7 @@ paths:
                     description: For each selected daily weather variable, the unit will be listed here.
                   current_weather:
                     type: CurrentWeather
-                    description: "Current weather conditions with the attributes: time, temperature, windspeed, winddirection and weathercode"
+                    description: "Current weather conditions with the attributes: time, temperature, wind_speed, wind_direction and weather_code"
         400:
           description: Bad Request
           content:
@@ -223,11 +223,11 @@ components:
           type: array
           items:
             type: float
-        relativehumidity_2m:
+        relative_humidity_2m:
           type: array
           items:
             type: float
-        dewpoint_2m:
+        dew_point_2m:
           type: array
           items:
             type: float
@@ -239,55 +239,55 @@ components:
           type: array
           items:
             type: float
-        cloudcover:
+        cloud_cover:
           type: array
           items:
             type: float
-        cloudcover_low:
+        cloud_cover_low:
           type: array
           items:
             type: float
-        cloudcover_mid:
+        cloud_cover_mid:
           type: array
           items:
             type: float
-        cloudcover_high:
+        cloud_cover_high:
           type: array
           items:
             type: float
-        windspeed_10m:
+        wind_speed_10m:
           type: array
           items:
             type: float
-        windspeed_80m:
+        wind_speed_80m:
           type: array
           items:
             type: float
-        windspeed_120m:
+        wind_speed_120m:
           type: array
           items:
             type: float
-        windspeed_180m:
+        wind_speed_180m:
           type: array
           items:
             type: float
-        winddirection_10m:
+        wind_direction_10m:
           type: array
           items:
             type: float
-        winddirection_80m:
+        wind_direction_80m:
           type: array
           items:
             type: float
-        winddirection_120m:
+        wind_direction_120m:
           type: array
           items:
             type: float
-        winddirection_180m:
+        wind_direction_180m:
           type: array
           items:
             type: float
-        windgusts_10m:
+        wind_gusts_10m:
           type: array
           items:
             type: float
@@ -307,7 +307,7 @@ components:
           type: array
           items:
             type: float
-        vapor_pressure_deficit:
+        vapour_pressure_deficit:
           type: array
           items:
             type: float
@@ -319,7 +319,7 @@ components:
           type: array
           items:
             type: float
-        weathercode:
+        weather_code:
           type: array
           items:
             type: float
@@ -327,7 +327,7 @@ components:
           type: array
           items:
             type: float
-        freezinglevel_height:
+        freezing_level_height:
           type: array
           items:
             type: float
@@ -398,7 +398,7 @@ components:
           type: array
           items:
             type: float
-        weathercode:
+        weather_code:
           type: array
           items:
             type: float
@@ -410,15 +410,15 @@ components:
           type: array
           items:
             type: float
-        windspeed_10m_max:
+        wind_speed_10m_max:
           type: array
           items:
             type: float
-        windgusts_10m_max:
+        wind_gusts_10m_max:
           type: array
           items:
             type: float
-        winddirection_10m_dominant:
+        wind_direction_10m_dominant:
           type: array
           items:
             type: float
@@ -447,15 +447,15 @@ components:
           type: string
         temperature:
           type: float
-        windspeed:
+        wind_speed:
           type: float
-        winddirection:
+        wind_direction:
           type: float
-        weathercode:
+        weather_code:
           type: int
       required:
         - time
         - temperature
-        - windspeed
-        - winddirection
-        - weathercode
+        - wind_speed
+        - wind_direction
+        - weather_code

--- a/openapi_historical_weather_api.yml
+++ b/openapi_historical_weather_api.yml
@@ -44,28 +44,28 @@ paths:
             type: string
             enum:
             - temperature_2m
-            - relativehumidity_2m
-            - dewpoint_2m
+            - relative_humidity_2m
+            - dew_point_2m
             - apparent_temperature
             - pressure_msl
-            - cloudcover
-            - cloudcover_low
-            - cloudcover_mid
-            - cloudcover_high
-            - windspeed_10m
-            - windspeed_100m
-            - winddirection_10m
-            - winddirection_100m
-            - windgusts_10m
+            - cloud_cover
+            - cloud_cover_low
+            - cloud_cover_mid
+            - cloud_cover_high
+            - wind_speed_10m
+            - wind_speed_100m
+            - wind_direction_10m
+            - wind_direction_100m
+            - wind_gusts_10m
             - shortwave_radiation
             - direct_radiation
             - direct_normal_irradiance
             - diffuse_radiation
-            - vapor_pressure_deficit
+            - vapour_pressure_deficit
             - et0_fao_evapotranspiration
             - precipitation
             - rain
-            - weathercode
+            - weather_code
             - snowfall
             - soil_temperature_0_to_7cm
             - soil_temperature_7_to_28cm
@@ -88,12 +88,12 @@ paths:
             - apparent_temperature_min
             - precipitation_sum
             - precipitation_hours
-            - weathercode
+            - weather_code
             - sunrise
             - sunset
-            - windspeed_10m_max
-            - windgusts_10m_max
-            - winddirection_10m_dominant
+            - wind_speed_10m_max
+            - wind_gusts_10m_max
+            - wind_direction_10m_dominant
             - shortwave_radiation_sum
             - et0_fao_evapotranspiration
       - name: latitude
@@ -118,7 +118,7 @@ paths:
           enum:
           - celsius
           - fahrenheit
-      - name: windspeed_unit
+      - name: wind_speed_unit
         in: query
         schema:
           type: string


### PR DESCRIPTION
The old encoding wrongly used attributes which had to be filled with zeros in the binary representation. The new schema uses arrays with attributes

This PR adds variable names like `wind_speed_10m` in addition to `windspeed_10m` to have consistent snake and camel case. The documentation will also be updated to use the correct snake case variables. Needless to say, the old names will be supported as well.