### PR TITLE
feat: Integrate daylight and sunshine duration

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-meteo/sdk.git",
       "state" : {
-        "revision" : "d69218cb0fea5d455dd5f8ac4cc683a1a5f0d1e2",
-        "version" : "1.5.0"
+        "revision" : "f9f94bce409cda53f3c75f9eebf7d7f1ef7ad531",
+        "version" : "1.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.67.4"),
         .package(url: "https://github.com/google/flatbuffers.git", from: "23.3.3"),
-        .package(url: "https://github.com/open-meteo/sdk.git", from: "1.4.0"),
+        .package(url: "https://github.com/open-meteo/sdk.git", from: "1.6.0"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftNetCDF.git", from: "1.0.0"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftTimeZoneLookup.git", from: "1.0.1"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftEccodes.git", from: "0.1.5"),

--- a/Sources/App/Cmip6/CmipController.swift
+++ b/Sources/App/Cmip6/CmipController.swift
@@ -589,7 +589,7 @@ struct Cmip6ReaderPostBiasCorrected<ReaderNext: GenericReaderProtocol>: GenericR
             let soilMoisture = try get(raw: .derived(.soil_moisture_0_to_100cm_mean), time: time)
             return DataAndUnit(type.calculateSoilMoistureIndex(soilMoisture.data), .fraction)
         case .daylight_duration:
-            // note: time should aldign to UTC 0 midnight
+            // note: time should align to UTC 0 midnight
             return DataAndUnit(Zensun.calculateDaylightDuration(utcMidnight: time.range, lat: modelLat, lon: modelLon), .seconds)
         case .windspeed_2m_max, .wind_speed_2m_max:
             let wind = try get(raw: .raw(.windspeed_10m_max), time: time)

--- a/Sources/App/Controllers/EnsembleController.swift
+++ b/Sources/App/Controllers/EnsembleController.swift
@@ -229,6 +229,8 @@ enum EnsembleSurfaceVariable: String, GenericVariableMixable, Equatable, RawRepr
     case soil_moisture_40_to_100cm
     case soil_moisture_100_to_200cm
     
+    case sunshine_duration
+    
     /// Soil moisture or snow depth are cumulative processes and have offests if mutliple models are mixed
     var requiresOffsetCorrectionForMixing: Bool {
         switch self {

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -186,6 +186,11 @@ struct WeatherApiController {
                                         return ApiColumn(variable: .sunrise, unit: params.timeformatOrDefault.unit, variables: [.timestamp(times.rise)])
                                     }
                                 }
+                                if variable == .daylight_duration {
+                                    let duration = Zensun.calculateDaylightDuration(localMidnight: dailyTime.range, lat: reader.modelLat)
+                                    return ApiColumn(variable: .daylight_duration, unit: .seconds, variables: [.float(duration)])
+                                }
+                                
                                 guard let d = try reader.getDaily(variable: variable, params: params, time: dailyTime) else {
                                     return nil
                                 }
@@ -497,6 +502,7 @@ enum ForecastSurfaceVariable: String, GenericVariableMixable {
     case snow_height
     case snowfall
     case snowfall_water_equivalent
+    case sunshine_duration
     case soil_moisture_0_1cm
     case soil_moisture_0_to_1cm
     case soil_moisture_0_to_100cm
@@ -746,6 +752,8 @@ enum ForecastVariableDaily: String, DailyVariableCalculatable, RawRepresentableS
     case soil_temperature_7_to_28cm_mean
     case sunrise
     case sunset
+    case daylight_duration
+    case sunshine_duration
     case surface_pressure_max
     case surface_pressure_mean
     case surface_pressure_min
@@ -927,6 +935,10 @@ enum ForecastVariableDaily: String, DailyVariableCalculatable, RawRepresentableS
             return .min(.surface(.wet_bulb_temperature_2m))
         case .wet_bulb_temperature_2m_mean:
             return .mean(.surface(.wet_bulb_temperature_2m))
+        case .daylight_duration:
+            return .none
+        case .sunshine_duration:
+            return .sum(.surface(.sunshine_duration))
         }
     }
 }

--- a/Sources/App/Era5/CerraDomain.swift
+++ b/Sources/App/Era5/CerraDomain.swift
@@ -39,6 +39,7 @@ enum CerraVariableDerived: String, RawRepresentableString, GenericVariableMixabl
     case cloud_cover_low
     case cloud_cover_mid
     case cloud_cover_high
+    case sunshine_duration
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false
@@ -155,6 +156,8 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             try prefetchData(raw: .windspeed_100m, time: time)
         case .wind_direction_100m:
             try prefetchData(raw: .windspeed_100m, time: time)
+        case .sunshine_duration:
+            try prefetchData(raw: .direct_radiation, time: time)
         }
     }
     
@@ -294,6 +297,10 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             return try get(raw: .cloudcover_mid, time: time)
         case .cloud_cover_high:
             return try get(raw: .cloudcover_high, time: time)
+        case .sunshine_duration:
+            let directRadiation = try get(raw: .direct_radiation, time: time)
+            let duration = Zensun.calculateBackwardsSunshineDuration(directRadiation: directRadiation.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
+            return DataAndUnit(duration, .seconds)
         }
     }
 }

--- a/Sources/App/Era5/Era5Controller.swift
+++ b/Sources/App/Era5/Era5Controller.swift
@@ -52,6 +52,7 @@ enum Era5VariableDerived: String, RawRepresentableString, GenericVariableMixable
     case wet_bulb_temperature_2m
     case wind_gusts_10m
     case dew_point_2m
+    case sunshine_duration
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false

--- a/Sources/App/Era5/Era5Domain.swift
+++ b/Sources/App/Era5/Era5Domain.swift
@@ -516,6 +516,8 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             try prefetchData(raw: .windgusts_10m, time: time)
         case .dew_point_2m:
             try prefetchData(raw: .dewpoint_2m, time: time)
+        case .sunshine_duration:
+            try prefetchData(raw: .direct_radiation, time: time)
         }
     }
     
@@ -752,6 +754,10 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             return try get(raw: .windgusts_10m, time: time)
         case .dew_point_2m:
             return try get(raw: .dewpoint_2m, time: time)
+        case .sunshine_duration:
+            let directRadiation = try get(raw: .direct_radiation, time: time)
+            let duration = Zensun.calculateBackwardsSunshineDuration(directRadiation: directRadiation.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
+            return DataAndUnit(duration, .seconds)
         }
     }
 }

--- a/Sources/App/Gem/GemController.swift
+++ b/Sources/App/Gem/GemController.swift
@@ -44,6 +44,8 @@ enum GemVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case wind_direction_120m
     case wind_gusts_10m
     
+    case sunshine_duration
+    
     var requiresOffsetCorrectionForMixing: Bool {
         return false
     }
@@ -204,6 +206,8 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 try prefetchData(raw: .init(.surface(.winddirection_120m), member), time: time)
             case .wind_gusts_10m:
                 try prefetchData(raw: .init(.surface(.windgusts_10m), member), time: time)
+            case .sunshine_duration:
+                try prefetchData(derived: .init(.surface(.direct_radiation), member), time: time)
             }
         case .pressure(let v):
             switch v.variable {
@@ -389,6 +393,10 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 return try get(raw: .init(.surface(.winddirection_120m), member), time: time)
             case .wind_gusts_10m:
                 return try get(raw: .init(.surface(.windgusts_10m), member), time: time)
+            case .sunshine_duration:
+                let directRadiation = try get(derived: .init(.surface(.direct_radiation), member), time: time)
+                let duration = Zensun.calculateBackwardsSunshineDuration(directRadiation: directRadiation.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
+                return DataAndUnit(duration, .seconds)
             }
         case .pressure(let v):
             switch v.variable {

--- a/Sources/App/Gfs/GfsController.swift
+++ b/Sources/App/Gfs/GfsController.swift
@@ -53,6 +53,8 @@ enum GfsVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case wind_gusts_10m
     case freezing_level_height
     
+    case sunshine_duration
+    
     var requiresOffsetCorrectionForMixing: Bool {
         return false
     }
@@ -334,6 +336,8 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(raw: .init(.surface(.windgusts_10m), member), time: time)
             case .freezing_level_height:
                 try prefetchData(raw: .init(.surface(.freezinglevel_height), member), time: time)
+            case .sunshine_duration:
+                try prefetchData(derived: .init(.surface(.direct_radiation), member), time: time)
             }
         case .pressure(let v):
             switch v.variable {
@@ -565,6 +569,10 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 return try get(raw: .init(.surface(.windgusts_10m), member), time: time)
             case .freezing_level_height:
                 return try get(raw: .init(.surface(.freezinglevel_height), member), time: time)
+            case .sunshine_duration:
+                let directRadiation = try get(derived: .init(.surface(.direct_radiation), member), time: time)
+                let duration = Zensun.calculateBackwardsSunshineDuration(directRadiation: directRadiation.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
+                return DataAndUnit(duration, .seconds)
             }
         case .pressure(let v):
             switch v.variable {

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+EnsembleApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+EnsembleApi.swift
@@ -97,6 +97,8 @@ extension EnsembleSurfaceVariable: FlatBuffersVariable {
             return .init(variable: .soilMoisture, depth: 40, depthTo: 100)
         case .soil_moisture_100_to_200cm:
             return .init(variable: .soilMoisture, depth: 100, depthTo: 255)
+        case .sunshine_duration:
+            return .init(variable: .sunshineDuration)
         }
     }
 }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
@@ -256,6 +256,8 @@ extension ForecastSurfaceVariable: FlatBuffersVariable {
             return .init(variable: .waveDirection)
         case .wave_period:
             return .init(variable: .wavePeriod)
+        case .sunshine_duration:
+            return .init(variable: .sunshineDuration)
         }
     }
 }
@@ -430,6 +432,10 @@ extension ForecastVariableDaily: FlatBuffersVariable {
             return .init(variable: .wetBulbTemperature, aggregation: .mean, altitude: 2)
         case .wet_bulb_temperature_2m_min:
             return .init(variable: .wetBulbTemperature, aggregation: .minimum, altitude: 2)
+        case .daylight_duration:
+            return .init(variable: .daylightDuration)
+        case .sunshine_duration:
+            return .init(variable: .sunshineDuration)
         }
     }
 }

--- a/Sources/App/Helper/Zensun.swift
+++ b/Sources/App/Helper/Zensun.swift
@@ -304,10 +304,73 @@ public struct Zensun {
     
     /// Approximate daylight duration (DNI > 120 w/m2) in seconds. `directRadiation` must be backwards averaged over dt.
     /// Assumes a linear distribution over 60-180 watts. Could be improved with different distribution forms
+    /// Timeinterval `dt`is adjusted to sunrise and sunset to ensure. Only considering DNI will lead to sunshine greated than daylight duration.
     public static func calculateBackwardsSunshineDuration(directRadiation: [Float], latitude: Float, longitude: Float, timerange: TimerangeDt) -> [Float] {
         let dt =  Float(timerange.dtSeconds)
-        return calculateBackwardsDNI(directRadiation: directRadiation, latitude: latitude, longitude: longitude, timerange: timerange).map { dni in
-            return min(max(dni - 60, 0) / (180 - 60) * dt, dt)
+        
+        return zip(directRadiation, timerange).map { (dhi, timestamp) in
+            if dhi.isNaN {
+                return .nan
+            }
+            if dhi <= 0 {
+                return 0
+            }
+            
+            /// DNI is typically limted to 85° zenith. We apply 5° to the parallax in addition to atmospheric refraction
+            /// The parallax is then use to limit integral coefficients to sun rise/set
+            let alpha = Float(0.83333 - 5).degreesToRadians
+
+            let decang = timestamp.getSunDeclination()
+            let eqtime = timestamp.getSunEquationOfTime()
+            
+            let latsun=decang
+            /// universal time
+            let ut = timestamp.hourWithFraction
+            let t1 = (90-latsun).degreesToRadians
+            
+            let lonsun = -15.0*(ut-12.0+eqtime)
+            
+            /// longitude of sun
+            let p1 = lonsun.degreesToRadians
+            
+            
+            let ut0 = ut - (Float(timerange.dtSeconds)/3600)
+            let lonsun0 = -15.0*(ut0-12.0+eqtime)
+            
+            let p10 = lonsun0.degreesToRadians
+            
+            let t0=(90-latitude).degreesToRadians
+
+            /// longitude of point
+            var p0 = longitude.degreesToRadians
+            if p0 < p1 - .pi {
+                p0 += 2 * .pi
+            }
+            if p0 > p1 + .pi {
+                p0 -= 2 * .pi
+            }
+
+            // limit p1 and p10 to sunrise/set
+            let arg = -(sin(alpha)+cos(t0)*cos(t1))/(sin(t0)*sin(t1))
+            let carg = arg > 1 || arg < -1 ? .pi : acos(arg)
+            let sunrise = p0 + carg
+            let sunset = p0 - carg
+            let p1_l = min(sunrise, p10)
+            let p10_l = max(sunset, p1)
+            
+            // limit dt to sunrise/set
+            let dtBound = dt * (p1_l - p10_l) / (p10 - p1)
+            
+            // solve integral to get sun elevation dt
+            // integral(cos(t0) cos(t1) + sin(t0) sin(t1) cos(p - p0)) dp = sin(t0) sin(t1) sin(p - p0) + p cos(t0) cos(t1) + constant
+            let left = sin(t0) * sin(t1) * sin(p1_l - p0) + p1_l * cos(t0) * cos(t1)
+            let right = sin(t0) * sin(t1) * sin(p10_l - p0) + p10_l * cos(t0) * cos(t1)
+            let zzBackwards = (left-right) / (p1_l - p10_l)
+            let dni = dhi / zzBackwards
+            // Prevent possible division by zero
+            // See https://github.com/open-meteo/open-meteo/discussions/395
+            let dniBounded = zzBackwards <= 0.0001 ? dhi : dni
+            return min(max(dniBounded - 60, 0) / (180 - 60) * dtBound, dtBound)
         }
     }
     

--- a/Sources/App/Icon/IconController.swift
+++ b/Sources/App/Icon/IconController.swift
@@ -113,6 +113,7 @@ enum IconSurfaceVariableDerived: String, CaseIterable, GenericVariableMixable {
     case latent_heat_flux
     case wind_gusts_10m
     case freezing_level_height
+    case sunshine_duration
     
     var requiresOffsetCorrectionForMixing: Bool {
         return self == .snow_height

--- a/Sources/App/Icon/IconReader.swift
+++ b/Sources/App/Icon/IconReader.swift
@@ -352,7 +352,8 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(raw: .windgusts_10m, member: member, time: time)
             case .freezing_level_height:
                 try prefetchData(raw: .freezinglevel_height, member: member, time: time)
-            }
+            case .sunshine_duration:
+                try prefetchData(raw: .direct_radiation, member: member, time: time)            }
         case .pressure(let variable):
             let level = variable.level
             switch variable.variable {
@@ -568,6 +569,10 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
                 return try get(raw: .windgusts_10m, member: member, time: time)
             case .freezing_level_height:
                 return try get(raw: .freezinglevel_height, member: member, time: time)
+            case .sunshine_duration:
+                let directRadiation = try get(raw: .direct_radiation, member: member, time: time)
+                let duration = Zensun.calculateBackwardsSunshineDuration(directRadiation: directRadiation.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
+                return DataAndUnit(duration, .seconds)
             }
         case .pressure(let variable):
             let level = variable.level

--- a/Sources/App/JMA/JmaController.swift
+++ b/Sources/App/JMA/JmaController.swift
@@ -33,6 +33,7 @@ enum JmaVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case cloud_cover_low
     case cloud_cover_mid
     case cloud_cover_high
+    case sunshine_duration
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false
@@ -176,6 +177,8 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 try prefetchData(raw: .cloudcover_mid, time: time)
             case .cloud_cover_high:
                 try prefetchData(raw: .cloudcover_high, time: time)
+            case .sunshine_duration:
+                try prefetchData(derived: .surface(.direct_radiation), time: time)
             }
         case .pressure(let v):
             switch v.variable {
@@ -330,6 +333,10 @@ struct JmaReader: GenericReaderDerivedSimple, GenericReaderProtocol {
                 return try get(raw: .cloudcover_mid, time: time)
             case .cloud_cover_high:
                 return try get(raw: .cloudcover_high, time: time)
+            case .sunshine_duration:
+                let directRadiation = try get(derived: .surface(.direct_radiation), time: time)
+                let duration = Zensun.calculateBackwardsSunshineDuration(directRadiation: directRadiation.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
+                return DataAndUnit(duration, .seconds)
             }
         case .pressure(let v):
             switch v.variable {

--- a/Sources/App/MetNo/MetNoController.swift
+++ b/Sources/App/MetNo/MetNoController.swift
@@ -92,6 +92,8 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             try prefetchData(raw: .winddirection_10m, time: time)
         case .wind_gusts_10m:
             try prefetchData(raw: .windgusts_10m, time: time)
+        case .sunshine_duration:
+            try prefetchData(derived: .direct_radiation, time: time)
         }
     }
     
@@ -215,6 +217,10 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             return try get(raw: .winddirection_10m, time: time)
         case .wind_gusts_10m:
             return try get(raw: .windgusts_10m, time: time)
+        case .sunshine_duration:
+            let directRadiation = try get(derived: .direct_radiation, time: time)
+            let duration = Zensun.calculateBackwardsSunshineDuration(directRadiation: directRadiation.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
+            return DataAndUnit(duration, .seconds)
         }
     }
 }
@@ -253,6 +259,7 @@ enum MetNoVariableDerived: String, GenericVariableMixable {
     case wind_speed_10m
     case wind_direction_10m
     case wind_gusts_10m
+    case sunshine_duration
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false

--- a/Sources/App/MeteoFrance/MeteoFranceController.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceController.swift
@@ -77,6 +77,7 @@ enum MeteoFranceVariableDerivedSurface: String, CaseIterable, GenericVariableMix
     case cloud_cover_mid
     case cloud_cover_high
     case wind_gusts_10m
+    case sunshine_duration
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false
@@ -288,6 +289,8 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(variable: .cloudcover_high, time: time)
             case .wind_gusts_10m:
                 try prefetchData(variable: .windgusts_10m, time: time)
+            case .sunshine_duration:
+                try prefetchData(derived: .surface(.direct_radiation), time: time)
             }
         case .pressure(let v):
             switch v.variable {
@@ -512,6 +515,10 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
                 return try get(raw: .cloudcover_high, time: time)
             case .wind_gusts_10m:
                 return try get(raw: .windgusts_10m, time: time)
+            case .sunshine_duration:
+                let directRadiation = try get(derived: .surface(.direct_radiation), time: time)
+                let duration = Zensun.calculateBackwardsSunshineDuration(directRadiation: directRadiation.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time)
+                return DataAndUnit(duration, .seconds)
             }
         case .pressure(let v):
             switch v.variable {


### PR DESCRIPTION
Add `daylight_duration` to daily variables. Calculation is based on sunrise/-set time.

Add `sunshine_duration` to hourly and daily variables. Calculation is based on DNI > 120. Because data is averaged over 1 hour. It is assuming a linear distribution between 60 and 180 watts. Sunrise and -set times are used to bound the available daylight.