### PR TITLE
fix: switch /v1/ecmwf api endpoint to ifs025 version as default model

### DIFF
--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -54,7 +54,7 @@ public struct ForecastapiController: RouteCollection {
             forecastDay: 10,
             has15minutely: false,
             hasCurrentWeather: false,
-            defaultModel: .ecmwf_ifs04).query
+            defaultModel: .ecmwf_ifs025).query
         )
         categoriesRoute.getAndPost("cma", use: WeatherApiController(
             has15minutely: false,


### PR DESCRIPTION
The old 0.4° will be shut down in the near future and does not provide all variables like solar radiation