### PR TITLE
fix missing return keyword in switch case blocks

### DIFF
--- a/Sources/App/Bom/BomDomain.swift
+++ b/Sources/App/Bom/BomDomain.swift
@@ -43,8 +43,8 @@ enum BomDomain: String, GenericDomain, CaseIterable {
     
     var dtSeconds: Int {
         switch self {
-        case .access_global: 3600
-        case .access_global_ensemble: 3*3600
+        case .access_global: return 3600
+        case .access_global_ensemble: return 3*3600
         }
     }
     
@@ -58,8 +58,8 @@ enum BomDomain: String, GenericDomain, CaseIterable {
     
     var omFileLength: Int {
         switch self {
-        case .access_global: 240+48
-        case .access_global_ensemble: (240+48) / 3
+        case .access_global: return 240+48
+        case .access_global_ensemble: return (240+48) / 3
         }
     }
     


### PR DESCRIPTION
For some reason my swift compiler failed without adding the `return`s in these switch/case statements.

My compiler is on Fedora 38 linux, on intel-i7 CPUs:
```swift --version
Swift version 5.8.1 (swift-5.8.1-RELEASE)
Target: x86_64-unknown-linux-gnu
```
