### PR TITLE
Fix: Protect JMA downloader against overlapping runs

### DIFF
--- a/Sources/App/Helper/Intrinsics/Concurrency.swift
+++ b/Sources/App/Helper/Intrinsics/Concurrency.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension Sequence {
+    func asyncMap<T>(
+        _ transform: (Element) async throws -> T
+    ) async rethrows -> [T] {
+        var values = [T]()
+        values.reserveCapacity(self.underestimatedCount)
+        for element in self {
+            try await values.append(transform(element))
+        }
+        return values
+    }
+    
+    func asyncFlatMap<T>(
+        _ transform: (Element) async throws -> [T]
+    ) async rethrows -> [T] {
+        var values = [T]()
+        values.reserveCapacity(self.underestimatedCount)
+        for element in self {
+            try await values.append(contentsOf: transform(element))
+        }
+        return values
+    }
+
+    func asyncCompactMap<T>(
+        _ transform: (Element) async throws -> T?
+    ) async rethrows -> [T] {
+        var values = [T]()
+        values.reserveCapacity(self.underestimatedCount)
+
+        for element in self {
+            guard let result = try await transform(element) else {
+                continue
+            }
+            values.append(result)
+        }
+        return values
+    }
+}

--- a/Sources/SwiftPFor2D/FileExtension.swift
+++ b/Sources/SwiftPFor2D/FileExtension.swift
@@ -6,7 +6,7 @@ extension FileHandle {
     public static func createNewFile(file: String, size: Int? = nil) throws -> FileHandle {
         // 0644 permissions
         // O_TRUNC for overwrite
-        let fn = open(file, O_WRONLY | O_CREAT, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH)
+        let fn = open(file, O_RDWR | O_CREAT, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH)
         guard fn > 0 else {
             let error = String(cString: strerror(errno))
             throw SwiftPFor2DError.cannotOpenFile(filename: file, errno: errno, error: error)


### PR DESCRIPTION
A couple of weeks ago, overlapping JMA MSM runs seems to have occurred. This PR keeps file handles open to protect from overlapping runs