### PR TITLE
Check integrity of downloaded NetCDF files and retry corrupted files

### DIFF
--- a/Sources/App/Bom/BomDownloader.swift
+++ b/Sources/App/Bom/BomDownloader.swift
@@ -84,16 +84,18 @@ struct DownloadBomCommand: AsyncCommand {
         let topogFile = "\(domain.downloadDirectory)topog.nc"
         let lndMaskFile = "\(domain.downloadDirectory)lnd_mask.nc"
         if !FileManager.default.fileExists(atPath: topogFile) {
-            try await curl.download(
+            let _ = try await curl.downloadNetCdf(
                 url: "\(base)sfc/topog.nc",
-                toFile: topogFile,
+                file: topogFile,
+                ncVariable: "topog",
                 bzip2Decode: false
             )
         }
         if !FileManager.default.fileExists(atPath: lndMaskFile) {
-            try await curl.download(
+            let _ = try await curl.downloadNetCdf(
                 url: "\(base)sfc/lnd_mask.nc",
-                toFile: lndMaskFile,
+                file: lndMaskFile,
+                ncVariable: "lnd_mask",
                 bzip2Decode: false
             )
         }
@@ -130,16 +132,18 @@ struct DownloadBomCommand: AsyncCommand {
             let analysisFile = "\(domain.downloadDirectory)\(variable)_an.nc"
             let forecastFile = "\(domain.downloadDirectory)\(variable)_fc.nc"
             if !skipFilesIfExisting || !FileManager.default.fileExists(atPath: analysisFile) {
-                try await curl.download(
+                let _ = try await curl.downloadNetCdf(
                     url: "\(base)an/ml/\(variable).nc",
-                    toFile: analysisFile,
+                    file: analysisFile,
+                    ncVariable: variable,
                     bzip2Decode: false
                 )
             }
             if !skipFilesIfExisting || !FileManager.default.fileExists(atPath: forecastFile) {
-                try await curl.download(
+                let _ = try await curl.downloadNetCdf(
                     url: "\(base)fc/ml/\(variable).nc",
-                    toFile: forecastFile,
+                    file: forecastFile,
+                    ncVariable: variable,
                     bzip2Decode: false
                 )
             }
@@ -225,9 +229,10 @@ struct DownloadBomCommand: AsyncCommand {
                 let memberStr = ((run.hour % 12 == 6) ? (member+17) : member).zeroPadded(len: 3)
                 if !skipFilesIfExisting || !FileManager.default.fileExists(atPath: forecastFile) {
                     let url = member == 0 ? "\(base)cf/sfc/\(variable.name).nc" : "\(base)pf/\(memberStr)/sfc/\(variable.name).nc"
-                    try await curl.download(
+                    let _ = try await curl.downloadNetCdf(
                         url: url,
-                        toFile: forecastFile,
+                        file: forecastFile,
+                        ncVariable: variable.name,
                         bzip2Decode: false
                     )
                 }
@@ -357,16 +362,18 @@ struct DownloadBomCommand: AsyncCommand {
             let analysisFile = "\(domain.downloadDirectory)\(variable.name)_an.nc"
             let forecastFile = "\(domain.downloadDirectory)\(variable.name)_fc.nc"
             if !skipFilesIfExisting || !FileManager.default.fileExists(atPath: analysisFile) {
-                try await curl.download(
+                let _ = try await curl.downloadNetCdf(
                     url: "\(base)an/sfc/\(variable.name).nc",
-                    toFile: analysisFile,
+                    file: analysisFile,
+                    ncVariable: variable.name,
                     bzip2Decode: false
                 )
             }
             if !skipFilesIfExisting || !FileManager.default.fileExists(atPath: forecastFile) {
-                try await curl.download(
+                let _ = try await curl.downloadNetCdf(
                     url: "\(base)fc/sfc/\(variable.name).nc",
-                    toFile: forecastFile,
+                    file: forecastFile,
+                    ncVariable: variable.name,
                     bzip2Decode: false
                 )
             }

--- a/Sources/App/Helper/Download/Curl+Grib.swift
+++ b/Sources/App/Helper/Download/Curl+Grib.swift
@@ -1,0 +1,164 @@
+import Foundation
+import SwiftEccodes
+import CHelper
+
+extension Curl {
+    /// Download all grib files and return an array of grib messages
+    func downloadGrib(url: String, bzip2Decode: Bool, range: String? = nil, minSize: Int? = nil, nConcurrent: Int = 1, deadLineHours: Double? = nil) async throws -> [GribMessage] {
+        let deadline = deadLineHours.map { Date().addingTimeInterval(TimeInterval($0 * 3600)) } ?? deadline
+        let timeout = TimeoutTracker(logger: logger, deadline: deadline)
+        
+        // AWS does not allow multi http download ranges. Split download into multiple downloads
+        let supportMultiRange = !url.contains("amazonaws.com")
+        if !supportMultiRange, let parts = range?.split(separator: ","), parts.count > 1 {
+            var messages = [GribMessage]()
+            for part in parts {
+                messages.append(contentsOf: try await downloadGrib(url: url, bzip2Decode: bzip2Decode, range: String(part)))
+            }
+            return messages
+        }
+        
+        while true {
+            // Start the download and wait for the header
+            let response = try await initiateDownload(url: url, range: range, minSize: minSize, deadline: deadline, nConcurrent: nConcurrent, waitAfterLastModifiedBeforeDownload: waitAfterLastModifiedBeforeDownload)
+            
+            // Retry failed file transfers after this point
+            do {
+                var messages = [GribMessage]()
+                let contentLength = try response.contentLength()
+                let tracker = TransferAmountTracker(logger: logger, totalSize: contentLength)
+                if bzip2Decode {
+                    for try await m in response.body.tracker(tracker).decompressBzip2().decodeGrib() {
+                        try Task.checkCancellation()
+                        messages.append(m)
+                        chelper_malloc_trim()
+                    }
+                } else {
+                    for try await m in response.body.tracker(tracker).decodeGrib() {
+                        try Task.checkCancellation()
+                        messages.append(m)
+                        chelper_malloc_trim()
+                    }
+                }
+                let trackerTransfered = await tracker.transfered
+                await totalBytesTransfered.add(trackerTransfered)
+                if let minSize = minSize, trackerTransfered < minSize {
+                    throw CurlError.sizeTooSmall
+                }
+                try await response.waitAfterLastModified(logger: logger, wait: waitAfterLastModified)
+                return messages
+            } catch {
+                try await timeout.check(error: error, delay: nil)
+            }
+        }
+    }
+    
+    /// Stream GRIB messages. The grib stream might be restarted on error.
+    func withGribStream<T>(url: String, bzip2Decode: Bool, range: String? = nil, minSize: Int? = nil, nConcurrent: Int = 1, deadLineHours: Double? = nil, body: (AnyAsyncSequence<GribMessage>) async throws -> (T)) async throws -> T {
+        let deadline = deadLineHours.map { Date().addingTimeInterval(TimeInterval($0 * 3600)) } ?? deadline
+        let timeout = TimeoutTracker(logger: logger, deadline: deadline)
+        
+        // TODO fix AWS code path
+        // TODO use grib stream for GLOFAS downloader
+        
+        // AWS does not allow multi http download ranges. Split download into multiple downloads
+        /*let supportMultiRange = !url.contains("amazonaws.com")
+        if !supportMultiRange, let parts = range?.split(separator: ","), parts.count > 1 {
+            var messages = [GribMessage]()
+            for part in parts {
+                messages.append(contentsOf: try await downloadGrib(url: url, bzip2Decode: bzip2Decode, range: String(part)))
+            }
+            return messages
+        }*/
+        
+        while true {
+            // Start the download and wait for the header
+            let response = try await initiateDownload(url: url, range: range, minSize: minSize, deadline: deadline, nConcurrent: nConcurrent, waitAfterLastModifiedBeforeDownload: waitAfterLastModifiedBeforeDownload)
+            
+            // Retry failed file transfers after this point
+            do {
+                let contentLength = try response.contentLength()
+                let tracker = TransferAmountTracker(logger: logger, totalSize: contentLength)
+                let result: T
+                if bzip2Decode {
+                    result = try await body(response.body.tracker(tracker).decompressBzip2().decodeGrib().eraseToAnyAsyncSequence())
+                } else {
+                    result = try await body(response.body.tracker(tracker).decodeGrib().eraseToAnyAsyncSequence())
+                }
+                let trackerTransfered = await tracker.transfered
+                await totalBytesTransfered.add(trackerTransfered)
+                if let minSize = minSize, trackerTransfered < minSize {
+                    throw CurlError.sizeTooSmall
+                }
+                try await response.waitAfterLastModified(logger: logger, wait: waitAfterLastModified)
+                return result
+            } catch {
+                try await timeout.check(error: error)
+            }
+        }
+    }
+}
+
+extension GribMessage {
+    func dumpCoordinates() throws {
+        guard let nx = get(attribute: "Nx").map(Int.init) ?? nil else {
+            fatalError("Could not get Nx")
+        }
+        guard let ny = get(attribute: "Ny").map(Int.init) ?? nil else {
+            fatalError("Could not get Ny")
+        }
+        print("nx=\(nx) ny=\(ny)")
+        for (i,(latitude, longitude,value)) in try iterateCoordinatesAndValues().enumerated() {
+            if i % 10_000 == 0 || i == ny*nx-1 {
+                print("grid \(i) lat \(latitude) lon \(longitude) value \(value)")
+            }
+        }
+    }
+}
+
+struct GribArray2D {
+    var bitmap: [Int]
+    var double: [Double]
+    var array: Array2D
+    
+    public init(nx: Int, ny: Int) {
+        array = Array2D(data: [Float](repeating: .nan, count: nx*ny), nx: nx, ny: ny)
+        bitmap = .init(repeating: 0, count: nx*ny)
+        double = .init(repeating: .nan, count: nx*ny)
+    }
+    
+    public mutating func load(message: GribMessage) throws {
+        guard let gridType = message.get(attribute: "gridType") else {
+            fatalError("Could not get gridType")
+        }
+        if gridType == "reduced_gg" {
+            guard let numberOfCodedValues = message.get(attribute: "numberOfCodedValues").map(Int.init) ?? nil else {
+                fatalError("Could not get numberOfCodedValues")
+            }
+            guard numberOfCodedValues == array.count else {
+                fatalError("GRIB dimensions (count=\(numberOfCodedValues)) do not match domain grid dimensions (nx=\(array.nx), ny=\(array.ny))")
+            }
+        } else {
+            guard let nx = message.get(attribute: "Nx").map(Int.init) ?? nil else {
+                fatalError("Could not get Nx")
+            }
+            guard let ny = message.get(attribute: "Ny").map(Int.init) ?? nil else {
+                fatalError("Could not get Ny")
+            }
+            guard nx == array.nx, ny == array.ny else {
+                fatalError("GRIB dimensions (nx=\(nx), ny=\(ny)) do not match domain grid dimensions (nx=\(array.nx), ny=\(array.ny))")
+            }
+        }
+        try message.loadDoubleNotNaNChecked(into: &double)
+        for i in double.indices {
+            array.data[i] = Float(double[i])
+        }
+        if try message.loadBitmap(into: &bitmap) {
+            for i in bitmap.indices {
+                if bitmap[i] == 0 {
+                    array.data[i] = .nan
+                }
+            }
+        }
+    }
+}

--- a/Sources/App/Helper/Download/Curl+NetCDF.swift
+++ b/Sources/App/Helper/Download/Curl+NetCDF.swift
@@ -1,0 +1,38 @@
+import Foundation
+import SwiftNetCDF
+
+
+fileprivate enum CurlNetCdfError: Error {
+    case netcdfOpenFailed
+    case netcdfVarGetFailed
+}
+
+extension Curl {
+    /// Download all grib files and return an array of grib messages
+    func downloadNetCdf(url: String, file: String, ncVariable: String, bzip2Decode: Bool, minSize: Int? = nil, nConcurrent: Int = 1, deadLineHours: Double? = nil) async throws -> Group {
+        
+        let deadline = deadLineHours.map { Date().addingTimeInterval(TimeInterval($0 * 3600)) } ?? deadline
+        let timeout = TimeoutTracker(logger: logger, deadline: deadline)
+        
+        while true {
+            // Start the download and wait for the header
+            try await download(url: url, toFile: file, bzip2Decode: bzip2Decode, minSize: minSize, nConcurrent: nConcurrent, deadLineHours: deadLineHours)
+            
+            // If NetCDF open fails, retry
+            // Can happen for truncated files while downloading
+            do {
+                guard let nc = try NetCDF.open(path: file, allowUpdate: false) else {
+                    throw CurlNetCdfError.netcdfOpenFailed
+                }
+                // Try to read meta data from variable
+                guard (nc.getVariable(name: ncVariable)?.dimensions) != nil else {
+                    throw CurlNetCdfError.netcdfVarGetFailed
+                }
+                return nc
+            } catch {
+                // wait 3 minutes
+                try await timeout.check(error: error, delay: 60*3)
+            }
+        }
+    }
+}

--- a/Sources/App/Helper/Download/Curl.swift
+++ b/Sources/App/Helper/Download/Curl.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Vapor
-import SwiftEccodes
 import AsyncHTTPClient
 import CHelper
 
@@ -290,167 +289,9 @@ final class Curl {
             }
         }
     }
-    
-    /// Download all grib files and return an array of grib messages
-    func downloadGrib(url: String, bzip2Decode: Bool, range: String? = nil, minSize: Int? = nil, nConcurrent: Int = 1, deadLineHours: Double? = nil) async throws -> [GribMessage] {
-        let deadline = deadLineHours.map { Date().addingTimeInterval(TimeInterval($0 * 3600)) } ?? deadline
-        let timeout = TimeoutTracker(logger: logger, deadline: deadline)
-        
-        // AWS does not allow multi http download ranges. Split download into multiple downloads
-        let supportMultiRange = !url.contains("amazonaws.com")
-        if !supportMultiRange, let parts = range?.split(separator: ","), parts.count > 1 {
-            var messages = [GribMessage]()
-            for part in parts {
-                messages.append(contentsOf: try await downloadGrib(url: url, bzip2Decode: bzip2Decode, range: String(part)))
-            }
-            return messages
-        }
-        
-        while true {
-            // Start the download and wait for the header
-            let response = try await initiateDownload(url: url, range: range, minSize: minSize, deadline: deadline, nConcurrent: nConcurrent, waitAfterLastModifiedBeforeDownload: waitAfterLastModifiedBeforeDownload)
-            
-            // Retry failed file transfers after this point
-            do {
-                var messages = [GribMessage]()
-                let contentLength = try response.contentLength()
-                let tracker = TransferAmountTracker(logger: logger, totalSize: contentLength)
-                if bzip2Decode {
-                    for try await m in response.body.tracker(tracker).decompressBzip2().decodeGrib() {
-                        try Task.checkCancellation()
-                        messages.append(m)
-                        chelper_malloc_trim()
-                    }
-                } else {
-                    for try await m in response.body.tracker(tracker).decodeGrib() {
-                        try Task.checkCancellation()
-                        messages.append(m)
-                        chelper_malloc_trim()
-                    }
-                }
-                let trackerTransfered = await tracker.transfered
-                await totalBytesTransfered.add(trackerTransfered)
-                if let minSize = minSize, trackerTransfered < minSize {
-                    throw CurlError.sizeTooSmall
-                }
-                try await response.waitAfterLastModified(logger: logger, wait: waitAfterLastModified)
-                return messages
-            } catch {
-                try await timeout.check(error: error)
-            }
-        }
-    }
-    
-    /// Stream GRIB messages. The grib stream might be restarted on error.
-    func withGribStream<T>(url: String, bzip2Decode: Bool, range: String? = nil, minSize: Int? = nil, nConcurrent: Int = 1, deadLineHours: Double? = nil, body: (AnyAsyncSequence<GribMessage>) async throws -> (T)) async throws -> T {
-        let deadline = deadLineHours.map { Date().addingTimeInterval(TimeInterval($0 * 3600)) } ?? deadline
-        let timeout = TimeoutTracker(logger: logger, deadline: deadline)
-        
-        // TODO fix AWS code path
-        // TODO use grib stream for GLOFAS downloader
-        
-        // AWS does not allow multi http download ranges. Split download into multiple downloads
-        /*let supportMultiRange = !url.contains("amazonaws.com")
-        if !supportMultiRange, let parts = range?.split(separator: ","), parts.count > 1 {
-            var messages = [GribMessage]()
-            for part in parts {
-                messages.append(contentsOf: try await downloadGrib(url: url, bzip2Decode: bzip2Decode, range: String(part)))
-            }
-            return messages
-        }*/
-        
-        while true {
-            // Start the download and wait for the header
-            let response = try await initiateDownload(url: url, range: range, minSize: minSize, deadline: deadline, nConcurrent: nConcurrent, waitAfterLastModifiedBeforeDownload: waitAfterLastModifiedBeforeDownload)
-            
-            // Retry failed file transfers after this point
-            do {
-                let contentLength = try response.contentLength()
-                let tracker = TransferAmountTracker(logger: logger, totalSize: contentLength)
-                let result: T
-                if bzip2Decode {
-                    result = try await body(response.body.tracker(tracker).decompressBzip2().decodeGrib().eraseToAnyAsyncSequence())
-                } else {
-                    result = try await body(response.body.tracker(tracker).decodeGrib().eraseToAnyAsyncSequence())
-                }
-                let trackerTransfered = await tracker.transfered
-                await totalBytesTransfered.add(trackerTransfered)
-                if let minSize = minSize, trackerTransfered < minSize {
-                    throw CurlError.sizeTooSmall
-                }
-                try await response.waitAfterLastModified(logger: logger, wait: waitAfterLastModified)
-                return result
-            } catch {
-                try await timeout.check(error: error)
-            }
-        }
-    }
-    
 }
 
-extension GribMessage {
-    func dumpCoordinates() throws {
-        guard let nx = get(attribute: "Nx").map(Int.init) ?? nil else {
-            fatalError("Could not get Nx")
-        }
-        guard let ny = get(attribute: "Ny").map(Int.init) ?? nil else {
-            fatalError("Could not get Ny")
-        }
-        print("nx=\(nx) ny=\(ny)")
-        for (i,(latitude, longitude,value)) in try iterateCoordinatesAndValues().enumerated() {
-            if i % 10_000 == 0 || i == ny*nx-1 {
-                print("grid \(i) lat \(latitude) lon \(longitude) value \(value)")
-            }
-        }
-    }
-}
 
-struct GribArray2D {
-    var bitmap: [Int]
-    var double: [Double]
-    var array: Array2D
-    
-    public init(nx: Int, ny: Int) {
-        array = Array2D(data: [Float](repeating: .nan, count: nx*ny), nx: nx, ny: ny)
-        bitmap = .init(repeating: 0, count: nx*ny)
-        double = .init(repeating: .nan, count: nx*ny)
-    }
-    
-    public mutating func load(message: GribMessage) throws {
-        guard let gridType = message.get(attribute: "gridType") else {
-            fatalError("Could not get gridType")
-        }
-        if gridType == "reduced_gg" {
-            guard let numberOfCodedValues = message.get(attribute: "numberOfCodedValues").map(Int.init) ?? nil else {
-                fatalError("Could not get numberOfCodedValues")
-            }
-            guard numberOfCodedValues == array.count else {
-                fatalError("GRIB dimensions (count=\(numberOfCodedValues)) do not match domain grid dimensions (nx=\(array.nx), ny=\(array.ny))")
-            }
-        } else {
-            guard let nx = message.get(attribute: "Nx").map(Int.init) ?? nil else {
-                fatalError("Could not get Nx")
-            }
-            guard let ny = message.get(attribute: "Ny").map(Int.init) ?? nil else {
-                fatalError("Could not get Ny")
-            }
-            guard nx == array.nx, ny == array.ny else {
-                fatalError("GRIB dimensions (nx=\(nx), ny=\(ny)) do not match domain grid dimensions (nx=\(array.nx), ny=\(array.ny))")
-            }
-        }
-        try message.loadDoubleNotNaNChecked(into: &double)
-        for i in double.indices {
-            array.data[i] = Float(double[i])
-        }
-        if try message.loadBitmap(into: &bitmap) {
-            for i in bitmap.indices {
-                if bitmap[i] == 0 {
-                    array.data[i] = .nan
-                }
-            }
-        }
-    }
-}
 
 extension AsyncSequence where Element == ByteBuffer {
     /// Store incoming data to file. Buffers up to 1024kb until flushed to disk.
@@ -523,7 +364,7 @@ extension HTTPClientResponse {
     }
     
     /// Optionally wait to stay delayed a fixed time amount after last modified header
-    fileprivate func waitAfterLastModified(logger: Logger, wait: TimeInterval?) async throws {
+    func waitAfterLastModified(logger: Logger, wait: TimeInterval?) async throws {
         guard let wait, let lastModified = headers.lastModified?.value else {
             return
             

--- a/Sources/App/Helper/Download/TimeoutTracker.swift
+++ b/Sources/App/Helper/Download/TimeoutTracker.swift
@@ -17,17 +17,18 @@ final class TimeoutTracker {
     }
     
     /// Print statistics, throw if deadline reached, sleep backoff timer
-    func check(error: Error) async throws {
+    func check(error: Error, delay: Int? = nil) async throws {
+        let delay = delay ?? retryDelaySeconds
         let timeElapsed = Date().timeIntervalSince(startTime)
         if Date().timeIntervalSince(lastPrint) > 60 {
-            logger.info("Download failed, retry every \(retryDelaySeconds) seconds, (\(Int(timeElapsed/60)) minutes elapsed, curl error '\(error)'")
+            logger.info("Download failed, retry every \(delay) seconds, (\(Int(timeElapsed/60)) minutes elapsed, curl error '\(error)'")
             lastPrint = Date()
         }
         if Date() > deadline {
             logger.error("Deadline reached. Last Error \(error)")
             throw CurlError.timeoutReached
         }
-        try await Task.sleep(nanoseconds: UInt64(retryDelaySeconds * 1_000_000_000))
+        try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
     }
 }
 


### PR DESCRIPTION
Downloaders like BOM may download files that are being uploaded at the same time. This results in corrupted files. Check integrity of downloaded NetCDF files and retry