### PR TITLE
Rework NCEP GFS downloader

### DIFF
--- a/Sources/App/Cams/CamsDownload.swift
+++ b/Sources/App/Cams/CamsDownload.swift
@@ -76,6 +76,7 @@ struct DownloadCamsCommand: AsyncCommand {
         
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient)
         Process.alarm(seconds: 6 * 3600)
+        defer { Process.alarm(seconds: 0) }
         
         let dateRun = run.format_YYYYMMddHH
         let remoteDir = "https://\(user):\(password)@aux.ecmwf.int/ecpds/data/file/CAMS_GLOBAL/\(dateRun)/"

--- a/Sources/App/Cams/CamsDownload.swift
+++ b/Sources/App/Cams/CamsDownload.swift
@@ -75,6 +75,8 @@ struct DownloadCamsCommand: AsyncCommand {
         let writer = OmFileWriter(dim0: nx, dim1: ny, chunk0: nx, chunk1: ny)
         
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient)
+        Process.alarm(seconds: 6 * 3600)
+        
         let dateRun = run.format_YYYYMMddHH
         let remoteDir = "https://\(user):\(password)@aux.ecmwf.int/ecpds/data/file/CAMS_GLOBAL/\(dateRun)/"
         /// The surface level of multi-level files is available in the `CAMS_GLOBAL_ADDITIONAL` directory

--- a/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
+++ b/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
@@ -124,6 +124,8 @@ struct DownloadEcmwfCommand: AsyncCommand {
     func downloadEcmwf(application: Application, domain: EcmwfDomain, base: String, run: Timestamp, skipFilesIfExisting: Bool, variables: [EcmwfVariable]) async throws {
         let logger = application.logger
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient)
+        Process.alarm(seconds: 6 * 3600)
+        
         let downloadDirectory = domain.downloadDirectory
         let forecastSteps = domain.getDownloadForecastSteps(run: run.hour)
         var grib2d = GribArray2D(nx: domain.grid.nx, ny: domain.grid.ny)

--- a/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
+++ b/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
@@ -125,6 +125,7 @@ struct DownloadEcmwfCommand: AsyncCommand {
         let logger = application.logger
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient)
         Process.alarm(seconds: 6 * 3600)
+        defer { Process.alarm(seconds: 0) }
         
         let downloadDirectory = domain.downloadDirectory
         let forecastSteps = domain.getDownloadForecastSteps(run: run.hour)

--- a/Sources/App/Gfs/GfsDomain.swift
+++ b/Sources/App/Gfs/GfsDomain.swift
@@ -279,19 +279,29 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
         let useArchive = (Timestamp.now().timeIntervalSince1970 - run.timeIntervalSince1970) > 36*3600
         /// 4 week archive
         let gfsAws = "https://noaa-gfs-bdp-pds.s3.amazonaws.com/"
+        
         let gfsNomads = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/"
         let yyyymmdd = run.format_YYYYMMdd
         let hh = run.hh
+        
+        let gefsAws = "https://noaa-gefs-pds.s3.amazonaws.com/"
+        let gefsNomads = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gens/prod/"
+        let gefsServer = useArchive ? gefsAws : gefsNomads
+        
+        let hrrrNomads = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/"
+        let hrrrAws = "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/"
+        let hrrrServer = useArchive ? hrrrAws : hrrrNomads
+        
         switch self {
         case .gfs05_ens:
             let memberString = member == 0 ? "gec00" : "gep\(member.zeroPadded(len: 2))"
-            return ["https://nomads.ncep.noaa.gov/pub/data/nccf/com/gens/prod/gefs.\(yyyymmdd)/\(hh)/atmos/pgrb2ap5/\(memberString).t\(hh)z.pgrb2a.0p50.f\(fHHH)",
-                    "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gens/prod/gefs.\(yyyymmdd)/\(hh)/atmos/pgrb2bp5/\(memberString).t\(hh)z.pgrb2b.0p50.f\(fHHH)"]
+            return ["\(gefsServer)gefs.\(yyyymmdd)/\(hh)/atmos/pgrb2ap5/\(memberString).t\(hh)z.pgrb2a.0p50.f\(fHHH)",
+                    "\(gefsServer)gefs.\(yyyymmdd)/\(hh)/atmos/pgrb2bp5/\(memberString).t\(hh)z.pgrb2b.0p50.f\(fHHH)"]
         case .gfs025_ensemble:
             fallthrough
         case .gfs025_ens:
             let memberString = member == 0 ? "gec00" : "gep\(member.zeroPadded(len: 2))"
-            return ["https://nomads.ncep.noaa.gov/pub/data/nccf/com/gens/prod/gefs.\(yyyymmdd)/\(hh)/atmos/pgrb2sp25/\(memberString).t\(hh)z.pgrb2s.0p25.f\(fHHH)"]
+            return ["\(gefsServer)gefs.\(yyyymmdd)/\(hh)/atmos/pgrb2sp25/\(memberString).t\(hh)z.pgrb2s.0p25.f\(fHHH)"]
         case .gfs013:
             return ["\(useArchive ? gfsAws : gfsNomads)gfs.\(yyyymmdd)/\(hh)/atmos/gfs.t\(hh)z.sfluxgrbf\(fHHH).grib2"]
         case .gfs025:
@@ -300,14 +310,10 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
         //case .nam_conus:
         //    return "https://nomads.ncep.noaa.gov/pub/data/nccf/com/nam/prod/nam.\(run.format_YYYYMMdd)/nam.t\(run.hh)z.conusnest.hiresf\(fHH).tm00.grib2"
         case .hrrr_conus:
-            let nomads = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/"
             //let google = "https://storage.googleapis.com/high-resolution-rapid-refresh/"
-            let aws = "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/"
-            return ["\(useArchive ? aws : nomads)hrrr.\(yyyymmdd)/conus/hrrr.t\(hh)z.wrfprsf\(fHH).grib2"]
+            return ["\(hrrrServer)hrrr.\(yyyymmdd)/conus/hrrr.t\(hh)z.wrfprsf\(fHH).grib2"]
         case .hrrr_conus_15min:
-            let nomads = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod/"
-            let aws = "https://noaa-hrrr-bdp-pds.s3.amazonaws.com/"
-            return ["\(useArchive ? aws : nomads)hrrr.\(yyyymmdd)/conus/hrrr.t\(hh)z.wrfsubhf\(fHH).grib2"]
+            return ["\(hrrrServer)hrrr.\(yyyymmdd)/conus/hrrr.t\(hh)z.wrfsubhf\(fHH).grib2"]
         }
     }
 }

--- a/Sources/App/Gfs/GfsDownload.swift
+++ b/Sources/App/Gfs/GfsDownload.swift
@@ -213,6 +213,8 @@ struct GfsDownload: AsyncCommand {
         let waitAfterLastModified: TimeInterval = domain == .gfs025 ? 180 : 120
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient, deadLineHours: deadLineHours, waitAfterLastModified: waitAfterLastModified)
         Process.alarm(seconds: Int(deadLineHours+2) * 3600)
+        defer { Process.alarm(seconds: 0) }
+        
         var forecastHours = domain.forecastHours(run: run.hour, secondFlush: secondFlush)
         if let maxForecastHour {
             forecastHours = forecastHours.filter({$0 <= maxForecastHour})

--- a/Sources/App/Gfs/GfsDownload.swift
+++ b/Sources/App/Gfs/GfsDownload.swift
@@ -212,6 +212,7 @@ struct GfsDownload: AsyncCommand {
         }
         let waitAfterLastModified: TimeInterval = domain == .gfs025 ? 180 : 120
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient, deadLineHours: deadLineHours, waitAfterLastModified: waitAfterLastModified)
+        Process.alarm(seconds: Int(deadLineHours+2) * 3600)
         var forecastHours = domain.forecastHours(run: run.hour, secondFlush: secondFlush)
         if let maxForecastHour {
             forecastHours = forecastHours.filter({$0 <= maxForecastHour})

--- a/Sources/App/Helper/Intrinsics/Sequence.swift
+++ b/Sources/App/Helper/Intrinsics/Sequence.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+extension Sequence {
+    /// Group the sequence by the given criterion.
+    /// - Parameter criterion: The basis by which to group the sequence.
+    /// - Throws: `Error`.
+    /// - Returns: Array of `(key: Group, values: [Element])`
+    func groupedPreservedOrder<Group: Equatable>(
+        by criterion: (_ transforming: Element) throws -> Group
+    ) rethrows -> [(key: Group, values: [Element])] {
+        var groups = [(key: Group, values: [Element])]()
+        for element in self {
+            let key = try criterion(_: element)
+            if let keyIndex = groups.firstIndex(where: {$0.key == key}) {
+                groups[keyIndex] = (key, groups[keyIndex].values + [element])
+            } else {
+                groups.append((key: key, values: [element]))
+            }
+        }
+        return groups
+    }
+}

--- a/Sources/App/Helper/Time/Time.swift
+++ b/Sources/App/Helper/Time/Time.swift
@@ -284,6 +284,11 @@ public struct TimerangeDt: Hashable {
         self.dtSeconds = dtSeconds
     }
     
+    public init(range: ClosedRange<Timestamp>, dtSeconds: Int) {
+        self.range = range.lowerBound ..< range.upperBound.add(dtSeconds)
+        self.dtSeconds = dtSeconds
+    }
+    
     public init(start: Timestamp, nTime: Int, dtSeconds: Int) {
         self.range = start ..< start.add(nTime * dtSeconds)
         self.dtSeconds = dtSeconds
@@ -292,6 +297,11 @@ public struct TimerangeDt: Hashable {
     /// devide time by dtSeconds
     @inlinable public func toIndexTime() -> Range<Int> {
         return range.lowerBound.timeIntervalSince1970 / dtSeconds ..< range.upperBound.timeIntervalSince1970 / dtSeconds
+    }
+    
+    @inlinable public func index(of: Timestamp) -> Int? {
+        let index = (of.timeIntervalSince1970 - range.lowerBound.timeIntervalSince1970) / dtSeconds
+        return index < 0 || index >= count ? nil : index
     }
     
     @inlinable public func add(_ seconds: Int) -> TimerangeDt {

--- a/Sources/App/Helper/Ulimit.swift
+++ b/Sources/App/Helper/Ulimit.swift
@@ -17,6 +17,15 @@ extension Process {
             print("[WARNING] Could not set number of open file limit to 65536). \(String(cString: strerror(errno)))")
         }
     }
+    
+    /// Set alarm to terminate the process in case it gets stuck
+    public static func alarm(seconds: Int) {
+        #if os(Linux)
+        Glibc.alarm(UInt32(seconds))
+        #else
+        Darwin.alarm(UInt32(seconds))
+        #endif
+    }
 }
 
 

--- a/Sources/App/Icon/DownloadIconCommand.swift
+++ b/Sources/App/Icon/DownloadIconCommand.swift
@@ -99,6 +99,7 @@ struct DownloadIconCommand: AsyncCommand {
         
         let deadLineHours: Double = (domain == .iconD2 || domain == .iconD2Eps) ? 2 : 5
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient, deadLineHours: deadLineHours, waitAfterLastModified: 120)
+        Process.alarm(seconds: Int(deadLineHours + 1) * 3600)
         
         let domainPrefix = "\(domain.rawValue)_\(domain.region)"
         let cdo = try await CdoHelper(domain: domain, logger: logger, curl: curl)
@@ -262,6 +263,7 @@ struct DownloadIconCommand: AsyncCommand {
             }
         }
         curl.printStatistics()
+        Process.alarm(seconds: 0)
     }
 
     /// unompress and remap

--- a/Sources/App/Icon/DownloadIconCommand.swift
+++ b/Sources/App/Icon/DownloadIconCommand.swift
@@ -100,6 +100,7 @@ struct DownloadIconCommand: AsyncCommand {
         let deadLineHours: Double = (domain == .iconD2 || domain == .iconD2Eps) ? 2 : 5
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient, deadLineHours: deadLineHours, waitAfterLastModified: 120)
         Process.alarm(seconds: Int(deadLineHours + 1) * 3600)
+        defer { Process.alarm(seconds: 0) }
         
         let domainPrefix = "\(domain.rawValue)_\(domain.region)"
         let cdo = try await CdoHelper(domain: domain, logger: logger, curl: curl)
@@ -263,7 +264,6 @@ struct DownloadIconCommand: AsyncCommand {
             }
         }
         curl.printStatistics()
-        Process.alarm(seconds: 0)
     }
 
     /// unompress and remap

--- a/Sources/App/JMA/JmaDownloader.swift
+++ b/Sources/App/JMA/JmaDownloader.swift
@@ -77,7 +77,12 @@ struct JmaDownload: AsyncCommand {
         let logger = application.logger
         let deadLineHours: Double = domain == .gsm ? 3 : 6
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient, deadLineHours: deadLineHours)
-        defer { curl.printStatistics() }
+        Process.alarm(seconds: Int(deadLineHours + 1) * 3600)
+        defer {
+            curl.printStatistics()
+            Process.alarm(seconds: 0)
+        }
+        
         
         let nLocationsPerChunk = OmFileSplitter(domain).nLocationsPerChunk
         let writer = OmFileWriter(dim0: 1, dim1: domain.grid.count, chunk0: 1, chunk1: nLocationsPerChunk)

--- a/Sources/App/MetNo/MetNoDownloader.swift
+++ b/Sources/App/MetNo/MetNoDownloader.swift
@@ -51,6 +51,7 @@ struct MetNoDownloader: AsyncCommand {
     func convert(logger: Logger, domain: MetNoDomain, variables: [MetNoVariable], run: Timestamp, createNetcdf: Bool) throws {
         let om = OmFileSplitter(domain)
         Process.alarm(seconds: 3 * 3600)
+        defer { Process.alarm(seconds: 0) }
         
         let openDap = "https://thredds.met.no/thredds/dodsC/metpplatest/met_forecast_1_0km_nordic_\(run.format_YYYYMMdd)T\(run.hour.zeroPadded(len: 2))Z.nc"
         

--- a/Sources/App/MetNo/MetNoDownloader.swift
+++ b/Sources/App/MetNo/MetNoDownloader.swift
@@ -50,6 +50,7 @@ struct MetNoDownloader: AsyncCommand {
     /// Process each variable and update time-series optimised files
     func convert(logger: Logger, domain: MetNoDomain, variables: [MetNoVariable], run: Timestamp, createNetcdf: Bool) throws {
         let om = OmFileSplitter(domain)
+        Process.alarm(seconds: 3 * 3600)
         
         let openDap = "https://thredds.met.no/thredds/dodsC/metpplatest/met_forecast_1_0km_nordic_\(run.format_YYYYMMdd)T\(run.hour.zeroPadded(len: 2))Z.nc"
         

--- a/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
@@ -133,6 +133,7 @@ struct MeteoFranceDownload: AsyncCommand {
         /// Up to 6 hours download times are possible for arpege europe 12z run, after Meteofrance open-data limitations on the 12. February 2023
         let deadLineHours: Double = domain == .arpege_europe && run.hour == 12 ? 5.9 : 5
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient, deadLineHours: deadLineHours)
+        Process.alarm(seconds: Int(deadLineHours + 1) * 3600)
                 
         /// world 0-24, 27-48, 51-72, 75-102
         let fileTimes = domain.getForecastHoursPerFile(run: run.hour, hourlyForArpegeEurope: false)

--- a/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
@@ -134,6 +134,7 @@ struct MeteoFranceDownload: AsyncCommand {
         let deadLineHours: Double = domain == .arpege_europe && run.hour == 12 ? 5.9 : 5
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient, deadLineHours: deadLineHours)
         Process.alarm(seconds: Int(deadLineHours + 1) * 3600)
+        defer { Process.alarm(seconds: 0) }
                 
         /// world 0-24, 27-48, 51-72, 75-102
         let fileTimes = domain.getForecastHoursPerFile(run: run.hour, hourlyForArpegeEurope: false)

--- a/Sources/App/SeasonalForecast/SeasonalForecastDownload.swift
+++ b/Sources/App/SeasonalForecast/SeasonalForecastDownload.swift
@@ -80,6 +80,7 @@ struct SeasonalForecastDownload: AsyncCommand {
         try FileManager.default.createDirectory(atPath: domain.downloadDirectory, withIntermediateDirectories: true)
         
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient, deadLineHours: 18, readTimeout: 20*60)
+        Process.alarm(seconds: Int(18 + 1) * 3600)
         
         let gribVariables = ["tmp2m", "tmin", "soilt1", "dswsfc", "cprat", "q2m", "wnd10m", "tcdcclm", "prate", "soilm3", "pressfc", "soilm2", "soilm1", "soilm4", "tmax"]
         

--- a/Sources/App/SeasonalForecast/SeasonalForecastDownload.swift
+++ b/Sources/App/SeasonalForecast/SeasonalForecastDownload.swift
@@ -81,6 +81,7 @@ struct SeasonalForecastDownload: AsyncCommand {
         
         let curl = Curl(logger: logger, client: application.dedicatedHttpClient, deadLineHours: 18, readTimeout: 20*60)
         Process.alarm(seconds: Int(18 + 1) * 3600)
+        defer { Process.alarm(seconds: 0) }
         
         let gribVariables = ["tmp2m", "tmin", "soilt1", "dswsfc", "cprat", "q2m", "wnd10m", "tcdcclm", "prate", "soilm3", "pressfc", "soilm2", "soilm1", "soilm4", "tmax"]
         


### PR DESCRIPTION
GFS ensemble downloads may take longer than 6 hours resulting in overlapping runs. Because the downloaded files could be overwritten by the next downloader process, the previous downloader will be terminated.

Change downloader to keep file handles open, solving this issue and allow parallel downloads.