### PR TITLE
feat: Implement cache tier to use hybrid storage

### DIFF
--- a/Sources/App/Cmip6/CmipDownloader.swift
+++ b/Sources/App/Cmip6/CmipDownloader.swift
@@ -278,7 +278,7 @@ extension GenericDomain {
         return .domainChunk(domain: domainRegistry, variable: variable, type: .linear_bias_seasonal, chunk: nil, ensembleMember: 0, previousDay: 0)
     }
     
-    func openBiasCorrectionFile(for variable: String) throws -> OmFileReader<MmapFile>? {
+    func openBiasCorrectionFile(for variable: String) throws -> OmFileReader<MmapFileCached>? {
         return try OmFileManager.get(getBiasCorrectionFile(for: variable))
     }
 }

--- a/Sources/App/Commands/ExportCommand.swift
+++ b/Sources/App/Commands/ExportCommand.swift
@@ -520,7 +520,7 @@ struct ExportCommand: AsyncCommand {
 
 extension Gridable {
     /// Return true if there is no land around a 5x5 box
-    func onlySeaAround(gridpoint: Int, elevationFile: OmFileReader<MmapFile>) throws -> Bool {
+    func onlySeaAround(gridpoint: Int, elevationFile: OmFileReader<MmapFileCached>) throws -> Bool {
         for y in -2...2 {
             for x in -2...2 {
                 let point = max(0, min(gridpoint + y * nx + x, count))

--- a/Sources/App/Commands/SyncCommand.swift
+++ b/Sources/App/Commands/SyncCommand.swift
@@ -74,7 +74,7 @@ struct SyncCommand: AsyncCommand {
            fatalError("Number of servers and models sets must be the same")
         }
         let pastDays = signature.pastDays ?? 7
-        var variablesSig = signature.variables.split(separator: ",").map(String.init) + ["static"]
+        let variablesSig = signature.variables.split(separator: ",").map(String.init) + ["static"]
         let concurrent = signature.concurrent ?? 4
         /// Undocumented switch to download all weather variables. This can generate immense traffic!
         let downloadAllVariables = variablesSig.contains("really_download_all_variables")
@@ -105,7 +105,7 @@ struct SyncCommand: AsyncCommand {
                         guard let variablePos = remoteDirectory.dropLast().lastIndex(of: "/") else {
                             fatalError("could not get variable from string")
                         }
-                        let variable = remoteDirectory[variablePos..<remoteDirectory.index(before: remoteDirectory.endIndex)]
+                        let variable = remoteDirectory[remoteDirectory.index(after: variablePos)..<remoteDirectory.index(before: remoteDirectory.endIndex)]
                         let isPreviousDay = variable.contains("_previous_day")
                         let isPressureLevel = variable.contains("hPa")
                         let isSurface = !isPressureLevel && !variable.contains("_previous_day")

--- a/Sources/App/Domains/Gridable.swift
+++ b/Sources/App/Domains/Gridable.swift
@@ -58,7 +58,7 @@ extension Gridable {
         return nx * ny
     }
     
-    func findPoint(lat: Float, lon: Float, elevation: Float, elevationFile: OmFileReader<MmapFile>?, mode: GridSelectionMode) throws -> (gridpoint: Int, gridElevation: ElevationOrSea)? {
+    func findPoint(lat: Float, lon: Float, elevation: Float, elevationFile: OmFileReader<MmapFileCached>?, mode: GridSelectionMode) throws -> (gridpoint: Int, gridElevation: ElevationOrSea)? {
         guard let elevationFile = elevationFile else {
             guard let point = findPoint(lat: lat, lon: lon) else {
                 return nil
@@ -78,7 +78,7 @@ extension Gridable {
     }
     
     /// Read elevation for a single grid point
-    func readElevation(gridpoint: Int, elevationFile: OmFileReader<MmapFile>) throws -> ElevationOrSea {
+    func readElevation(gridpoint: Int, elevationFile: OmFileReader<MmapFileCached>) throws -> ElevationOrSea {
         let elevation = try readFromStaticFile(gridpoint: gridpoint, file: elevationFile)
         if elevation.isNaN {
             return .noData
@@ -91,7 +91,7 @@ extension Gridable {
     }
     
     /// Read elevation for a single grid point. Interpolates linearly between grid-cells. Should only be used for linear interpolated reads afterwards
-    func readElevationInterpolated(gridpoint: GridPoint2DFraction, elevationFile: OmFileReader<MmapFile>) throws -> ElevationOrSea {
+    func readElevationInterpolated(gridpoint: GridPoint2DFraction, elevationFile: OmFileReader<MmapFileCached>) throws -> ElevationOrSea {
         let elevation = try elevationFile.readInterpolated(pos: gridpoint)
         if elevation.isNaN {
             return .noData
@@ -105,7 +105,7 @@ extension Gridable {
     }
     
     /// Read static information e.g. elevation or soil type
-    func readFromStaticFile(gridpoint: Int, file: OmFileReader<MmapFile>) throws -> Float {
+    func readFromStaticFile(gridpoint: Int, file: OmFileReader<MmapFileCached>) throws -> Float {
         let x = gridpoint % nx
         let y = gridpoint / nx
         var value = Float.nan
@@ -114,7 +114,7 @@ extension Gridable {
     }
     
     /// Get nearest grid point
-    func findPointNearest(lat: Float, lon: Float, elevationFile: OmFileReader<MmapFile>) throws -> (gridpoint: Int, gridElevation: ElevationOrSea)? {
+    func findPointNearest(lat: Float, lon: Float, elevationFile: OmFileReader<MmapFileCached>) throws -> (gridpoint: Int, gridElevation: ElevationOrSea)? {
         guard let center = findPoint(lat: lat, lon: lon) else {
             return nil
         }
@@ -127,7 +127,7 @@ extension Gridable {
     }
     
     /// Find point, perferably in sea
-    func findPointInSea(lat: Float, lon: Float, elevationFile: OmFileReader<MmapFile>) throws -> (gridpoint: Int, gridElevation: ElevationOrSea)? {
+    func findPointInSea(lat: Float, lon: Float, elevationFile: OmFileReader<MmapFileCached>) throws -> (gridpoint: Int, gridElevation: ElevationOrSea)? {
         guard let center = findPoint(lat: lat, lon: lon) else {
             return nil
         }
@@ -165,7 +165,7 @@ extension Gridable {
     }
     
     /// Analyse 3x3 locations around the desired coordinate and return the best elevation match
-    func findPointTerrainOptimised(lat: Float, lon: Float, elevation: Float, elevationFile: OmFileReader<MmapFile>) throws -> (gridpoint: Int, gridElevation: ElevationOrSea)? {
+    func findPointTerrainOptimised(lat: Float, lon: Float, elevation: Float, elevationFile: OmFileReader<MmapFileCached>) throws -> (gridpoint: Int, gridElevation: ElevationOrSea)? {
         guard let center = findPoint(lat: lat, lon: lon) else {
             return nil
         }

--- a/Sources/App/Helper/OmFileManager.swift
+++ b/Sources/App/Helper/OmFileManager.swift
@@ -17,29 +17,33 @@ enum OmFileManagerReadable: Hashable {
     
     /// Assemble the full file system path
     func getFilePath() -> String {
+        return "\(OpenMeteo.dataDirectory)\(getRelativeFilePath())"
+    }
+    
+    private func getRelativeFilePath() -> String {
         switch self {
         case .domainChunk(let domain, let variable, let type, let chunk, let ensembleMember, let previousDay):
             let ensembleMember = ensembleMember > 0 ? "_member\(ensembleMember.zeroPadded(len: 2))" : ""
             let previousDay = previousDay > 0 ? "_previous_day\(previousDay)" : ""
             if let chunk {
-                return "\(domain.directory)\(variable)\(previousDay)\(ensembleMember)/\(type)_\(chunk).om"
+                return "\(domain.rawValue)\(variable)\(previousDay)\(ensembleMember)/\(type)_\(chunk).om"
             }
-            return "\(domain.directory)\(variable)\(previousDay)\(ensembleMember)/\(type).om"
+            return "\(domain.rawValue)\(variable)\(previousDay)\(ensembleMember)/\(type).om"
         case .staticFile(let domain, let variable, let chunk):
             if let chunk {
                 // E.g. DEM model '/copernicus_dem90/static/lat_-1.om'
-                return "\(domain.directory)static/\(variable)_\(chunk).om"
+                return "\(domain.rawValue)static/\(variable)_\(chunk).om"
             }
-            return "\(domain.directory)static/\(variable).om"
+            return "\(domain.rawValue)static/\(variable).om"
         }
     }
     
-    func createDirectory() throws {
-        let file = getFilePath()
+    func createDirectory(dataDirectory: String = OpenMeteo.dataDirectory) throws {
+        let file = getRelativeFilePath()
         guard let last = file.lastIndex(of: "/") else {
             return
         }
-        let path = String(file[file.startIndex..<last])
+        let path = "\(dataDirectory)\(file[file.startIndex..<last])"
         try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
     }
     
@@ -50,6 +54,20 @@ enum OmFileManagerReadable: Hashable {
         }
         return try OmFileReader(file: file)
     }
+    
+    func openReadCached() throws -> OmFileReader<MmapFileCached>? {
+        let fileRel = getRelativeFilePath()
+        let file = "\(OpenMeteo.dataDirectory)\(fileRel)"
+        guard FileManager.default.fileExists(atPath: file) else {
+            return nil
+        }
+        if let cacheDir = OpenMeteo.cacheDirectory {
+            let cacheFile = "\(cacheDir)\(fileRel)"
+            try createDirectory(dataDirectory: cacheDir)
+            return try OmFileReader(file: file, cacheFile: cacheFile)
+        }
+        return try OmFileReader(file: file, cacheFile: nil)
+    }
 }
 
 /// cache file handles, background close checks
@@ -57,7 +75,7 @@ enum OmFileManagerReadable: Hashable {
 final class OmFileManager: LifecycleHandler {
     /// A file might exist and is open, or it is missing
     enum OmFileState {
-        case exists(file: OmFileReader<MmapFile>)
+        case exists(file: OmFileReader<MmapFileCached>)
         case missing(path: String)
     }
     
@@ -128,12 +146,12 @@ final class OmFileManager: LifecycleHandler {
     }
     
     /// Get cached file or return nil, if the files does not exist
-    public static func get(_ file: OmFileManagerReadable) throws -> OmFileReader<MmapFile>? {
+    public static func get(_ file: OmFileManagerReadable) throws -> OmFileReader<MmapFileCached>? {
         try instance.get(file)
     }
 
     /// Get cached file or return nil, if the files does not exist
-    public func get(_ file: OmFileManagerReadable) throws -> OmFileReader<MmapFile>? {
+    public func get(_ file: OmFileManagerReadable) throws -> OmFileReader<MmapFileCached>? {
         let key = file.hashValue
         
         return try cached.withLockedValue { cached in
@@ -145,7 +163,7 @@ final class OmFileManager: LifecycleHandler {
                     return nil
                 }
             }
-            guard let file = try file.openRead() else {
+            guard let file = try file.openReadCached() else {
                 cached[key] = .missing(path: file.getFilePath())
                 return nil
             }

--- a/Sources/App/Helper/OmFileManager.swift
+++ b/Sources/App/Helper/OmFileManager.swift
@@ -26,15 +26,15 @@ enum OmFileManagerReadable: Hashable {
             let ensembleMember = ensembleMember > 0 ? "_member\(ensembleMember.zeroPadded(len: 2))" : ""
             let previousDay = previousDay > 0 ? "_previous_day\(previousDay)" : ""
             if let chunk {
-                return "\(domain.rawValue)\(variable)\(previousDay)\(ensembleMember)/\(type)_\(chunk).om"
+                return "\(domain.rawValue)/\(variable)\(previousDay)\(ensembleMember)/\(type)_\(chunk).om"
             }
-            return "\(domain.rawValue)\(variable)\(previousDay)\(ensembleMember)/\(type).om"
+            return "\(domain.rawValue)/\(variable)\(previousDay)\(ensembleMember)/\(type).om"
         case .staticFile(let domain, let variable, let chunk):
             if let chunk {
                 // E.g. DEM model '/copernicus_dem90/static/lat_-1.om'
-                return "\(domain.rawValue)static/\(variable)_\(chunk).om"
+                return "\(domain.rawValue)/static/\(variable)_\(chunk).om"
             }
-            return "\(domain.rawValue)static/\(variable).om"
+            return "\(domain.rawValue)/static/\(variable).om"
         }
     }
     

--- a/Sources/App/Helper/Reader/GenericDomain.swift
+++ b/Sources/App/Helper/Reader/GenericDomain.swift
@@ -36,7 +36,7 @@ extension GenericDomain {
     }
     
     /// The the file containing static information for elevation of soil types
-    func getStaticFile(type: ReaderStaticVariable) -> OmFileReader<MmapFile>? {
+    func getStaticFile(type: ReaderStaticVariable) -> OmFileReader<MmapFileCached>? {
         guard let domainRegistryStatic else {
             return nil
         }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -20,6 +20,11 @@ struct OpenMeteo {
         }
         return  "./data/"
     }()
+    
+    /// Cache all data access using spare files in this directory
+    static var cacheDirectory = {
+        return Environment.get("CACHE_DIRECTORY")
+    }()
 }
 
 extension Application {

--- a/Sources/SwiftPFor2D/Backend.swift
+++ b/Sources/SwiftPFor2D/Backend.swift
@@ -13,6 +13,7 @@ public protocol OmFileReaderBackend {
     var count: Int { get }
     var needsPrefetch: Bool { get }
     func prefetchData(offset: Int, count: Int)
+    func preRead(offset: Int, count: Int)
     
     func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType
 }
@@ -54,6 +55,10 @@ extension FileHandle: OmFileWriterBackend {
 
 /// Make `FileHandle` work as reader
 extension MmapFile: OmFileReaderBackend {
+    public func preRead(offset: Int, count: Int) {
+        
+    }
+    
     public var count: Int {
         return data.count
     }
@@ -69,6 +74,10 @@ extension MmapFile: OmFileReaderBackend {
 
 /// Make `Data` work as reader
 extension DataAsClass: OmFileReaderBackend {
+    public func preRead(offset: Int, count: Int) {
+        
+    }
+    
     public var count: Int {
         return data.count
     }

--- a/Sources/SwiftPFor2D/FileExtension.swift
+++ b/Sources/SwiftPFor2D/FileExtension.swift
@@ -3,7 +3,7 @@ import Foundation
 extension FileHandle {
     /// Create new file and convert it into a `FileHandle`. For some reason this does not exist in stock swift....
     /// Error on existing file
-    public static func createNewFile(file: String, size: Int? = nil) throws -> FileHandle {
+    public static func createNewFile(file: String, size: Int? = nil, sparseSize: Int? = nil) throws -> FileHandle {
         // 0644 permissions
         // O_TRUNC for overwrite
         let fn = open(file, O_RDWR | O_CREAT, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH)
@@ -13,6 +13,12 @@ extension FileHandle {
         }
         
         let handle = FileHandle(fileDescriptor: fn, closeOnDealloc: true)
+        if let sparseSize {
+            guard ftruncate(fn, off_t(sparseSize)) == 0 else {
+                let error = String(cString: strerror(errno))
+                throw SwiftPFor2DError.cannotTruncateFile(filename: file, errno: errno, error: error)
+            }
+        }
         if let size {
             try handle.preAllocate(size: size)
         }
@@ -59,6 +65,19 @@ extension FileHandle {
         return handle
     }
     
+    /// Open file for read/write
+    public static func openFileReadWrite(file: String) throws -> FileHandle {
+        // 0644 permissions
+        // O_TRUNC for overwrite
+        let fn = open(file, O_RDWR, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH)
+        guard fn > 0 else {
+            let error = String(cString: strerror(errno))
+            throw SwiftPFor2DError.cannotOpenFile(filename: file, errno: errno, error: error)
+        }
+        let handle = FileHandle(fileDescriptor: fn, closeOnDealloc: true)
+        return handle
+    }
+    
     /// Check if the file was deleted on the file system. Linux keep the file alive, as long as some processes have it open.
     public func wasDeleted() -> Bool {
         var stats = stat()
@@ -77,6 +96,17 @@ extension FileHandle {
             fatalError("fstat failed on open file descriptor. Error \(errno) \(error)")
         }
         return Int(stats.st_size)
+    }
+    
+    public func fileSizeAndModificationTime() -> (size: Int, modificationTime: Date) {
+        var stats = stat()
+        guard fstat(fileDescriptor, &stats) != -1 else {
+            let error = String(cString: strerror(errno))
+            fatalError("fstat failed on open file descriptor. Error \(errno) \(error)")
+        }
+        let seconds = Double(stats.st_mtimespec.tv_sec)
+        let nanosends = Double(stats.st_mtimespec.tv_nsec)
+        return (Int(stats.st_size), Date(timeIntervalSince1970: seconds + nanosends / 1000))
     }
 }
 

--- a/Sources/SwiftPFor2D/FileExtension.swift
+++ b/Sources/SwiftPFor2D/FileExtension.swift
@@ -104,8 +104,13 @@ extension FileHandle {
             let error = String(cString: strerror(errno))
             fatalError("fstat failed on open file descriptor. Error \(errno) \(error)")
         }
-        let seconds = Double(stats.st_mtimespec.tv_sec)
-        let nanosends = Double(stats.st_mtimespec.tv_nsec)
+        #if os(Linux)
+            let seconds = Double(stats.st_mtim.tv_sec)
+            let nanosends = Double(stats.st_mtim.tv_nsec)
+        #else
+            let seconds = Double(stats.st_mtimespec.tv_sec)
+            let nanosends = Double(stats.st_mtimespec.tv_nsec)
+        #endif
         return (Int(stats.st_size), Date(timeIntervalSince1970: seconds + nanosends / 1000))
     }
 }

--- a/Sources/SwiftPFor2D/MmapFile.swift
+++ b/Sources/SwiftPFor2D/MmapFile.swift
@@ -1,23 +1,35 @@
 import Foundation
 
-/// Mmap a all pages for a file
+/// `Mmap` all pages for a file
 public final class MmapFile {
     public let data: UnsafeBufferPointer<UInt8>
     public let file: FileHandle
+    
+    public enum Mode {
+        case readOnly
+        case readWrite
+        
+        /// mmap `prot` attribute
+        fileprivate var prot: Int32 {
+            switch self {
+            case .readOnly:
+                return PROT_READ
+            case .readWrite:
+                return PROT_READ | PROT_WRITE
+            }
+        }
+    }
 
     /// Mmap the entire filehandle
-    public init(fn: FileHandle) throws {
+    public init(fn: FileHandle, mode: Mode = .readOnly) throws {
         let len = try Int(fn.seekToEnd())
-                
-        // for write: guard let mem = mmap(nil, len, PROT_READ | PROT_WRITE, MAP_SHARED, fn, 0),
-        guard let mem = mmap(nil, len, PROT_READ, MAP_SHARED, fn.fileDescriptor, 0), mem != UnsafeMutableRawPointer(bitPattern: -1) else {
+        guard let mem = mmap(nil, len, mode.prot, MAP_SHARED, fn.fileDescriptor, 0), mem != UnsafeMutableRawPointer(bitPattern: -1) else {
             let error = String(cString: strerror(errno))
             throw SwiftPFor2DError.cannotOpenFile(errno: errno, error: error)
         }
         //madvise(mem, len, MADV_SEQUENTIAL)
         let start = mem.assumingMemoryBound(to: UInt8.self)
-        data = UnsafeBufferPointer(start: start, count: len)
-        
+        self.data = UnsafeBufferPointer(start: start, count: len)
         self.file = fn
     }
     

--- a/Sources/SwiftPFor2D/MmapFileCached.swift
+++ b/Sources/SwiftPFor2D/MmapFileCached.swift
@@ -3,12 +3,12 @@ import Foundation
 /// Mmap a all pages for a file
 public final class MmapFileCached {
     public let backend: MmapFile
-    public let frontend: MmapMutableFile?
+    public let frontend: MmapFile?
     public let cacheFile: String?
 
     public init(backend: FileHandle, frontend: FileHandle?, cacheFile: String?) throws {
         self.backend = try MmapFile(fn: backend)
-        self.frontend = try frontend.map { try MmapMutableFile(fn: $0) }
+        self.frontend = try frontend.map { try MmapFile(fn: $0, mode: .readWrite) }
         self.cacheFile = cacheFile
     }
     
@@ -37,6 +37,7 @@ public final class MmapFileCached {
 }
 
 extension MmapFileCached: OmFileReaderBackend {
+    /// Populate cache frontend before reading
     public func preRead(offset: Int, count: Int) {
         guard let frontend else {
             return
@@ -45,11 +46,12 @@ extension MmapFileCached: OmFileReaderBackend {
         let blockSize = 128*1024
         let blockStart = offset.floor(to: blockSize)
         let blockEnd = (offset + count).ceil(to: blockSize)
+        let backendData = UnsafeMutableBufferPointer(mutating: backend.data)
+        let frontendData = UnsafeMutableBufferPointer(mutating: frontend.data)
         for block in stride(from: blockStart, to: blockEnd, by: blockSize) {
-            let range = block..<min(block+blockSize, backend.data.count)
-            if frontend.data.allZero(range) {
-                let backendData = UnsafeMutableBufferPointer(mutating: backend.data)
-                frontend.data[range] = backendData[range]
+            let range = block..<min(block+blockSize, backendData.count)
+            if frontendData.allZero(range) {
+                frontendData[range] = backendData[range]
             }
         }
     }
@@ -64,56 +66,12 @@ extension MmapFileCached: OmFileReaderBackend {
     
     public func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
         if let frontend {
-            try frontend.data.withUnsafeBytes(body)
+            try frontend.withUnsafeBytes(body)
         } else {
             try backend.withUnsafeBytes(body)
         }
     }
 }
-
-
-/// Similar to MmapFile, but mutable
-public final class MmapMutableFile {
-    public let data: UnsafeMutableBufferPointer<UInt8>
-    public let file: FileHandle
-
-    /// Mmap the entire filehandle
-    public init(fn: FileHandle) throws {
-        let len = try Int(fn.seekToEnd())
-        guard let mem = mmap(nil, len, PROT_READ | PROT_WRITE, MAP_SHARED, fn.fileDescriptor, 0), mem != UnsafeMutableRawPointer(bitPattern: -1) else {
-            let error = String(cString: strerror(errno))
-            throw SwiftPFor2DError.cannotOpenFile(errno: errno, error: error)
-        }
-        //madvise(mem, len, MADV_SEQUENTIAL)
-        let start = mem.assumingMemoryBound(to: UInt8.self)
-        data = UnsafeMutableBufferPointer(start: start, count: len)
-        self.file = fn
-    }
-    
-    /// Check if the file was deleted on the file system. Linux keep the file alive, as long as some processes have it open.
-    public func wasDeleted() -> Bool {
-        file.wasDeleted()
-    }
-    
-    public func prefetchData(offset: Int, count: Int) {
-        let pageStart = offset.floor(to: 4096)
-        let pageEnd = (offset + count).ceil(to: 4096)
-        let length = pageEnd - pageStart
-        let ret = madvise(UnsafeMutableRawPointer(mutating: data.baseAddress!.advanced(by: pageStart)), length, MADV_WILLNEED)
-        guard ret == 0 else {
-            let error = String(cString: strerror(errno))
-            fatalError("madvice failed! ret=\(ret), errno=\(errno), \(error)")
-        }
-    }
-
-    deinit {
-        let len = data.count * MemoryLayout<UInt8>.size
-        guard munmap(UnsafeMutableRawPointer(mutating: data.baseAddress!), len) == 0 else {
-            fatalError("munmap failed")
-        }
-    }
-}
-
 
 extension UnsafeMutableBufferPointer where Element == UInt8 {
     /// Check if a range contains all zero bytes

--- a/Sources/SwiftPFor2D/MmapFileCached.swift
+++ b/Sources/SwiftPFor2D/MmapFileCached.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Mmap a all pages for a file
+public final class MmapFileCached {
+    public let backend: MmapFile
+    public let frontend: MmapMutableFile?
+    public let cacheFile: String?
+
+    public init(backend: FileHandle, frontend: FileHandle?, cacheFile: String?) throws {
+        self.backend = try MmapFile(fn: backend)
+        self.frontend = try frontend.map { try MmapMutableFile(fn: $0) }
+        self.cacheFile = cacheFile
+    }
+    
+    /// Check if the file was deleted on the file system
+    public func wasDeleted() -> Bool {
+        if frontend?.wasDeleted() == true {
+            return true
+        }
+        if backend.wasDeleted() {
+            if let cacheFile {
+                try? FileManager.default.removeItemIfExists(at: cacheFile)
+            }
+            return true
+        }
+        return false
+    }
+    
+    /// Check if data is in cache, otherwise load data from backend into cache
+    public func prefetchData(offset: Int, count: Int) {
+        if let frontend {
+            // Check for sparse hole and promote data from backend
+            let range = offset ..< offset + count
+            if frontend.data.allZero(range) {
+                let backendData = UnsafeMutableBufferPointer(mutating: backend.data)
+                frontend.data[range] = backendData[range]
+            }
+        } else {
+            backend.prefetchData(offset: offset, count: count)
+        }
+    }
+}
+
+extension MmapFileCached: OmFileReaderBackend {
+    public var count: Int {
+        return backend.count
+    }
+    
+    public var needsPrefetch: Bool {
+        return true
+    }
+    
+    public func withUnsafeBytes<ResultType>(_ body: (UnsafeRawBufferPointer) throws -> ResultType) rethrows -> ResultType {
+        if let frontend {
+            try frontend.data.withUnsafeBytes(body)
+        } else {
+            try backend.withUnsafeBytes(body)
+        }
+    }
+}
+
+
+/// Similar to MmapFile, but mutable
+public final class MmapMutableFile {
+    public let data: UnsafeMutableBufferPointer<UInt8>
+    public let file: FileHandle
+
+    /// Mmap the entire filehandle
+    public init(fn: FileHandle) throws {
+        let len = try Int(fn.seekToEnd())
+        guard let mem = mmap(nil, len, PROT_READ | PROT_WRITE, MAP_SHARED, fn.fileDescriptor, 0), mem != UnsafeMutableRawPointer(bitPattern: -1) else {
+            let error = String(cString: strerror(errno))
+            throw SwiftPFor2DError.cannotOpenFile(errno: errno, error: error)
+        }
+        //madvise(mem, len, MADV_SEQUENTIAL)
+        let start = mem.assumingMemoryBound(to: UInt8.self)
+        data = UnsafeMutableBufferPointer(start: start, count: len)
+        self.file = fn
+    }
+    
+    /// Check if the file was deleted on the file system. Linux keep the file alive, as long as some processes have it open.
+    public func wasDeleted() -> Bool {
+        file.wasDeleted()
+    }
+
+    deinit {
+        let len = data.count * MemoryLayout<UInt8>.size
+        guard munmap(UnsafeMutableRawPointer(mutating: data.baseAddress!), len) == 0 else {
+            fatalError("munmap failed")
+        }
+    }
+}
+
+
+extension UnsafeMutableBufferPointer where Element == UInt8 {
+    /// Check if a range contains all zero bytes
+    func allZero(_ range: Range<Int>) -> Bool {
+        for i in (range).clamped(to: indices) {
+            if self[i] != 0 {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/build/openmeteo-sync.service
+++ b/build/openmeteo-sync.service
@@ -8,7 +8,7 @@ Type=simple
 User=openmeteo-api
 Group=openmeteo-api
 WorkingDirectory=/var/lib/openmeteo-api/
-ExecStart=/bin/sh -c "/usr/local/bin/openmeteo-api sync $$SYNC_DOMAINS $$SYNC_VARIABLES $${SYNC_APIKEY:+--apikey $$SYNC_APIKEY} $${SYNC_PAST_DAYS:+--past-days $$SYNC_PAST_DAYS} $${SYNC_SERVER:+--server $$SYNC_SERVER} $${SYNC_REPEAT_INTERVAL:+--repeat-interval $$SYNC_REPEAT_INTERVAL} $${SYNC_CONCURRENT:+--concurrent $$SYNC_CONCURRENT}"
+ExecStart=/bin/sh -c "/usr/local/bin/openmeteo-api sync $$SYNC_DOMAINS $$SYNC_VARIABLES $${SYNC_APIKEY:+--apikey $$SYNC_APIKEY} $${SYNC_PAST_DAYS:+--past-days $$SYNC_PAST_DAYS} $${SYNC_SERVER:+--server $$SYNC_SERVER} $${SYNC_REPEAT_INTERVAL:+--repeat-interval $$SYNC_REPEAT_INTERVAL} $${SYNC_CONCURRENT:+--concurrent $$SYNC_CONCURRENT} $${SYNC_DATA_DIRECTORY_MAX_SIZE_GB:+--data-directory-max-size-gb $$SYNC_DATA_DIRECTORY_MAX_SIZE_GB} $${SYNC_CACHE_DIRECTORY_MAX_SIZE_GB:+--cache-directory-max-size-gb $$SYNC_CACHE_DIRECTORY_MAX_SIZE_GB} --execute"
 ExecStopPost=/bin/bash -c 'if [ "$$EXIT_STATUS" != 0 ]; then /usr/local/bin/openmeteo-notify.sh $NOTIFICATION_EMAIL %N; fi'
 Restart=on-failure
 RestartSec=1


### PR DESCRIPTION
Currently open-meteo archives use hybrid storage using ZFS with HDDs as large storage and SSDs as fast cache. This adds a lot of overhead and cannot be fine controlled. This PR adds a direct implementation for storage tiering. This is a bit experimental and uncertain if it works out.