### PR TITLE
Integrate AIFS from ECMWF

### DIFF
--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -309,6 +309,7 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
     
     case ecmwf_ifs04
     case ecmwf_ifs025
+    case ecmwf_aifs025
     
     case metno_nordic
     
@@ -442,6 +443,8 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
             return try EcmwfReader(domain: .ifs04, lat: lat, lon: lon, elevation: elevation, mode: mode).flatMap({[$0]}) ?? []
         case .ecmwf_ifs025:
             return try EcmwfReader(domain: .ifs025, lat: lat, lon: lon, elevation: elevation, mode: mode).flatMap({[$0]}) ?? []
+        case .ecmwf_aifs025:
+            return try EcmwfReader(domain: .aifs025, lat: lat, lon: lon, elevation: elevation, mode: mode).flatMap({[$0]}) ?? []
         case .metno_nordic:
             return try MetNoReader(domain: .nordic_pp, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
         case .gem_seamless:

--- a/Sources/App/Domains/GaussianGrid.swift
+++ b/Sources/App/Domains/GaussianGrid.swift
@@ -18,7 +18,7 @@ struct GaussianGrid: Gridable {
     
     let type: GridType
     
-    var nx: Int { return 4 * 1280 * (1280 + 9) }
+    var nx: Int { return type.count }
     
     var ny: Int { 1 }
     

--- a/Sources/App/Domains/GaussianGrid.swift
+++ b/Sources/App/Domains/GaussianGrid.swift
@@ -4,9 +4,15 @@ import Foundation
 struct GaussianGrid: Gridable {
     enum GridType {
         case o1280
+        case t639
         
         var count: Int {
-            return 4 * 1280 * (1280 + 9) // 6599680
+            switch self {
+            case .o1280:
+                return 4 * 1280 * (1280 + 9) // 6599680
+            case .t639:
+                return 542080
+            }
         }
     }
     

--- a/Sources/App/Domains/GaussianGrid.swift
+++ b/Sources/App/Domains/GaussianGrid.swift
@@ -4,14 +4,77 @@ import Foundation
 struct GaussianGrid: Gridable {
     enum GridType {
         case o1280
-        case t639
+        case n320
+        
+        /// Note quite sure if there is an analysical soltiuion for N type grid. https://confluence.ecmwf.int/display/FCST/Gaussian+grid+with+320+latitude+lines+between+pole+and+equator
+        /// Therefore here is a lookup table
+        static var n320CountPerLine = [18,25,36,40,45,50,60,64,72,72,75,81,90,96,100,108,120,120,125,135,144,144,150,160,180,180,180,192,192,200,216,216,216,225,240,240,240,250,256,270,270,288,288,288,300,300,320,320,320,324,360,360,360,360,360,360,375,375,384,384,400,400,405,432,432,432,432,450,450,450,480,480,480,480,480,486,500,500,500,512,512,540,540,540,540,540,576,576,576,576,576,576,600,600,600,600,640,640,640,640,640,640,640,648,648,675,675,675,675,720,720,720,720,720,720,720,720,720,729,750,750,750,750,768,768,768,768,800,800,800,800,800,800,810,810,864,864,864,864,864,864,864,864,864,864,864,900,900,900,900,900,900,900,900,960,960,960,960,960,960,960,960,960,960,960,960,960,960,972,972,1000,1000,1000,1000,1000,1000,1000,1000,1024,1024,1024,1024,1024,1024,1080,1080,1080,1080,1080,1080,1080,1080,1080,1080,1080,1080,1080,1080,1125,1125,1125,1125,1125,1125,1125,1125,1125,1125,1125,1125,1125,1125,1152,1152,1152,1152,1152,1152,1152,1152,1152,1200,1200,1200,1200,1200,1200,1200,1200,1200,1200,1200,1200,1200,1200,1200,1200,1200,1200,1215,1215,1215,1215,1215,1215,1215,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280,1280]
         
         var count: Int {
             switch self {
             case .o1280:
                 return 4 * 1280 * (1280 + 9) // 6599680
-            case .t639:
+            case .n320:
                 return 542080
+            }
+        }
+        
+        var latitudeLines: Int {
+            switch self {
+            case .o1280:
+                return 1280
+            case .n320:
+                return 320
+            }
+        }
+        
+        @inlinable func nxOf(y: Int) -> Int {
+            switch self {
+            case .o1280:
+                return y < latitudeLines ? (20 + y * 4) : ((2*latitudeLines - y - 1) * 4 + 20)
+            case .n320:
+                return y < latitudeLines ? Self.n320CountPerLine[y] : Self.n320CountPerLine[2*Self.n320CountPerLine.count-y-1]
+            }
+        }
+        
+        /// Integrate the number of grid points at this latitude line
+        @inlinable func integral(y: Int) -> Int {
+            switch self {
+            case .o1280:
+                return y < latitudeLines ? (2*y*y + 18 * y) : (count - (2*(2*latitudeLines-y)*(2*latitudeLines-y) + 18 * (2*latitudeLines-y)))
+            case .n320:
+                if y < latitudeLines {
+                    return Self.n320CountPerLine[0..<y].reduce(0, +)
+                }
+                //return count / 2 + Self.n320CountPerLine.reversed()[0..<y-Self.n320CountPerLine.count].reduce(0, +)
+                return count / 2 + Self.n320CountPerLine[2*Self.n320CountPerLine.count-y ..< Self.n320CountPerLine.count].reduce(0, +)
+            }
+        }
+        
+        /// Find latiture line for given gridpoint
+        @inlinable func getPos(gridpoint: Int) -> (y: Int, x: Int, nxPerLine: Int) {
+            switch self {
+            case .o1280:
+                let y = gridpoint < count / 2 ? Int((sqrt(2 * Float(gridpoint) + 81) - 9) / 2) : (2*latitudeLines - 1 - Int((sqrt(2 * Float(count - gridpoint - 1) + 81) - 9) / 2))
+                let x = gridpoint - integral(y: y)
+                let nx = nxOf(y: y)
+                return (y, x, nx)
+            case .n320:
+                var sum = 0
+                for (y, n) in Self.n320CountPerLine.enumerated() {
+                    sum += n
+                    if gridpoint < sum {
+                        return (y, gridpoint - (sum - n), n)
+                    }
+                    
+                }
+                for (y, n) in Self.n320CountPerLine.reversed().enumerated() {
+                    sum += n
+                    if gridpoint < sum {
+                        return (y + Self.n320CountPerLine.count, gridpoint - (sum - n), n)
+                    }
+                }
+                fatalError("Index out of range")
             }
         }
     }
@@ -27,35 +90,33 @@ struct GaussianGrid: Gridable {
     }
     
     func getCoordinates(gridpoint: Int) -> (latitude: Float, longitude: Float) {
-        let y = gridpoint < count / 2 ? Int((sqrt(2 * Float(gridpoint) + 81) - 9) / 2) : (2*1280 - 1 - Int((sqrt(2 * Float(count - gridpoint - 1) + 81) - 9) / 2))
-        let x = gridpoint - integral(y: y)
-        let nx = nxOf(y: y)
+        let latitudeLines = type.latitudeLines
+        let (y, x, nx) = type.getPos(gridpoint: gridpoint)
         let dx = 360 / Float(nx)
-        let dy = Float(180)/(2*1280 + 0.5)
+        let dy = Float(180)/(2*Float(latitudeLines) + 0.5)
         let lon = Float(x) * dx
-        // grid points are shifted by dy/2
-        //print("y=\(y) x=\(x)")
-        return (Float(1280 - y - 1) * dy + dy/2, lon >= 180 ? lon - 360 : lon)
+        return (Float(latitudeLines - y - 1) * dy + dy/2, lon >= 180 ? lon - 360 : lon)
     }
     
     @inlinable func nxOf(y: Int) -> Int {
-        return y < 1280 ? (20 + y * 4) : ((2*1280 - y - 1) * 4 + 20)
+        return type.nxOf(y: y)
     }
     
     /// Integrate the number of grid points at this latitude line
     @inlinable func integral(y: Int) -> Int {
-        return y < 1280 ? (2*y*y + 18 * y) : (count - (2*(2*1280-y)*(2*1280-y) + 18 * (2*1280-y)))
+        return type.integral(y: y)
     }
     
     func findPoint(lat: Float, lon: Float) -> Int? {
-        let dy = Float(180)/(2*1280+0.5)
-        let y = (Int(round(Float(1280) - 1 - ((lat - dy/2) / dy))) + 2*1280) % (2*1280)
+        let latitudeLines = type.latitudeLines
+        
+        let dy = Float(180)/(2*Float(latitudeLines)+0.5)
+        let y = (Int(round(Float(latitudeLines) - 1 - ((lat - dy/2) / dy))) + 2*latitudeLines) % (2*latitudeLines)
         
         let nx = nxOf(y: y)
         let dx = 360 / Float(nx)
         
         let x = (Int(round(lon / dx)) + nx) % nx
-        //print("y=\(y) x=\(x)")
         return integral(y: y) + x
     }
 }

--- a/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
+++ b/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
@@ -127,7 +127,12 @@ struct DownloadEcmwfCommand: AsyncCommand {
         }
         //try Array2DFastSpace(data: elevation, nLocations: domain.grid.count, nTime: 1).writeNetcdf(filename: "\(domain.downloadDirectory)/elevation.nc", nx: domain.grid.nx, ny: domain.grid.ny)
         try domain.surfaceElevationFileOm.createDirectory()
-        try OmFileWriter(dim0: domain.grid.ny, dim1: domain.grid.nx, chunk0: 20, chunk1: 20).write(file: domain.surfaceElevationFileOm.getFilePath(), compressionType: .p4nzdec256, scalefactor: 1, all: elevation)
+        if domain == .aifs025 {
+            try OmFileWriter(dim0: domain.grid.ny, dim1: domain.grid.nx, chunk0: 1, chunk1: 20*20).write(file: domain.surfaceElevationFileOm.getFilePath(), compressionType: .p4nzdec256, scalefactor: 1, all: elevation)
+        } else {
+            try OmFileWriter(dim0: domain.grid.ny, dim1: domain.grid.nx, chunk0: 20, chunk1: 20).write(file: domain.surfaceElevationFileOm.getFilePath(), compressionType: .p4nzdec256, scalefactor: 1, all: elevation)
+        }
+
     }
     
     /// Download ECMWF ifs open data

--- a/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
+++ b/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
@@ -262,7 +262,7 @@ struct DownloadEcmwfCommand: AsyncCommand {
                     }
                 }
                 
-                if domain == .aifs025 && variable == .dew_point_2m {
+                if variable == .dew_point_2m {
                     await inMemory.set(.init(variable, member), grib2d.array.data)
                     return nil
                 }
@@ -313,10 +313,13 @@ struct DownloadEcmwfCommand: AsyncCommand {
                 try await calcRh(rh: .relative_humidity_925hPa, q: .specific_humidity_925hPa, t: .temperature_925hPa, member: member, hpa: 925)
                 try await calcRh(rh: .relative_humidity_850hPa, q: .specific_humidity_850hPa, t: .temperature_850hPa, member: member, hpa: 850)
                 try await calcRh(rh: .relative_humidity_700hPa, q: .specific_humidity_700hPa, t: .temperature_700hPa, member: member, hpa: 700)
+                try await calcRh(rh: .relative_humidity_600hPa, q: .specific_humidity_600hPa, t: .temperature_600hPa, member: member, hpa: 600)
                 try await calcRh(rh: .relative_humidity_500hPa, q: .specific_humidity_500hPa, t: .temperature_500hPa, member: member, hpa: 500)
+                try await calcRh(rh: .relative_humidity_400hPa, q: .specific_humidity_400hPa, t: .temperature_400hPa, member: member, hpa: 400)
                 try await calcRh(rh: .relative_humidity_300hPa, q: .specific_humidity_300hPa, t: .temperature_300hPa, member: member, hpa: 300)
                 try await calcRh(rh: .relative_humidity_250hPa, q: .specific_humidity_250hPa, t: .temperature_250hPa, member: member, hpa: 250)
                 try await calcRh(rh: .relative_humidity_200hPa, q: .specific_humidity_200hPa, t: .temperature_200hPa, member: member, hpa: 200)
+                try await calcRh(rh: .relative_humidity_100hPa, q: .specific_humidity_100hPa, t: .temperature_100hPa, member: member, hpa: 100)
                 try await calcRh(rh: .relative_humidity_50hPa, q: .specific_humidity_50hPa, t: .temperature_50hPa, member: member, hpa: 50)
                 
                 guard let rh1000 = await inMemory.get(.init(.relative_humidity_1000hPa, member)),

--- a/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
+++ b/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
@@ -323,6 +323,9 @@ extension EcmwfDomain {
         case .ifs04,. ifs025:
             // ECMWF has a delay of 7-8 hours after initialisation
             return twoHoursAgo.with(hour: ((t.hour - 7 + 24) % 24) / 6 * 6)
+        case .aifs025:
+            // AIFS025 has a delay of 6-7 hours after initialisation
+            return twoHoursAgo.with(hour: ((t.hour - 6 + 24) % 24) / 6 * 6)
         }
     }
     /// Get download url for a given domain and timestep
@@ -340,6 +343,9 @@ extension EcmwfDomain {
             return "\(base)\(dateStr)/\(runStr)z/ifs/0p25/\(product)/\(dateStr)\(runStr)0000-\(hour)h-\(product)-fc.grib2"
         case .ifs025_ensemble:
             return "\(base)\(dateStr)/\(runStr)z/ifs/0p25/enfo/\(dateStr)\(runStr)0000-\(hour)h-enfo-ef.grib2"
+        case .aifs025:
+            let product = "oper"// run.hour == 0 || run.hour == 12 ? "oper" : "scda"
+            return "\(base)\(dateStr)/\(runStr)z/aifs/0p25/\(product)/\(dateStr)\(runStr)0000-\(hour)h-\(product)-fc.grib2"
         }
     }
 }

--- a/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
+++ b/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
@@ -193,7 +193,10 @@ struct DownloadEcmwfCommand: AsyncCommand {
                     if variable == .total_column_integrated_water_vapour && shortName == "tcwv" {
                         return true
                     }
-                    return shortName == variable.gribName && levelhPa == (variable.level ?? 0)
+                    if let level = variable.level {
+                        return shortName == variable.gribName && levelhPa == level
+                    }
+                    return shortName == variable.gribName
                 }) else {
                     print(
                         message.get(attribute: "name")!,

--- a/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
+++ b/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
@@ -214,6 +214,9 @@ struct DownloadEcmwfCommand: AsyncCommand {
                 try grib2d.load(message: message)
                 grib2d.array.flipLatitude()
                 
+                //try message.debugGrid(grid: domain.grid, flipLatidude: false, shift180Longitude: false)
+                //fatalError()
+                
                 // Scaling before compression with scalefactor
                 if let fma = variable.multiplyAdd {
                     grib2d.array.data.multiplyAdd(multiply: fma.multiply, add: fma.add)

--- a/Sources/App/Ecmwf/EcmwfDomain.swift
+++ b/Sources/App/Ecmwf/EcmwfDomain.swift
@@ -12,6 +12,9 @@ enum EcmwfDomain: String, GenericDomain {
     case aifs025
     
     func getDownloadForecastSteps(run: Int) -> [Int] {
+        if self == .aifs025 {
+            return Array(stride(from: 0, through: 360, by: dtHours))
+        }
         switch run {
         case 0,12: return Array(stride(from: 0, through: 144, by: dtHours)) + Array(stride(from: 150, through: isEnsemble ? 360 : 240, by: dtHours))
         case 6,18: return Array(stride(from: 0, through: isEnsemble ? 144 : 90, by: dtHours))

--- a/Sources/App/Ecmwf/EcmwfDomain.swift
+++ b/Sources/App/Ecmwf/EcmwfDomain.swift
@@ -74,7 +74,7 @@ enum EcmwfDomain: String, GenericDomain {
         case .ifs025, .ifs025_ensemble:
             return RegularGrid(nx: 1440, ny: 721, latMin: -90, lonMin: -180, dx: 360/1440, dy: 180/721)
         case .aifs025:
-            return GaussianGrid(type: .t639)
+            return GaussianGrid(type: .n320)
         }
         
     }

--- a/Sources/App/Ecmwf/EcmwfDomain.swift
+++ b/Sources/App/Ecmwf/EcmwfDomain.swift
@@ -9,10 +9,12 @@ enum EcmwfDomain: String, GenericDomain {
     case ifs025
     case ifs025_ensemble
     
+    case aifs025
+    
     func getDownloadForecastSteps(run: Int) -> [Int] {
         switch run {
-        case 0,12: return Array(stride(from: 0, through: 144, by: 3)) + Array(stride(from: 150, through: isEnsemble ? 360 : 240, by: 6))
-        case 6,18: return Array(stride(from: 0, through: isEnsemble ? 144 : 90, by: 3))
+        case 0,12: return Array(stride(from: 0, through: 144, by: dtHours)) + Array(stride(from: 150, through: isEnsemble ? 360 : 240, by: dtHours))
+        case 6,18: return Array(stride(from: 0, through: isEnsemble ? 144 : 90, by: dtHours))
         default: fatalError("Invalid run")
         }
     }
@@ -27,6 +29,8 @@ enum EcmwfDomain: String, GenericDomain {
             return .ecmwf_ifs025
         case .ifs025_ensemble:
             return .ecmwf_ifs025_ensemble
+        case .aifs025:
+            return .ecmwf_aifs025
         }
     }
     
@@ -48,7 +52,19 @@ enum EcmwfDomain: String, GenericDomain {
     }
     
     var dtSeconds: Int {
-        return 3*3600
+        switch self {
+        case .ifs04:
+            return 3*3600
+        case .ifs04_ensemble:
+            return 3*3600
+        case .ifs025:
+            return 3*3600
+        case .ifs025_ensemble:
+            return 3*3600
+        case .aifs025:
+            return 6*3600
+        }
+        
     }
     
     var grid: Gridable {
@@ -57,6 +73,8 @@ enum EcmwfDomain: String, GenericDomain {
             return RegularGrid(nx: 900, ny: 451, latMin: -90, lonMin: -180, dx: 360/900, dy: 180/450)
         case .ifs025, .ifs025_ensemble:
             return RegularGrid(nx: 1440, ny: 721, latMin: -90, lonMin: -180, dx: 360/1440, dy: 180/721)
+        case .aifs025:
+            return GaussianGrid(type: .t639)
         }
         
     }
@@ -67,6 +85,8 @@ enum EcmwfDomain: String, GenericDomain {
             return 1
         case .ifs04_ensemble, .ifs025_ensemble:
             return 50+1
+        case .aifs025:
+            return 1
         }
     }
     

--- a/Sources/App/Ecmwf/EcmwfReader.swift
+++ b/Sources/App/Ecmwf/EcmwfReader.swift
@@ -75,11 +75,25 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             let u = try get(raw: .wind_u_component_700hPa, time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
+        case .wind_speed_600hPa:
+            fallthrough
+        case .windspeed_600hPa:
+            let v = try get(raw: .wind_v_component_600hPa, time: time)
+            let u = try get(raw: .wind_u_component_600hPa, time: time)
+            let speed = zip(u.data,v.data).map(Meteorology.windspeed)
+            return DataAndUnit(speed, .metrePerSecond)
         case .wind_speed_500hPa:
             fallthrough
         case .windspeed_500hPa:
             let v = try get(raw: .wind_v_component_500hPa, time: time)
             let u = try get(raw: .wind_u_component_500hPa, time: time)
+            let speed = zip(u.data,v.data).map(Meteorology.windspeed)
+            return DataAndUnit(speed, .metrePerSecond)
+        case .wind_speed_400hPa:
+            fallthrough
+        case .windspeed_400hPa:
+            let v = try get(raw: .wind_v_component_400hPa, time: time)
+            let u = try get(raw: .wind_u_component_400hPa, time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
         case .wind_speed_300hPa:
@@ -101,6 +115,13 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
         case .windspeed_200hPa:
             let v = try get(raw: .wind_v_component_200hPa, time: time)
             let u = try get(raw: .wind_u_component_200hPa, time: time)
+            let speed = zip(u.data,v.data).map(Meteorology.windspeed)
+            return DataAndUnit(speed, .metrePerSecond)
+        case .wind_speed_100hPa:
+            fallthrough
+        case .windspeed_100hPa:
+            let v = try get(raw: .wind_v_component_100hPa, time: time)
+            let u = try get(raw: .wind_u_component_100hPa, time: time)
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
         case .wind_speed_50hPa:
@@ -138,11 +159,25 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             let u = try get(raw: .wind_u_component_700hPa, time: time)
             let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
             return DataAndUnit(direction, .degreeDirection)
+        case .wind_direction_600hPa:
+            fallthrough
+        case .winddirection_600hPa:
+            let v = try get(raw: .wind_v_component_600hPa, time: time)
+            let u = try get(raw: .wind_u_component_600hPa, time: time)
+            let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
+            return DataAndUnit(direction, .degreeDirection)
         case .wind_direction_500hPa:
             fallthrough
         case .winddirection_500hPa:
             let v = try get(raw: .wind_v_component_500hPa, time: time)
             let u = try get(raw: .wind_u_component_500hPa, time: time)
+            let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
+            return DataAndUnit(direction, .degreeDirection)
+        case .wind_direction_400hPa:
+            fallthrough
+        case .winddirection_400hPa:
+            let v = try get(raw: .wind_v_component_400hPa, time: time)
+            let u = try get(raw: .wind_u_component_400hPa, time: time)
             let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
             return DataAndUnit(direction, .degreeDirection)
         case .wind_direction_300hPa:
@@ -164,6 +199,13 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
         case .winddirection_200hPa:
             let v = try get(raw: .wind_v_component_200hPa, time: time)
             let u = try get(raw: .wind_u_component_200hPa, time: time)
+            let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
+            return DataAndUnit(direction, .degreeDirection)
+        case .wind_direction_100hPa:
+            fallthrough
+        case .winddirection_100hPa:
+            let v = try get(raw: .wind_v_component_100hPa, time: time)
+            let u = try get(raw: .wind_u_component_100hPa, time: time)
             let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
             return DataAndUnit(direction, .degreeDirection)
         case .wind_direction_50hPa:
@@ -217,11 +259,21 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
         case .cloudcover_700hPa:
             let rh = try get(raw: .relative_humidity_700hPa, time: time)
             return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 700)}), .percentage)
+        case .cloud_cover_600hPa:
+            fallthrough
+        case .cloudcover_600hPa:
+            let rh = try get(raw: .relative_humidity_600hPa, time: time)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 600)}), .percentage)
         case .cloud_cover_500hPa:
             fallthrough
         case .cloudcover_500hPa:
             let rh = try get(raw: .relative_humidity_500hPa, time: time)
             return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 500)}), .percentage)
+        case .cloud_cover_400hPa:
+            fallthrough
+        case .cloudcover_400hPa:
+            let rh = try get(raw: .relative_humidity_400hPa, time: time)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 400)}), .percentage)
         case .cloud_cover_300hPa:
             fallthrough
         case .cloudcover_300hPa:
@@ -237,6 +289,11 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
         case .cloudcover_200hPa:
             let rh = try get(raw: .relative_humidity_200hPa, time: time)
             return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 200)}), .percentage)
+        case .cloud_cover_100hPa:
+            fallthrough
+        case .cloudcover_100hPa:
+            let rh = try get(raw: .relative_humidity_100hPa, time: time)
+            return DataAndUnit(rh.data.map({Meteorology.relativeHumidityToCloudCover(relativeHumidity: $0, pressureHPa: 100)}), .percentage)
         case .cloudcover_50hPa:
             fallthrough
         case .cloud_cover_50hPa:
@@ -260,14 +317,20 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             return try get(raw: .relative_humidity_850hPa, time: time)
         case .relativehumidity_700hPa:
             return try get(raw: .relative_humidity_700hPa, time: time)
+        case .relativehumidity_600hPa:
+            return try get(raw: .relative_humidity_300hPa, time: time)
         case .relativehumidity_500hPa:
             return try get(raw: .relative_humidity_500hPa, time: time)
+        case .relativehumidity_400hPa:
+            return try get(raw: .relative_humidity_300hPa, time: time)
         case .relativehumidity_300hPa:
             return try get(raw: .relative_humidity_300hPa, time: time)
         case .relativehumidity_250hPa:
             return try get(raw: .relative_humidity_250hPa, time: time)
         case .relativehumidity_200hPa:
             return try get(raw: .relative_humidity_200hPa, time: time)
+        case .relativehumidity_100hPa:
+            return try get(raw: .relative_humidity_300hPa, time: time)
         case .relativehumidity_50hPa:
             return try get(raw: .relative_humidity_50hPa, time: time)
         case .dew_point_1000hPa:
@@ -294,11 +357,23 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             let temperature = try get(raw: .temperature_700hPa, time: time)
             let rh = try get(raw: .relative_humidity_700hPa, time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+        case .dew_point_600hPa:
+            fallthrough
+        case .dewpoint_600hPa:
+            let temperature = try get(raw: .temperature_600hPa, time: time)
+            let rh = try get(raw: .relative_humidity_600hPa, time: time)
+            return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
         case .dew_point_500hPa:
             fallthrough
         case .dewpoint_500hPa:
             let temperature = try get(raw: .temperature_500hPa, time: time)
             let rh = try get(raw: .relative_humidity_500hPa, time: time)
+            return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+        case .dew_point_400hPa:
+            fallthrough
+        case .dewpoint_400hPa:
+            let temperature = try get(raw: .temperature_400hPa, time: time)
+            let rh = try get(raw: .relative_humidity_400hPa, time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
         case .dew_point_300hPa:
             fallthrough
@@ -317,6 +392,12 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
         case .dewpoint_200hPa:
             let temperature = try get(raw: .temperature_200hPa, time: time)
             let rh = try get(raw: .relative_humidity_200hPa, time: time)
+            return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
+        case .dew_point_100hPa:
+            fallthrough
+        case .dewpoint_100hPa:
+            let temperature = try get(raw: .temperature_100hPa, time: time)
+            let rh = try get(raw: .relative_humidity_100hPa, time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
         case .dew_point_50hPa:
             fallthrough
@@ -392,11 +473,21 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
         case .windspeed_700hPa:
             try prefetchData(raw: .wind_v_component_700hPa, time: time)
             try prefetchData(raw: .wind_u_component_700hPa, time: time)
+        case .wind_speed_600hPa:
+            fallthrough
+        case .windspeed_600hPa:
+            try prefetchData(raw: .wind_v_component_600hPa, time: time)
+            try prefetchData(raw: .wind_u_component_600hPa, time: time)
         case .wind_speed_500hPa:
             fallthrough
         case .windspeed_500hPa:
             try prefetchData(raw: .wind_v_component_500hPa, time: time)
             try prefetchData(raw: .wind_u_component_500hPa, time: time)
+        case .wind_speed_400hPa:
+            fallthrough
+        case .windspeed_400hPa:
+            try prefetchData(raw: .wind_v_component_400hPa, time: time)
+            try prefetchData(raw: .wind_u_component_400hPa, time: time)
         case .wind_speed_300hPa:
             fallthrough
         case .windspeed_300hPa:
@@ -412,6 +503,11 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
         case .windspeed_200hPa:
             try prefetchData(raw: .wind_v_component_200hPa, time: time)
             try prefetchData(raw: .wind_u_component_200hPa, time: time)
+        case .wind_speed_100hPa:
+            fallthrough
+        case .windspeed_100hPa:
+            try prefetchData(raw: .wind_v_component_100hPa, time: time)
+            try prefetchData(raw: .wind_u_component_100hPa, time: time)
         case .wind_speed_50hPa:
             fallthrough
         case .windspeed_50hPa:
@@ -442,11 +538,21 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
         case .winddirection_700hPa:
             try prefetchData(raw: .wind_v_component_700hPa, time: time)
             try prefetchData(raw: .wind_u_component_700hPa, time: time)
+        case .wind_direction_600hPa:
+            fallthrough
+        case .winddirection_600hPa:
+            try prefetchData(raw: .wind_v_component_600hPa, time: time)
+            try prefetchData(raw: .wind_u_component_600hPa, time: time)
         case .wind_direction_500hPa:
             fallthrough
         case .winddirection_500hPa:
             try prefetchData(raw: .wind_v_component_500hPa, time: time)
             try prefetchData(raw: .wind_u_component_500hPa, time: time)
+        case .wind_direction_400hPa:
+            fallthrough
+        case .winddirection_400hPa:
+            try prefetchData(raw: .wind_v_component_400hPa, time: time)
+            try prefetchData(raw: .wind_u_component_400hPa, time: time)
         case .wind_direction_300hPa:
             fallthrough
         case .winddirection_300hPa:
@@ -462,6 +568,11 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
         case .winddirection_200hPa:
             try prefetchData(raw: .wind_v_component_200hPa, time: time)
             try prefetchData(raw: .wind_u_component_200hPa, time: time)
+        case .wind_direction_100hPa:
+            fallthrough
+        case .winddirection_100hPa:
+            try prefetchData(raw: .wind_v_component_100hPa, time: time)
+            try prefetchData(raw: .wind_u_component_100hPa, time: time)
         case .wind_direction_50hPa:
             fallthrough
         case .winddirection_50hPa:
@@ -489,10 +600,18 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             fallthrough
         case .cloudcover_700hPa:
             try prefetchData(raw: .relative_humidity_700hPa, time: time)
+        case .cloud_cover_600hPa:
+            fallthrough
+        case .cloudcover_600hPa:
+            try prefetchData(raw: .relative_humidity_600hPa, time: time)
         case .cloud_cover_500hPa:
             fallthrough
         case .cloudcover_500hPa:
             try prefetchData(raw: .relative_humidity_500hPa, time: time)
+        case .cloud_cover_400hPa:
+            fallthrough
+        case .cloudcover_400hPa:
+            try prefetchData(raw: .relative_humidity_400hPa, time: time)
         case .cloud_cover_300hPa:
             fallthrough
         case .cloudcover_300hPa:
@@ -505,6 +624,10 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             fallthrough
         case .cloudcover_200hPa:
             try prefetchData(raw: .relative_humidity_200hPa, time: time)
+        case .cloud_cover_100hPa:
+            fallthrough
+        case .cloudcover_100hPa:
+            try prefetchData(raw: .relative_humidity_100hPa, time: time)
         case .cloud_cover_50hPa:
             fallthrough
         case .cloudcover_50hPa:
@@ -530,14 +653,20 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             try prefetchData(raw: .relative_humidity_850hPa, time: time)
         case .relativehumidity_700hPa:
             try prefetchData(raw: .relative_humidity_700hPa, time: time)
+        case .relativehumidity_600hPa:
+            try prefetchData(raw: .relative_humidity_600hPa, time: time)
         case .relativehumidity_500hPa:
             try prefetchData(raw: .relative_humidity_500hPa, time: time)
+        case .relativehumidity_400hPa:
+            try prefetchData(raw: .relative_humidity_400hPa, time: time)
         case .relativehumidity_300hPa:
             try prefetchData(raw: .relative_humidity_300hPa, time: time)
         case .relativehumidity_250hPa:
             try prefetchData(raw: .relative_humidity_250hPa, time: time)
         case .relativehumidity_200hPa:
             try prefetchData(raw: .relative_humidity_200hPa, time: time)
+        case .relativehumidity_100hPa:
+            try prefetchData(raw: .relative_humidity_100hPa, time: time)
         case .relativehumidity_50hPa:
             try prefetchData(raw: .relative_humidity_50hPa, time: time)
         case .dew_point_1000hPa:
@@ -560,11 +689,21 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
         case .dewpoint_700hPa:
             try prefetchData(raw: .temperature_700hPa, time: time)
             try prefetchData(raw: .relative_humidity_700hPa, time: time)
+        case .dew_point_600hPa:
+            fallthrough
+        case .dewpoint_600hPa:
+            try prefetchData(raw: .temperature_600hPa, time: time)
+            try prefetchData(raw: .relative_humidity_600hPa, time: time)
         case .dew_point_500hPa:
             fallthrough
         case .dewpoint_500hPa:
             try prefetchData(raw: .temperature_500hPa, time: time)
             try prefetchData(raw: .relative_humidity_500hPa, time: time)
+        case .dew_point_400hPa:
+            fallthrough
+        case .dewpoint_400hPa:
+            try prefetchData(raw: .temperature_400hPa, time: time)
+            try prefetchData(raw: .relative_humidity_400hPa, time: time)
         case .dew_point_300hPa:
             fallthrough
         case .dewpoint_300hPa:
@@ -580,6 +719,11 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
         case .dewpoint_200hPa:
             try prefetchData(raw: .temperature_200hPa, time: time)
             try prefetchData(raw: .relative_humidity_200hPa, time: time)
+        case .dew_point_100hPa:
+            fallthrough
+        case .dewpoint_100hPa:
+            try prefetchData(raw: .temperature_100hPa, time: time)
+            try prefetchData(raw: .relative_humidity_100hPa, time: time)
         case .dew_point_50hPa:
             fallthrough
         case .dewpoint_50hPa:

--- a/Sources/App/Ecmwf/EcmwfReader.swift
+++ b/Sources/App/Ecmwf/EcmwfReader.swift
@@ -330,15 +330,13 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             return try get(raw: .surface_temperature, time: time)
         case .surface_air_pressure:
             return try get(raw: .surface_pressure, time: time)
-        case .relative_humidity_2m:
-            fallthrough
         case .relativehumidity_2m:
-            return try get(raw: .relative_humidity_1000hPa, time: time)
+            return try get(raw: .relative_humidity_2m, time: time)
         case .dew_point_2m:
             fallthrough
         case .dewpoint_2m:
             let temperature = try get(raw: .temperature_2m, time: time)
-            let rh = try get(derived: .relativehumidity_2m, time: time)
+            let rh = try get(raw: .relative_humidity_2m, time: time)
             return DataAndUnit(zip(temperature.data, rh.data).map(Meteorology.dewpoint), temperature.unit)
         case .apparent_temperature:
             let windspeed = try get(derived: .windspeed_10m, time: time).data
@@ -593,14 +591,12 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
             try prefetchData(raw: .surface_temperature, time: time)
         case .surface_air_pressure:
             try prefetchData(raw: .surface_pressure, time: time)
-        case .relative_humidity_2m:
-            fallthrough
         case .relativehumidity_2m:
-            try prefetchData(raw: .relative_humidity_1000hPa, time: time)
+            try prefetchData(raw: .relative_humidity_2m, time: time)
         case .dew_point_2m:
             fallthrough
         case .dewpoint_2m:
-            try prefetchData(raw: .relative_humidity_1000hPa, time: time)
+            try prefetchData(raw: .relative_humidity_2m, time: time)
             try prefetchData(raw: .temperature_2m, time: time)
         case .apparent_temperature:
             try prefetchData(derived: .relativehumidity_2m, time: time)

--- a/Sources/App/Ecmwf/EcmwfVariable.swift
+++ b/Sources/App/Ecmwf/EcmwfVariable.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Represent a ECMWF variable as available in the grib2 files
+/// Only AIFS has additional levels 100, 400 and 600
 enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVariableMixable {
     case precipitation
     /// only in aifs
@@ -12,46 +13,61 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
     case geopotential_height_925hPa
     case geopotential_height_850hPa
     case geopotential_height_700hPa
+    case geopotential_height_600hPa
     case geopotential_height_500hPa
+    case geopotential_height_400hPa
     case geopotential_height_300hPa
     case geopotential_height_250hPa
     case geopotential_height_200hPa
+    case geopotential_height_100hPa
     case geopotential_height_50hPa
     case wind_v_component_1000hPa
     case wind_v_component_925hPa
     case wind_v_component_850hPa
     case wind_v_component_700hPa
+    case wind_v_component_600hPa
     case wind_v_component_500hPa
+    case wind_v_component_400hPa
     case wind_v_component_300hPa
     case wind_v_component_250hPa
     case wind_v_component_200hPa
+    case wind_v_component_100hPa
     case wind_v_component_50hPa
     case wind_u_component_1000hPa
     case wind_u_component_925hPa
     case wind_u_component_850hPa
     case wind_u_component_700hPa
+    case wind_u_component_600hPa
     case wind_u_component_500hPa
+    case wind_u_component_400hPa
     case wind_u_component_300hPa
     case wind_u_component_250hPa
     case wind_u_component_200hPa
+    case wind_u_component_100hPa
     case wind_u_component_50hPa
     case temperature_1000hPa
     case temperature_925hPa
     case temperature_850hPa
     case temperature_700hPa
+    case temperature_600hPa
     case temperature_500hPa
+    case temperature_400hPa
     case temperature_300hPa
     case temperature_250hPa
     case temperature_200hPa
+    case temperature_100hPa
     case temperature_50hPa
     case relative_humidity_1000hPa
     case relative_humidity_925hPa
     case relative_humidity_850hPa
     case relative_humidity_700hPa
+    case relative_humidity_600hPa
     case relative_humidity_500hPa
+    case relative_humidity_400hPa
     case relative_humidity_300hPa
     case relative_humidity_250hPa
     case relative_humidity_200hPa
+    case relative_humidity_100hPa
     case relative_humidity_50hPa
     case surface_pressure
     case pressure_msl
@@ -62,29 +78,38 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
     case specific_humidity_925hPa
     case specific_humidity_850hPa
     case specific_humidity_700hPa
+    case specific_humidity_600hPa
     case specific_humidity_500hPa
+    case specific_humidity_400hPa
     case specific_humidity_300hPa
     case specific_humidity_250hPa
     case specific_humidity_200hPa
+    case specific_humidity_100hPa
     case specific_humidity_50hPa
     case temperature_2m
     case relative_vorticity_1000hPa
     case relative_vorticity_925hPa
     case relative_vorticity_850hPa
     case relative_vorticity_700hPa
+    case relative_vorticity_600hPa
     case relative_vorticity_500hPa
+    case relative_vorticity_400hPa
     case relative_vorticity_300hPa
     case relative_vorticity_250hPa
     case relative_vorticity_200hPa
+    case relative_vorticity_100hPa
     case relative_vorticity_50hPa
     case divergence_of_wind_1000hPa
     case divergence_of_wind_925hPa
     case divergence_of_wind_850hPa
     case divergence_of_wind_700hPa
+    case divergence_of_wind_600hPa
     case divergence_of_wind_500hPa
+    case divergence_of_wind_400hPa
     case divergence_of_wind_300hPa
     case divergence_of_wind_250hPa
     case divergence_of_wind_200hPa
+    case divergence_of_wind_100hPa
     case divergence_of_wind_50hPa
     
     // Cloudcover is calculated while downloading
@@ -160,6 +185,12 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
             fallthrough
         case .relative_humidity_200hPa:
             fallthrough
+        case .relative_humidity_600hPa:
+            fallthrough
+        case .relative_humidity_400hPa:
+            fallthrough
+        case .relative_humidity_100hPa:
+            fallthrough
         case .relative_humidity_50hPa:
             return .downloadOnly
         default: return nil
@@ -194,46 +225,61 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .geopotential_height_925hPa: fallthrough
         case .geopotential_height_850hPa: fallthrough
         case .geopotential_height_700hPa: fallthrough
+        case .geopotential_height_600hPa: fallthrough
         case .geopotential_height_500hPa: fallthrough
+        case .geopotential_height_400hPa: fallthrough
         case .geopotential_height_300hPa: fallthrough
         case .geopotential_height_250hPa: fallthrough
         case .geopotential_height_200hPa: fallthrough
+        case .geopotential_height_100hPa: fallthrough
         case .geopotential_height_50hPa: return .metre
         case .wind_v_component_1000hPa: fallthrough
         case .wind_v_component_925hPa: fallthrough
         case .wind_v_component_850hPa: fallthrough
         case .wind_v_component_700hPa: fallthrough
+        case .wind_v_component_600hPa: fallthrough
         case .wind_v_component_500hPa: fallthrough
+        case .wind_v_component_400hPa: fallthrough
         case .wind_v_component_300hPa: fallthrough
         case .wind_v_component_250hPa: fallthrough
         case .wind_v_component_200hPa: fallthrough
+        case .wind_v_component_100hPa: fallthrough
         case .wind_v_component_50hPa: fallthrough
         case .wind_u_component_1000hPa: fallthrough
         case .wind_u_component_925hPa: fallthrough
         case .wind_u_component_850hPa: fallthrough
+        case .wind_u_component_600hPa: fallthrough
         case .wind_u_component_700hPa: fallthrough
         case .wind_u_component_500hPa: fallthrough
+        case .wind_u_component_400hPa: fallthrough
         case .wind_u_component_300hPa: fallthrough
         case .wind_u_component_250hPa: fallthrough
         case .wind_u_component_200hPa: fallthrough
+        case .wind_u_component_100hPa: fallthrough
         case .wind_u_component_50hPa: return .metrePerSecond
         case .temperature_1000hPa: fallthrough
         case .temperature_925hPa: fallthrough
         case .temperature_850hPa: fallthrough
         case .temperature_700hPa: fallthrough
+        case .temperature_600hPa: fallthrough
         case .temperature_500hPa: fallthrough
+        case .temperature_400hPa: fallthrough
         case .temperature_300hPa: fallthrough
         case .temperature_250hPa: fallthrough
         case .temperature_200hPa: fallthrough
+        case .temperature_100hPa: fallthrough
         case .temperature_50hPa: return .celsius
         case .relative_humidity_1000hPa: fallthrough
         case .relative_humidity_925hPa: fallthrough
         case .relative_humidity_850hPa: fallthrough
         case .relative_humidity_700hPa: fallthrough
+        case .relative_humidity_600hPa: fallthrough
         case .relative_humidity_500hPa: fallthrough
+        case .relative_humidity_400hPa: fallthrough
         case .relative_humidity_300hPa: fallthrough
         case .relative_humidity_250hPa: fallthrough
         case .relative_humidity_200hPa: fallthrough
+        case .relative_humidity_100hPa: fallthrough
         case .relative_humidity_50hPa: return .percentage
         case .surface_pressure: return .hectopascal
         case .pressure_msl: return .hectopascal
@@ -244,29 +290,38 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .specific_humidity_925hPa: fallthrough
         case .specific_humidity_850hPa: fallthrough
         case .specific_humidity_700hPa: fallthrough
+        case .specific_humidity_600hPa: fallthrough
         case .specific_humidity_500hPa: fallthrough
+        case .specific_humidity_400hPa: fallthrough
         case .specific_humidity_300hPa: fallthrough
         case .specific_humidity_250hPa: fallthrough
         case .specific_humidity_200hPa: fallthrough
+        case .specific_humidity_100hPa: fallthrough
         case .specific_humidity_50hPa: return .gramPerKilogram
         case .temperature_2m: return .celsius
         case .relative_vorticity_1000hPa: fallthrough
         case .relative_vorticity_925hPa: fallthrough
         case .relative_vorticity_850hPa: fallthrough
         case .relative_vorticity_700hPa: fallthrough
+        case .relative_vorticity_600hPa: fallthrough
         case .relative_vorticity_500hPa: fallthrough
+        case .relative_vorticity_400hPa: fallthrough
         case .relative_vorticity_300hPa: fallthrough
         case .relative_vorticity_250hPa: fallthrough
         case .relative_vorticity_200hPa: fallthrough
+        case .relative_vorticity_100hPa: fallthrough
         case .relative_vorticity_50hPa: return .perSecond
         case .divergence_of_wind_1000hPa: fallthrough
         case .divergence_of_wind_925hPa: fallthrough
         case .divergence_of_wind_850hPa: fallthrough
         case .divergence_of_wind_700hPa: fallthrough
+        case .divergence_of_wind_600hPa: fallthrough
         case .divergence_of_wind_500hPa: fallthrough
+        case .divergence_of_wind_400hPa: fallthrough
         case .divergence_of_wind_300hPa: fallthrough
         case .divergence_of_wind_250hPa: fallthrough
         case .divergence_of_wind_200hPa: fallthrough
+        case .divergence_of_wind_100hPa: fallthrough
         case .divergence_of_wind_50hPa: return .perSecond
         case .cloud_cover:
             return .percentage
@@ -294,46 +349,61 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .geopotential_height_925hPa: return 925
         case .geopotential_height_850hPa: return 850
         case .geopotential_height_700hPa: return 700
+        case .geopotential_height_600hPa: return 600
         case .geopotential_height_500hPa: return 500
+        case .geopotential_height_400hPa: return 400
         case .geopotential_height_300hPa: return 300
         case .geopotential_height_250hPa: return 250
         case .geopotential_height_200hPa: return 200
+        case .geopotential_height_100hPa: return 100
         case .geopotential_height_50hPa: return 50
         case .wind_v_component_1000hPa: return 1000
         case .wind_v_component_925hPa: return 925
         case .wind_v_component_850hPa: return 850
         case .wind_v_component_700hPa: return 700
+        case .wind_v_component_600hPa: return 600
         case .wind_v_component_500hPa: return 500
+        case .wind_v_component_400hPa: return 400
         case .wind_v_component_300hPa: return 300
         case .wind_v_component_250hPa: return 250
         case .wind_v_component_200hPa: return 200
+        case .wind_v_component_100hPa: return 100
         case .wind_v_component_50hPa: return 50
         case .wind_u_component_1000hPa: return 1000
         case .wind_u_component_925hPa: return 925
         case .wind_u_component_850hPa: return 850
         case .wind_u_component_700hPa: return 700
+        case .wind_u_component_600hPa: return 600
         case .wind_u_component_500hPa: return 500
+        case .wind_u_component_400hPa: return 400
         case .wind_u_component_300hPa: return 300
         case .wind_u_component_250hPa: return 250
         case .wind_u_component_200hPa: return 200
+        case .wind_u_component_100hPa: return 100
         case .wind_u_component_50hPa: return 50
         case .temperature_1000hPa: return 1000
         case .temperature_925hPa: return 925
         case .temperature_850hPa: return 850
         case .temperature_700hPa: return 700
+        case .temperature_600hPa: return 600
         case .temperature_500hPa: return 500
+        case .temperature_400hPa: return 400
         case .temperature_300hPa: return 300
         case .temperature_250hPa: return 250
         case .temperature_200hPa: return 200
+        case .temperature_100hPa: return 100
         case .temperature_50hPa: return 50
         case .relative_humidity_1000hPa: return 1000
         case .relative_humidity_925hPa: return 925
         case .relative_humidity_850hPa: return 850
         case .relative_humidity_700hPa: return 700
+        case .relative_humidity_600hPa: return 600
         case .relative_humidity_500hPa: return 500
+        case .relative_humidity_400hPa: return 400
         case .relative_humidity_300hPa: return 300
         case .relative_humidity_250hPa: return 250
         case .relative_humidity_200hPa: return 200
+        case .relative_humidity_100hPa: return 100
         case .relative_humidity_50hPa: return 50
         case .surface_pressure: return nil
         case .pressure_msl: return nil
@@ -344,29 +414,38 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .specific_humidity_925hPa: return 925
         case .specific_humidity_850hPa: return 850
         case .specific_humidity_700hPa: return 700
+        case .specific_humidity_600hPa: return 600
         case .specific_humidity_500hPa: return 500
+        case .specific_humidity_400hPa: return 400
         case .specific_humidity_300hPa: return 300
         case .specific_humidity_250hPa: return 250
         case .specific_humidity_200hPa: return 200
+        case .specific_humidity_100hPa: return 100
         case .specific_humidity_50hPa: return 50
         case .temperature_2m: return 2
         case .relative_vorticity_1000hPa: return 1000
         case .relative_vorticity_925hPa: return 925
         case .relative_vorticity_850hPa: return 850
         case .relative_vorticity_700hPa: return 700
+        case .relative_vorticity_600hPa: return 600
         case .relative_vorticity_500hPa: return 500
+        case .relative_vorticity_400hPa: return 400
         case .relative_vorticity_300hPa: return 300
         case .relative_vorticity_250hPa: return 250
         case .relative_vorticity_200hPa: return 200
+        case .relative_vorticity_100hPa: return 100
         case .relative_vorticity_50hPa: return 50
         case .divergence_of_wind_1000hPa: return 1000
         case .divergence_of_wind_925hPa: return 925
         case .divergence_of_wind_850hPa: return 850
         case .divergence_of_wind_700hPa: return 700
+        case .divergence_of_wind_600hPa: return 600
         case .divergence_of_wind_500hPa: return 500
+        case .divergence_of_wind_400hPa: return 400
         case .divergence_of_wind_300hPa: return 300
         case .divergence_of_wind_250hPa: return 250
         case .divergence_of_wind_200hPa: return 200
+        case .divergence_of_wind_100hPa: return 100
         case .divergence_of_wind_50hPa: return 50
         case .cloud_cover:
             return nil
@@ -393,46 +472,61 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .geopotential_height_925hPa: return "gh"
         case .geopotential_height_850hPa: return "gh"
         case .geopotential_height_700hPa: return "gh"
+        case .geopotential_height_600hPa: return "gh"
         case .geopotential_height_500hPa: return "gh"
+        case .geopotential_height_400hPa: return "gh"
         case .geopotential_height_300hPa: return "gh"
         case .geopotential_height_250hPa: return "gh"
         case .geopotential_height_200hPa: return "gh"
+        case .geopotential_height_100hPa: return "gh"
         case .geopotential_height_50hPa: return "gh"
         case .wind_v_component_1000hPa: return "v"
         case .wind_v_component_925hPa: return "v"
         case .wind_v_component_850hPa: return "v"
         case .wind_v_component_700hPa: return "v"
+        case .wind_v_component_600hPa: return "v"
         case .wind_v_component_500hPa: return "v"
+        case .wind_v_component_400hPa: return "v"
         case .wind_v_component_300hPa: return "v"
         case .wind_v_component_250hPa: return "v"
         case .wind_v_component_200hPa: return "v"
+        case .wind_v_component_100hPa: return "v"
         case .wind_v_component_50hPa: return "v"
         case .wind_u_component_1000hPa: return "u"
         case .wind_u_component_925hPa: return "u"
         case .wind_u_component_850hPa: return "u"
         case .wind_u_component_700hPa: return "u"
+        case .wind_u_component_600hPa: return "u"
         case .wind_u_component_500hPa: return "u"
+        case .wind_u_component_400hPa: return "u"
         case .wind_u_component_300hPa: return "u"
         case .wind_u_component_250hPa: return "u"
         case .wind_u_component_200hPa: return "u"
+        case .wind_u_component_100hPa: return "u"
         case .wind_u_component_50hPa: return "u"
         case .temperature_1000hPa: return "t"
         case .temperature_925hPa: return "t"
         case .temperature_850hPa: return "t"
         case .temperature_700hPa: return "t"
+        case .temperature_600hPa: return "t"
         case .temperature_500hPa: return "t"
+        case .temperature_400hPa: return "t"
         case .temperature_300hPa: return "t"
         case .temperature_250hPa: return "t"
         case .temperature_200hPa: return "t"
+        case .temperature_100hPa: return "t"
         case .temperature_50hPa: return "t"
         case .relative_humidity_1000hPa: return "r"
         case .relative_humidity_925hPa: return "r"
         case .relative_humidity_850hPa: return "r"
         case .relative_humidity_700hPa: return "r"
+        case .relative_humidity_600hPa: return "r"
         case .relative_humidity_500hPa: return "r"
+        case .relative_humidity_400hPa: return "r"
         case .relative_humidity_300hPa: return "r"
         case .relative_humidity_250hPa: return "r"
         case .relative_humidity_200hPa: return "r"
+        case .relative_humidity_100hPa: return "r"
         case .relative_humidity_50hPa: return "r"
         case .surface_pressure: return "sp"
         case .pressure_msl: return "msl"
@@ -443,29 +537,38 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .specific_humidity_925hPa: return "q"
         case .specific_humidity_850hPa: return "q"
         case .specific_humidity_700hPa: return "q"
+        case .specific_humidity_600hPa: return "q"
         case .specific_humidity_500hPa: return "q"
+        case .specific_humidity_400hPa: return "q"
         case .specific_humidity_300hPa: return "q"
         case .specific_humidity_250hPa: return "q"
         case .specific_humidity_200hPa: return "q"
+        case .specific_humidity_100hPa: return "q"
         case .specific_humidity_50hPa: return "q"
         case .temperature_2m: return "2t"
         case .relative_vorticity_1000hPa: return "vo"
         case .relative_vorticity_925hPa: return "vo"
         case .relative_vorticity_850hPa: return "vo"
         case .relative_vorticity_700hPa: return "vo"
+        case .relative_vorticity_600hPa: return "vo"
         case .relative_vorticity_500hPa: return "vo"
+        case .relative_vorticity_400hPa: return "vo"
         case .relative_vorticity_300hPa: return "vo"
         case .relative_vorticity_250hPa: return "vo"
         case .relative_vorticity_200hPa: return "vo"
+        case .relative_vorticity_100hPa: return "vo"
         case .relative_vorticity_50hPa: return "vo"
         case .divergence_of_wind_1000hPa: return "d"
         case .divergence_of_wind_925hPa: return "d"
         case .divergence_of_wind_850hPa: return "d"
         case .divergence_of_wind_700hPa: return "d"
+        case .divergence_of_wind_600hPa: return "d"
         case .divergence_of_wind_500hPa: return "d"
+        case .divergence_of_wind_400hPa: return "d"
         case .divergence_of_wind_300hPa: return "d"
         case .divergence_of_wind_250hPa: return "d"
         case .divergence_of_wind_200hPa: return "d"
+        case .divergence_of_wind_100hPa: return "d"
         case .divergence_of_wind_50hPa: return "d"
         case .cloud_cover:
             return nil
@@ -492,46 +595,61 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .geopotential_height_925hPa: fallthrough
         case .geopotential_height_850hPa: fallthrough
         case .geopotential_height_700hPa: fallthrough
+        case .geopotential_height_600hPa: fallthrough
         case .geopotential_height_500hPa: fallthrough
+        case .geopotential_height_400hPa: fallthrough
         case .geopotential_height_300hPa: fallthrough
         case .geopotential_height_250hPa: fallthrough
         case .geopotential_height_200hPa: fallthrough
+        case .geopotential_height_100hPa: fallthrough
         case .geopotential_height_50hPa: return 1
         case .wind_v_component_1000hPa: fallthrough
         case .wind_v_component_925hPa: fallthrough
         case .wind_v_component_850hPa: fallthrough
         case .wind_v_component_700hPa: fallthrough
+        case .wind_v_component_600hPa: fallthrough
         case .wind_v_component_500hPa: fallthrough
+        case .wind_v_component_400hPa: fallthrough
         case .wind_v_component_300hPa: fallthrough
         case .wind_v_component_250hPa: fallthrough
         case .wind_v_component_200hPa: fallthrough
+        case .wind_v_component_100hPa: fallthrough
         case .wind_v_component_50hPa: return 10
         case .wind_u_component_1000hPa: fallthrough
         case .wind_u_component_925hPa: fallthrough
         case .wind_u_component_850hPa: fallthrough
         case .wind_u_component_700hPa: fallthrough
+        case .wind_u_component_600hPa: fallthrough
         case .wind_u_component_500hPa: fallthrough
+        case .wind_u_component_400hPa: fallthrough
         case .wind_u_component_300hPa: fallthrough
         case .wind_u_component_250hPa: fallthrough
         case .wind_u_component_200hPa: fallthrough
+        case .wind_u_component_100hPa: fallthrough
         case .wind_u_component_50hPa: return 10
         case .temperature_1000hPa: fallthrough
         case .temperature_925hPa: fallthrough
         case .temperature_850hPa: fallthrough
         case .temperature_700hPa: fallthrough
+        case .temperature_600hPa: fallthrough
         case .temperature_500hPa: fallthrough
+        case .temperature_400hPa: fallthrough
         case .temperature_300hPa: fallthrough
         case .temperature_250hPa: fallthrough
         case .temperature_200hPa: fallthrough
+        case .temperature_100hPa: fallthrough
         case .temperature_50hPa: return 20
         case .relative_humidity_1000hPa: fallthrough
         case .relative_humidity_925hPa: fallthrough
         case .relative_humidity_850hPa: fallthrough
         case .relative_humidity_700hPa: fallthrough
+        case .relative_humidity_600hPa: fallthrough
         case .relative_humidity_500hPa: fallthrough
+        case .relative_humidity_400hPa: fallthrough
         case .relative_humidity_300hPa: fallthrough
         case .relative_humidity_250hPa: fallthrough
         case .relative_humidity_200hPa: fallthrough
+        case .relative_humidity_100hPa: fallthrough
         case .relative_humidity_50hPa: return 1
         case .surface_pressure: return 10
         case .pressure_msl: return 10
@@ -542,29 +660,38 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .specific_humidity_925hPa: fallthrough
         case .specific_humidity_850hPa: fallthrough
         case .specific_humidity_700hPa: fallthrough
+        case .specific_humidity_600hPa: fallthrough
         case .specific_humidity_500hPa: fallthrough
+        case .specific_humidity_400hPa: fallthrough
         case .specific_humidity_300hPa: fallthrough
         case .specific_humidity_250hPa: fallthrough
         case .specific_humidity_200hPa: fallthrough
+        case .specific_humidity_100hPa: fallthrough
         case .specific_humidity_50hPa: return 100
         case .temperature_2m: return 20
         case .relative_vorticity_1000hPa: fallthrough
         case .relative_vorticity_925hPa: fallthrough
         case .relative_vorticity_850hPa: fallthrough
         case .relative_vorticity_700hPa: fallthrough
+        case .relative_vorticity_600hPa: fallthrough
         case .relative_vorticity_500hPa: fallthrough
+        case .relative_vorticity_400hPa: fallthrough
         case .relative_vorticity_300hPa: fallthrough
         case .relative_vorticity_250hPa: fallthrough
         case .relative_vorticity_200hPa: fallthrough
+        case .relative_vorticity_100hPa: fallthrough
         case .relative_vorticity_50hPa: return 100
         case .divergence_of_wind_1000hPa: fallthrough
         case .divergence_of_wind_925hPa: fallthrough
         case .divergence_of_wind_850hPa: fallthrough
         case .divergence_of_wind_700hPa: fallthrough
+        case .divergence_of_wind_600hPa: fallthrough
         case .divergence_of_wind_500hPa: fallthrough
+        case .divergence_of_wind_400hPa: fallthrough
         case .divergence_of_wind_300hPa: fallthrough
         case .divergence_of_wind_250hPa: fallthrough
         case .divergence_of_wind_200hPa: fallthrough
+        case .divergence_of_wind_100hPa: fallthrough
         case .divergence_of_wind_50hPa: return 100
         case .cloud_cover:
             return 1
@@ -589,10 +716,13 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .temperature_925hPa: fallthrough
         case .temperature_850hPa: fallthrough
         case .temperature_700hPa: fallthrough
+        case .temperature_600hPa: fallthrough
         case .temperature_500hPa: fallthrough
+        case .temperature_400hPa: fallthrough
         case .temperature_300hPa: fallthrough
         case .temperature_250hPa: fallthrough
         case .temperature_200hPa: fallthrough
+        case .temperature_100hPa: fallthrough
         case .temperature_50hPa: fallthrough
         case .temperature_2m, .dew_point_2m:
             return (1, -273.15)
@@ -608,10 +738,13 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .specific_humidity_925hPa: fallthrough
         case .specific_humidity_850hPa: fallthrough
         case .specific_humidity_700hPa: fallthrough
+        case .specific_humidity_600hPa: fallthrough
         case .specific_humidity_500hPa: fallthrough
+        case .specific_humidity_400hPa: fallthrough
         case .specific_humidity_300hPa: fallthrough
         case .specific_humidity_250hPa: fallthrough
         case .specific_humidity_200hPa: fallthrough
+        case .specific_humidity_100hPa: fallthrough
         case .specific_humidity_50hPa:
             return (1000, 0)
         default:
@@ -631,10 +764,13 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .relative_humidity_925hPa: fallthrough
         case .relative_humidity_850hPa: fallthrough
         case .relative_humidity_700hPa: fallthrough
+        case .relative_humidity_600hPa: fallthrough
         case .relative_humidity_500hPa: fallthrough
+        case .relative_humidity_400hPa: fallthrough
         case .relative_humidity_300hPa: fallthrough
         case .relative_humidity_250hPa: fallthrough
         case .relative_humidity_200hPa: fallthrough
+        case .relative_humidity_100hPa: fallthrough
         case .relative_humidity_50hPa: return .hermite(bounds: 0...100)
         default: return .hermite(bounds: nil)
         }
@@ -653,85 +789,112 @@ enum EcmwfVariableDerived: String, GenericVariableMixable {
     case windspeed_925hPa
     case windspeed_850hPa
     case windspeed_700hPa
+    case windspeed_600hPa
     case windspeed_500hPa
+    case windspeed_400hPa
     case windspeed_300hPa
     case windspeed_250hPa
     case windspeed_200hPa
+    case windspeed_100hPa
     case windspeed_50hPa
     case wind_speed_10m
     case wind_speed_1000hPa
     case wind_speed_925hPa
     case wind_speed_850hPa
     case wind_speed_700hPa
+    case wind_speed_600hPa
     case wind_speed_500hPa
+    case wind_speed_400hPa
     case wind_speed_300hPa
     case wind_speed_250hPa
     case wind_speed_200hPa
+    case wind_speed_100hPa
     case wind_speed_50hPa
     case winddirection_10m
     case winddirection_1000hPa
     case winddirection_925hPa
     case winddirection_850hPa
     case winddirection_700hPa
+    case winddirection_600hPa
     case winddirection_500hPa
+    case winddirection_400hPa
     case winddirection_300hPa
     case winddirection_250hPa
     case winddirection_200hPa
+    case winddirection_100hPa
     case winddirection_50hPa
     case wind_direction_10m
     case wind_direction_1000hPa
     case wind_direction_925hPa
     case wind_direction_850hPa
     case wind_direction_700hPa
+    case wind_direction_600hPa
     case wind_direction_500hPa
+    case wind_direction_400hPa
     case wind_direction_300hPa
     case wind_direction_250hPa
     case wind_direction_200hPa
+    case wind_direction_100hPa
     case wind_direction_50hPa
     case cloudcover_1000hPa
     case cloudcover_925hPa
     case cloudcover_850hPa
     case cloudcover_700hPa
+    case cloudcover_600hPa
     case cloudcover_500hPa
+    case cloudcover_400hPa
     case cloudcover_300hPa
     case cloudcover_250hPa
     case cloudcover_200hPa
+    case cloudcover_100hPa
     case cloudcover_50hPa
     case cloud_cover_1000hPa
     case cloud_cover_925hPa
     case cloud_cover_850hPa
     case cloud_cover_700hPa
+    case cloud_cover_600hPa
     case cloud_cover_500hPa
+    case cloud_cover_400hPa
     case cloud_cover_300hPa
     case cloud_cover_250hPa
     case cloud_cover_200hPa
+    case cloud_cover_100hPa
     case cloud_cover_50hPa
     case relativehumidity_1000hPa
     case relativehumidity_925hPa
     case relativehumidity_850hPa
     case relativehumidity_700hPa
+    case relativehumidity_600hPa
     case relativehumidity_500hPa
+    case relativehumidity_400hPa
     case relativehumidity_300hPa
     case relativehumidity_250hPa
     case relativehumidity_200hPa
+    case relativehumidity_100hPa
     case relativehumidity_50hPa
     case dewpoint_1000hPa
     case dewpoint_925hPa
     case dewpoint_850hPa
     case dewpoint_700hPa
+    case dewpoint_600hPa
     case dewpoint_500hPa
+    case dewpoint_400hPa
     case dewpoint_300hPa
     case dewpoint_250hPa
     case dewpoint_200hPa
+    case dewpoint_100hPa
     case dewpoint_50hPa
     case dew_point_1000hPa
     case dew_point_925hPa
     case dew_point_850hPa
     case dew_point_700hPa
+    case dew_point_600hPa
     case dew_point_500hPa
+    case dew_point_400hPa
     case dew_point_300hPa
     case dew_point_250hPa
     case dew_point_200hPa
+    case dew_point_100hPa
     case dew_point_50hPa
     case soil_temperature_0_7cm
     case soil_temperature_0_10cm

--- a/Sources/App/Ecmwf/EcmwfVariable.swift
+++ b/Sources/App/Ecmwf/EcmwfVariable.swift
@@ -3,6 +3,8 @@ import Foundation
 /// Represent a ECMWF variable as available in the grib2 files
 enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVariableMixable {
     case precipitation
+    /// only in aifs
+    case dew_point_2m
     case runoff
     case soil_temperature_0_to_7cm
     case surface_temperature
@@ -90,6 +92,9 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
     case cloud_cover_low
     case cloud_cover_mid
     case cloud_cover_high
+    
+    /// Generated while downloading
+    case relative_humidity_2m
     
     
     enum DownloadOrProcess {
@@ -271,6 +276,10 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
             return .percentage
         case .cloud_cover_high:
             return .percentage
+        case .dew_point_2m:
+            return .celsius
+        case .relative_humidity_2m:
+            return .percentage
         }
     }
     
@@ -367,6 +376,10 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
             return nil
         case .cloud_cover_high:
             return nil
+        case .dew_point_2m:
+            return 2
+        case .relative_humidity_2m:
+            return 2
         }
     }
     
@@ -462,6 +475,10 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
             return nil
         case .cloud_cover_high:
             return nil
+        case .dew_point_2m:
+            return "2d"
+        case .relative_humidity_2m:
+            return "2r"
         }
     }
     
@@ -557,6 +574,10 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
             return 1
         case .cloud_cover_high:
             return 1
+        case .dew_point_2m:
+            return 20
+        case .relative_humidity_2m:
+            return 1
         }
     }
     
@@ -573,7 +594,7 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
         case .temperature_250hPa: fallthrough
         case .temperature_200hPa: fallthrough
         case .temperature_50hPa: fallthrough
-        case .temperature_2m:
+        case .temperature_2m, .dew_point_2m:
             return (1, -273.15)
         case .pressure_msl:
             return (1/100, 0)
@@ -622,7 +643,6 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
 
 enum EcmwfVariableDerived: String, GenericVariableMixable {
     case relativehumidity_2m
-    case relative_humidity_2m
     case dewpoint_2m
     case dew_point_2m
     case apparent_temperature

--- a/Sources/App/Ecmwf/EcmwfVariable.swift
+++ b/Sources/App/Ecmwf/EcmwfVariable.swift
@@ -131,7 +131,7 @@ enum EcmwfVariable: String, CaseIterable, Hashable, GenericVariable, GenericVari
     
     var storePreviousForecast: Bool {
         switch self {
-        case .temperature_2m, .relative_humidity_1000hPa: return true
+        case .temperature_2m, .relative_humidity_1000hPa, .dew_point_2m: return true
         case .precipitation: return true
         case .pressure_msl: return true
         case .cloud_cover: return true

--- a/Sources/App/Helper/DomainRegistry.swift
+++ b/Sources/App/Helper/DomainRegistry.swift
@@ -60,6 +60,7 @@ enum DomainRegistry: String, CaseIterable {
     case ecmwf_ifs04_ensemble
     case ecmwf_ifs025
     case ecmwf_ifs025_ensemble
+    case ecmwf_aifs025
     
     case jma_msm
     case jma_gsm
@@ -181,6 +182,8 @@ enum DomainRegistry: String, CaseIterable {
             return EcmwfDomain.ifs025
         case .ecmwf_ifs025_ensemble:
             return EcmwfDomain.ifs025_ensemble
+        case .ecmwf_aifs025:
+            return EcmwfDomain.aifs025
         case .jma_msm:
             return JmaDomain.msm
         case .ncep_cfsv2:

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
@@ -578,6 +578,9 @@ extension MultiDomains: ModelFlatbufferSerialisable {
             return .arpaeCosmo5m
         case .ecmwf_ifs025:
             return .ecmwfIfs025
+        case .ecmwf_aifs025:
+            // TODO register AIFS 025
+            return .ecmwfIfs025
         }
     }
 }


### PR DESCRIPTION
Data available here: https://data.ecmwf.int/forecasts/20240228/06z/aifs/0p25/oper/. First ever open-data of AIFS.

Specs:
- 6 hourly data, 15 days forecast
- 0.25° Gaussian N320 grid
- Same variables as IFS025 (surface and pressure)
- Additional pressure level 100, 400 and 600 hPa
- Dew point on 2 metre now directly available
