### PR TITLE
feat: Support for bounding box API calls

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/flatbuffers.git",
       "state" : {
-        "revision" : "0100f6a5779831fa7a651e4b67ef389a8752bd9b",
-        "version" : "23.5.26"
+        "revision" : "595bf0007ab1929570c7671f091313c8fc20644e",
+        "version" : "24.3.25"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-meteo/sdk.git",
       "state" : {
-        "revision" : "3b051ab69a150598f9710ce66105d6cf37b3d0d6",
-        "version" : "1.10.0"
+        "revision" : "0aea002e1fc850f683dcf9a91a839f6a6f8a3864",
+        "version" : "1.11.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.89.0"),
-        .package(url: "https://github.com/google/flatbuffers.git", from: "23.3.3"),
-        .package(url: "https://github.com/open-meteo/sdk.git", from: "1.10.0"),
+        .package(url: "https://github.com/google/flatbuffers.git", from: "24.3.25"),
+        .package(url: "https://github.com/open-meteo/sdk.git", from: "1.11.4"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftNetCDF.git", from: "1.0.0"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftTimeZoneLookup.git", from: "1.0.7"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftEccodes.git", from: "0.1.6"),

--- a/Sources/App/Arpae/ArpaeReader.swift
+++ b/Sources/App/Arpae/ArpaeReader.swift
@@ -48,6 +48,12 @@ struct ArpaeReader: GenericReaderDerived, GenericReaderProtocol {
         self.options = options
     }
     
+    public init(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+        let reader = try GenericReader<Domain, Variable>(domain: domain, position: gridpoint)
+        self.reader = GenericReaderCached(reader: reader)
+        self.options = options
+    }
+    
     func get(raw: ArpaeSurfaceVariable, time: TimerangeDtAndSettings) throws -> DataAndUnit {
         return try reader.get(variable: raw, time: time)
     }

--- a/Sources/App/Bom/BomReader.swift
+++ b/Sources/App/Bom/BomReader.swift
@@ -76,6 +76,12 @@ struct BomReader: GenericReaderDerived, GenericReaderProtocol {
         self.options = options
     }
     
+    public init(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+        let reader = try GenericReader<Domain, Variable>(domain: domain, position: gridpoint)
+        self.reader = GenericReaderCached(reader: reader)
+        self.options = options
+    }
+    
     func get(raw: BomVariable, time: TimerangeDtAndSettings) throws -> DataAndUnit {
         return try reader.get(variable: raw, time: time)
     }

--- a/Sources/App/CMA/CmaReader.swift
+++ b/Sources/App/CMA/CmaReader.swift
@@ -134,6 +134,12 @@ struct CmaReader: GenericReaderDerived, GenericReaderProtocol {
         self.options = options
     }
     
+    public init(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+        let reader = try GenericReader<Domain, Variable>(domain: domain, position: gridpoint)
+        self.reader = GenericReaderCached(reader: reader)
+        self.options = options
+    }
+    
     func get(raw: CmaVariable, time: TimerangeDtAndSettings) throws -> DataAndUnit {
         return try reader.get(variable: raw, time: time)
     }

--- a/Sources/App/Cams/CamsController.swift
+++ b/Sources/App/Cams/CamsController.swift
@@ -6,6 +6,7 @@ import Vapor
  */
 struct CamsController {
     func query(_ req: Request) async throws -> Response {
+        /*
         try await req.ensureSubdomain("air-quality-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         try req.ensureApiKey("air-quality-api", apikey: params.apikey)
@@ -80,6 +81,7 @@ struct CamsController {
         let result = ForecastapiResult<CamsQuery.Domain>(timeformat: params.timeformatOrDefault, results: locations)
         await req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))
         return try await result.response(format: params.format ?? .json)
+         */ fatalError()
     }
 }
 

--- a/Sources/App/Cams/CamsController.swift
+++ b/Sources/App/Cams/CamsController.swift
@@ -1,12 +1,46 @@
 import Foundation
 import Vapor
 
+extension CamsQuery.Domain: GenericDomainProvider {
+    var genericDomain: (any GenericDomain)? {
+        switch self {
+        case .auto:
+            return nil
+        case .cams_global:
+            return CamsDomain.cams_global
+        case .cams_europe:
+            return CamsDomain.cams_europe
+        }
+    }
+}
+
+extension CamsMixer: GenericReaderProvider {
+    init?(domain: CamsQuery.Domain, lat: Float, lon: Float, elevation: Float, mode: GridSelectionMode, options: GenericReaderOptions) throws {
+        guard let reader = try Self.init(domains: domain.camsDomains, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options) else {
+            return nil
+        }
+        self = reader
+    }
+    
+    init?(domain: CamsQuery.Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+        switch domain {
+        case .auto:
+            return nil
+        case .cams_global:
+            let reader = try GenericReader<CamsDomain, CamsVariable>(domain: .cams_global, position: gridpoint)
+            self.reader = [CamsReader(reader: GenericReaderCached(reader: reader))]
+        case .cams_europe:
+            let reader = try GenericReader<CamsDomain, CamsVariable>(domain: .cams_europe, position: gridpoint)
+            self.reader = [CamsReader(reader: GenericReaderCached(reader: reader))]
+        }
+    }
+}
+
 /**
  API for Air quality data
  */
 struct CamsController {
     func query(_ req: Request) async throws -> Response {
-        /*
         try await req.ensureSubdomain("air-quality-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         try req.ensureApiKey("air-quality-api", apikey: params.apikey)
@@ -14,25 +48,25 @@ struct CamsController {
         let currentTime = Timestamp.now()
         let allowedRange = Timestamp(2022, 7, 29) ..< currentTime.add(86400 * 6)
         
-        let prepared = try params.prepareCoordinates(allowTimezones: true)
         let paramsHourly = try VariableOrDerived<CamsVariable, CamsVariableDerived>.load(commaSeparatedOptional: params.hourly)
         let paramsCurrent = try VariableOrDerived<CamsVariable, CamsVariableDerived>.load(commaSeparatedOptional: params.current)
         let domains = try (params.domains.map({[$0]}) ?? CamsQuery.Domain.load(commaSeparatedOptional: params.models) ?? [.auto])
 
         let nVariables = (paramsHourly?.count ?? 0) * domains.count
         
+        let prepared = try CamsMixer.prepareReaders(domains: domains, params: params, currentTime: currentTime, forecastDayDefault: 5, forecastDaysMax: 7, pastDaysMax: 92, allowedRange: allowedRange)
+        
         let locations: [ForecastapiResult<CamsQuery.Domain>.PerLocation] = try prepared.map { prepared in
-            let coordinates = prepared.coordinate
             let timezone = prepared.timezone
-            let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: 5, forecastDaysMax: 7, startEndDate: prepared.startEndDate, allowedRange: allowedRange, pastDaysMax: 92)
+            let time = prepared.time
             let timeLocal = TimerangeLocal(range: time.dailyRead.range, utcOffsetSeconds: timezone.utcOffsetSeconds)
+            let currentTimeRange = TimerangeDt(start: currentTime.floor(toNearest: 3600/4), nTime: 1, dtSeconds: 3600/4)
             
-            let currentTimeRange = TimerangeDt(start: currentTime.floor(toNearest: 3600), nTime: 1, dtSeconds: 3600)
-            
-            let readers: [ForecastapiResult<CamsQuery.Domain>.PerModel] = try domains.compactMap { domain in
-                guard let reader = try CamsMixer(domains: domain.camsDomains, lat: coordinates.latitude, lon: coordinates.longitude, elevation: coordinates.elevation, mode: params.cell_selection ?? .nearest, options: params.readerOptions) else {
+            let readers: [ForecastapiResult<CamsQuery.Domain>.PerModel] = try prepared.perModel.compactMap { readerAndDomain in
+                guard let reader = try readerAndDomain.reader() else {
                     return nil
                 }
+                let domain = readerAndDomain.domain
                 
                 let hourlyFn: (() throws -> ApiSection<ForecastapiResult<CamsQuery.Domain>.SurfaceAndPressureVariable>)? = paramsHourly.map { variables in
                     return {
@@ -76,12 +110,11 @@ struct CamsController {
             guard !readers.isEmpty else {
                 throw ForecastapiError.noDataAvilableForThisLocation
             }
-            return .init(timezone: timezone, time: timeLocal, locationId: coordinates.locationId, results: readers)
+            return .init(timezone: timezone, time: timeLocal, locationId: prepared.locationId, results: readers)
         }
         let result = ForecastapiResult<CamsQuery.Domain>(timeformat: params.timeformatOrDefault, results: locations)
         await req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))
         return try await result.response(format: params.format ?? .json)
-         */ fatalError()
     }
 }
 

--- a/Sources/App/Cmip6/CmipController.swift
+++ b/Sources/App/Cmip6/CmipController.swift
@@ -5,7 +5,6 @@ import Vapor
 
 struct CmipController {
     func query(_ req: Request) async throws -> Response {
-        /*
         try await req.ensureSubdomain("climate-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         try req.ensureApiKey("climate-api", apikey: params.apikey)
@@ -14,6 +13,9 @@ struct CmipController {
         let allowedRange = Timestamp(1950, 1, 1) ..< Timestamp(2051, 1, 1)
         
         let prepared = try params.prepareCoordinates(allowTimezones: false)
+        guard case .coordinates(let prepared) = prepared else {
+            throw ForecastapiError.generic(message: "Bounding box not supported")
+        }
         let domains = try Cmip6Domain.load(commaSeparatedOptional: params.models) ?? [.MRI_AGCM3_2_S]
         let paramsDaily = try Cmip6VariableOrDerivedPostBias.load(commaSeparatedOptional: params.daily)
         let nVariables = (paramsDaily?.count ?? 0) * domains.count
@@ -73,8 +75,7 @@ struct CmipController {
         }
         let result = ForecastapiResult<Cmip6Domain>(timeformat: params.timeformatOrDefault, results: locations)
         await req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))
-        return try await result.response(format: params.format ?? .json)*/
-        fatalError()
+        return try await result.response(format: params.format ?? .json)
     }
 }
 

--- a/Sources/App/Cmip6/CmipController.swift
+++ b/Sources/App/Cmip6/CmipController.swift
@@ -5,6 +5,7 @@ import Vapor
 
 struct CmipController {
     func query(_ req: Request) async throws -> Response {
+        /*
         try await req.ensureSubdomain("climate-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         try req.ensureApiKey("climate-api", apikey: params.apikey)
@@ -72,7 +73,8 @@ struct CmipController {
         }
         let result = ForecastapiResult<Cmip6Domain>(timeformat: params.timeformatOrDefault, results: locations)
         await req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))
-        return try await result.response(format: params.format ?? .json)
+        return try await result.response(format: params.format ?? .json)*/
+        fatalError()
     }
 }
 

--- a/Sources/App/Controllers/EnsembleController.swift
+++ b/Sources/App/Controllers/EnsembleController.swift
@@ -98,6 +98,14 @@ extension EnsembleVariableWithoutMember {
 List of ensemble models. "Seamless" models combine global with local models. A best_match model is not possible, as all models are too different to give any advice
  */
 enum EnsembleMultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixerDomain {
+    var genericDomain: (any GenericDomain)? {
+        fatalError()
+    }
+    
+    func getReader(gridpoint: Int, options: GenericReaderOptions) throws -> (any GenericReaderProtocol)? {
+        fatalError()
+    }
+    
     case icon_seamless
     case icon_global
     case icon_eu

--- a/Sources/App/Controllers/EnsembleController.swift
+++ b/Sources/App/Controllers/EnsembleController.swift
@@ -8,6 +8,7 @@ import Vapor
  */
 public struct EnsembleApiController {
     func query(_ req: Request) async throws -> Response {
+        /*
         try await req.ensureSubdomain("ensemble-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         try req.ensureApiKey("ensemble-api", apikey: params.apikey)
@@ -75,7 +76,8 @@ public struct EnsembleApiController {
         }
         let result = ForecastapiResult<EnsembleMultiDomains>(timeformat: params.timeformatOrDefault, results: locations)
         await req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))
-        return try await result.response(format: params.format ?? .json)
+        return try await result.response(format: params.format ?? .json)*/
+        fatalError()
     }
 }
 

--- a/Sources/App/Controllers/EnsembleController.swift
+++ b/Sources/App/Controllers/EnsembleController.swift
@@ -132,11 +132,11 @@ enum EnsembleMultiDomains: String, RawRepresentableString, CaseIterable, MultiDo
         case .ecmwf_ifs025:
             return try EcmwfReader(domain: .ifs025_ensemble, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
         case .gfs025:
-            return try GfsReader(domain: .gfs025_ens, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
+            return try GfsReader(domains: [.gfs025_ens], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
         case .gfs05:
-            return try GfsReader(domain: .gfs05_ens, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
+            return try GfsReader(domains: [.gfs05_ens], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
         case .gfs_seamless:
-            return try GfsMixer(domains: [.gfs05_ens, .gfs025_ens], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)?.reader ?? []
+            return try GfsReader(domains: [.gfs05_ens, .gfs025_ens], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
         case .gem_global:
             return try GemReader(domain: .gem_global_ensemble, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
         case .bom_access_global_ensemble:

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -476,14 +476,60 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
     
     var genericDomain: (any GenericDomain)? {
         switch self {
-        case .icon_global:
-            return IconDomains.icon
         case .gfs025:
             return GfsDomain.gfs025
         case .gfs013:
             return GfsDomain.gfs013
         case .gfs_hrrr:
             return GfsDomain.hrrr_conus
+        case .gfs_graphcast025:
+            return GfsGraphCastDomain.graphcast025
+        case .meteofrance_arpege_world, .arpege_world:
+            return MeteoFranceDomain.arpege_world
+        case .meteofrance_arpege_europe, .arpege_europe:
+            return MeteoFranceDomain.arpege_europe
+        case .meteofrance_arome_france, .arome_france:
+            return MeteoFranceDomain.arome_france
+        case .meteofrance_arome_france_hd, .arome_france_hd:
+            return MeteoFranceDomain.arome_france_hd
+        case .icon_global:
+            return IconDomains.icon
+        case .icon_eu:
+            return IconDomains.iconEu
+        case .icon_d2:
+            return IconDomains.iconD2
+        case .ecmwf_ifs04:
+            return EcmwfDomain.ifs04
+        case .ecmwf_ifs025:
+            return EcmwfDomain.ifs025
+        case .ecmwf_aifs025:
+            return EcmwfDomain.aifs025
+        case .metno_nordic:
+            return MetNoDomain.nordic_pp
+        case .gem_global:
+            return GemDomain.gem_global
+        case .gem_regional:
+            return GemDomain.gem_regional
+        case .gem_hrdps_continental:
+            return GemDomain.gem_hrdps_continental
+        case .era5:
+            return CdsDomain.era5
+        case .era5_land:
+            return CdsDomain.era5_land
+        case .cerra:
+            return CdsDomain.cerra
+        case .ecmwf_ifs:
+            return CdsDomain.ecmwf_ifs
+        case .cma_grapes_global:
+            return CmaDomain.grapes_global
+        case .bom_access_global:
+            return BomDomain.access_global
+        case .arpae_cosmo_2i:
+            return ArpaeDomain.cosmo_2i
+        case .arpae_cosmo_2i_ruc:
+            return ArpaeDomain.cosmo_2i_ruc
+        case .arpae_cosmo_5m:
+            return ArpaeDomain.cosmo_5m
         default:
             return nil
         }
@@ -491,16 +537,60 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
     
     func getReader(gridpoint: Int, options: GenericReaderOptions) throws -> (any GenericReaderProtocol)? {
         switch self {
-        case .icon_global:
-            return try IconReader(domain: .icon, gridpoint: gridpoint, options: options)
         case .gfs025:
             return try GfsReader(domain: .gfs025, gridpoint: gridpoint, options: options)
         case .gfs013:
             return try GfsReader(domain: .gfs013, gridpoint: gridpoint, options: options)
         case .gfs_hrrr:
             return try GfsReader(domain: .hrrr_conus, gridpoint: gridpoint, options: options)
-        //case .gfs_graphcast025:
-            //return try GfsGraphCastReader(domain: .graphcast025, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]})
+        case .gfs_graphcast025:
+            return try GfsGraphCastReader(domain: .graphcast025, gridpoint: gridpoint, options: options)
+        case .meteofrance_arpege_world, .arpege_world:
+            return try MeteoFranceReader(domain: .arpege_world, gridpoint: gridpoint, options: options)
+        case .meteofrance_arpege_europe, .arpege_europe:
+            return try MeteoFranceReader(domain: .arpege_europe, gridpoint: gridpoint, options: options)
+        case .meteofrance_arome_france, .arome_france:
+            return try MeteoFranceReader(domain: .arome_france, gridpoint: gridpoint, options: options)
+        case .meteofrance_arome_france_hd, .arome_france_hd:
+            return try MeteoFranceReader(domain: .arome_france_hd, gridpoint: gridpoint, options: options)
+        case .icon_global:
+            return try IconReader(domain: .icon, gridpoint: gridpoint, options: options)
+        case .icon_eu:
+            return try IconReader(domain: .iconEu, gridpoint: gridpoint, options: options)
+        case .icon_d2:
+            return try IconReader(domain: .iconD2, gridpoint: gridpoint, options: options)
+        case .ecmwf_ifs04:
+            return try EcmwfReader(domain: .ifs04, gridpoint: gridpoint, options: options)
+        case .ecmwf_ifs025:
+            return try EcmwfReader(domain: .ifs025, gridpoint: gridpoint, options: options)
+        case .ecmwf_aifs025:
+            return try EcmwfReader(domain: .aifs025, gridpoint: gridpoint, options: options)
+        case .metno_nordic:
+            return try MetNoReader(domain: .nordic_pp, gridpoint: gridpoint, options: options)
+        case .gem_global:
+            return try GemReader(domain: .gem_global, gridpoint: gridpoint, options: options)
+        case .gem_regional:
+            return try GemReader(domain: .gem_regional, gridpoint: gridpoint, options: options)
+        case .gem_hrdps_continental:
+            return try GemReader(domain: .gem_hrdps_continental, gridpoint: gridpoint, options: options)
+        case .era5:
+            return try Era5Factory.makeReader(domain: .era5, gridpoint: gridpoint, options: options)
+        case .era5_land:
+            return try Era5Factory.makeReader(domain: .era5_land, gridpoint: gridpoint, options: options)
+        case .cerra:
+            return try CerraReader(domain: .cerra, gridpoint: gridpoint, options: options)
+        case .ecmwf_ifs:
+            return try Era5Factory.makeReader(domain: .ecmwf_ifs, gridpoint: gridpoint, options: options)
+        case .cma_grapes_global:
+            return try CmaReader(domain: .grapes_global, gridpoint: gridpoint, options: options)
+        case .bom_access_global:
+            return try BomReader(domain: .access_global, gridpoint: gridpoint, options: options)
+        case .arpae_cosmo_2i:
+            return try ArpaeReader(domain: .cosmo_2i, gridpoint: gridpoint, options: options)
+        case .arpae_cosmo_2i_ruc:
+            return try ArpaeReader(domain: .cosmo_2i_ruc, gridpoint: gridpoint, options: options)
+        case .arpae_cosmo_5m:
+            return try ArpaeReader(domain: .cosmo_5m, gridpoint: gridpoint, options: options)
         default:
             return nil
         }

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -123,11 +123,10 @@ struct WeatherApiController {
         let nParamsCurrent = paramsCurrent?.count ?? 0
         let nParamsDaily = paramsDaily?.count ?? 0
         let nVariables = (nParamsHourly + nParamsMinutely + nParamsCurrent + nParamsDaily) * domains.count
-        let options = params.readerOptions
         
         /// Prepare readers based on geometry
         /// Readers are returned as a callback to release memory after data has been retrieved
-        let prepared = try GenericReaderMulti<ForecastVariable>.prepareReaders(domains: domains, params: params, currentTime: currentTime, forecastDay: forecastDay, forecastDaysMax: forecastDaysMax, pastDaysMax: 92, allowedRange: allowedRange)
+        let prepared = try GenericReaderMulti<ForecastVariable, MultiDomains>.prepareReaders(domains: domains, params: params, currentTime: currentTime, forecastDay: forecastDay, forecastDaysMax: forecastDaysMax, pastDaysMax: 92, allowedRange: allowedRange)
         
         let locations: [ForecastapiResult<MultiDomains>.PerLocation] = try prepared.map { prepared in
             let timezone = prepared.timezone

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -105,7 +105,7 @@ struct WeatherApiController {
         /// True if running on `historical-forecast-api.open-meteo.com` -> Limit to current day, disable forecast
         let isHistoricalForecastApi = host?.starts(with: "historical-forecast-api") == true || host?.starts(with: "customer-historical-api") == true
         let forecastDaysMax = isHistoricalForecastApi ? 1 : self.forecastDaysMax
-        let forecastDay = isHistoricalForecastApi ? 1 : self.forecastDay
+        let forecastDayDefault = isHistoricalForecastApi ? 1 : self.forecastDay
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         try req.ensureApiKey(subdomain, alias: alias, apikey: params.apikey)
         
@@ -126,7 +126,7 @@ struct WeatherApiController {
         
         /// Prepare readers based on geometry
         /// Readers are returned as a callback to release memory after data has been retrieved
-        let prepared = try GenericReaderMulti<ForecastVariable, MultiDomains>.prepareReaders(domains: domains, params: params, currentTime: currentTime, forecastDay: forecastDay, forecastDaysMax: forecastDaysMax, pastDaysMax: 92, allowedRange: allowedRange)
+        let prepared = try GenericReaderMulti<ForecastVariable, MultiDomains>.prepareReaders(domains: domains, params: params, currentTime: currentTime, forecastDayDefault: forecastDayDefault, forecastDaysMax: forecastDaysMax, pastDaysMax: 92, allowedRange: allowedRange)
         
         let locations: [ForecastapiResult<MultiDomains>.PerLocation] = try prepared.map { prepared in
             let timezone = prepared.timezone

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -125,7 +125,7 @@ struct WeatherApiController {
         let nVariables = (nParamsHourly + nParamsMinutely + nParamsCurrent + nParamsDaily) * domains.count
         let options = params.readerOptions
         
-        /// Prepare readers for Point, MultiPoint or BoundBox queries
+        /// Prepare readers based on geometry
         /// Readers are returned as a callback to release memory after data has been retrieved
         let prepared = try GenericReaderMulti<ForecastVariable>.prepareReaders(domains: domains, params: params, currentTime: currentTime, forecastDay: forecastDay, forecastDaysMax: forecastDaysMax, pastDaysMax: 92, allowedRange: allowedRange)
         

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -278,8 +278,8 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
     case gfs_seamless
     case gfs_mix
     case gfs_global
-    case gfs_global025
-    case gfs_global013
+    case gfs025
+    case gfs013
     case gfs_hrrr
     case gfs_graphcast025
     
@@ -397,9 +397,9 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
             return try GfsReader(domains: [.gfs025_ensemble, .gfs025, .gfs013, .hrrr_conus, .hrrr_conus_15min], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
         case .gfs_global:
             return try GfsReader(domains: [.gfs025_ensemble, .gfs025, .gfs013], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
-        case .gfs_global025:
+        case .gfs025:
             return try GfsReader(domains: [.gfs025], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
-        case .gfs_global013:
+        case .gfs013:
             return try GfsReader(domains: [.gfs013], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
         case .gfs_hrrr:
             return try GfsReader(domains: [.hrrr_conus, .hrrr_conus_15min], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
@@ -500,6 +500,12 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
         switch self {
         case .icon_global:
             return IconDomains.icon
+        case .gfs025:
+            return GfsDomain.gfs025
+        case .gfs013:
+            return GfsDomain.gfs013
+        case .gfs_hrrr:
+            return GfsDomain.hrrr_conus
         default:
             return nil
         }
@@ -509,6 +515,14 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
         switch self {
         case .icon_global:
             return try IconReader(domain: .icon, gridpoint: gridpoint, options: options)
+        case .gfs025:
+            return try GfsReader(domain: .gfs025, gridpoint: gridpoint, options: options)
+        case .gfs013:
+            return try GfsReader(domain: .gfs013, gridpoint: gridpoint, options: options)
+        case .gfs_hrrr:
+            return try GfsReader(domain: .hrrr_conus, gridpoint: gridpoint, options: options)
+        //case .gfs_graphcast025:
+            //return try GfsGraphCastReader(domain: .graphcast025, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]})
         default:
             return nil
         }

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -391,9 +391,7 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
             
             // Remaining parts of the world
             return [gfs, icon]
-        case .gfs_seamless:
-            fallthrough
-        case .gfs_mix:
+        case .gfs_mix, .gfs_seamless:
             return try GfsReader(domains: [.gfs025_ensemble, .gfs025, .gfs013, .hrrr_conus, .hrrr_conus_15min], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
         case .gfs_global:
             return try GfsReader(domains: [.gfs025_ensemble, .gfs025, .gfs013], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
@@ -405,47 +403,27 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
             return try GfsReader(domains: [.hrrr_conus, .hrrr_conus_15min], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
         case .gfs_graphcast025:
             return try GfsGraphCastReader(domain: .graphcast025, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
-        case .meteofrance_seamless:
-            fallthrough
-        case .meteofrance_mix:
+        case .meteofrance_mix, .meteofrance_seamless:
             return try MeteoFranceMixer(domains: [.arpege_world, .arpege_europe, .arome_france, .arome_france_hd, .arome_france_15min, .arome_france_hd_15min], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)?.reader ?? []
-        case .meteofrance_arpege_seamless:
-            fallthrough
-        case .arpege_seamless:
+        case .meteofrance_arpege_seamless, .arpege_seamless:
             return try MeteoFranceMixer(domains: [.arpege_world, .arpege_europe], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)?.reader ?? []
-        case .meteofrance_arome_seamless:
-            fallthrough
-        case .arome_seamless:
+        case .meteofrance_arome_seamless, .arome_seamless:
             return try MeteoFranceMixer(domains: [.arome_france, .arome_france_hd, .arome_france_15min, .arome_france_hd_15min], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)?.reader ?? []
-        case .arpege_world:
-            fallthrough
-        case .meteofrance_arpege_world:
+        case .meteofrance_arpege_world, .arpege_world:
             return try MeteoFranceReader(domain: .arpege_world, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
-        case .arpege_europe:
-            fallthrough
-        case .meteofrance_arpege_europe:
+        case .meteofrance_arpege_europe, .arpege_europe:
             return try MeteoFranceReader(domain: .arpege_europe, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
-        case .arome_france:
-            fallthrough
-        case .meteofrance_arome_france:
+        case .meteofrance_arome_france, .arome_france:
             return try MeteoFranceReader(domain: .arome_france, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
-        case .arome_france_hd:
-            fallthrough
-        case .meteofrance_arome_france_hd:
+        case .meteofrance_arome_france_hd, .arome_france_hd:
             return try MeteoFranceReader(domain: .arome_france_hd, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
-        case .jma_seamless:
-            fallthrough
-        case .jma_mix:
+        case .jma_mix, .jma_seamless:
             return try JmaMixer(domains: [.gsm, .msm], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)?.reader ?? []
         case .jma_msm:
             return try JmaReader(domain: .msm, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
-        case .jms_gsm:
-            fallthrough
-        case .jma_gsm:
+        case .jms_gsm, .jma_gsm:
             return try JmaReader(domain: .gsm, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
-        case .icon_seamless:
-            fallthrough
-        case .icon_mix:
+        case .icon_seamless, .icon_mix:
             return try IconMixer(domains: [.icon, .iconEu, .iconD2, .iconD2_15min], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)?.reader ?? []
         case .icon_global:
             return try IconReader(domain: .icon, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []

--- a/Sources/App/Domains/GaussianGrid.swift
+++ b/Sources/App/Domains/GaussianGrid.swift
@@ -119,4 +119,8 @@ struct GaussianGrid: Gridable {
         let x = (Int(round(lon / dx)) + nx) % nx
         return integral(y: y) + x
     }
+    
+    func findBox(boundingBox bb: BoundingBoxWGS84) -> Optional<any Sequence<Int>> {
+        return nil
+    }
 }

--- a/Sources/App/Domains/Gridable.swift
+++ b/Sources/App/Domains/Gridable.swift
@@ -8,6 +8,7 @@ public protocol Gridable {
     
     func findPoint(lat: Float, lon: Float) -> Int?
     func findPointInterpolated(lat: Float, lon: Float) -> GridPoint2DFraction?
+    func findBox(boundingBox bb: BoundingBoxWGS84) -> Optional<any Sequence<Int>>
     func getCoordinates(gridpoint: Int) -> (latitude: Float, longitude: Float)
 }
 
@@ -219,7 +220,7 @@ enum GridSelectionMode: String, Codable {
 }
 
 
-struct BoundingBoxWGS84 {
+public struct BoundingBoxWGS84 {
     let latitude: Range<Float>
     let longitude: Range<Float>
 }

--- a/Sources/App/Domains/Gridable.swift
+++ b/Sources/App/Domains/Gridable.swift
@@ -217,3 +217,9 @@ enum GridSelectionMode: String, Codable {
     case sea
     case nearest
 }
+
+
+struct BoundingBoxWGS84 {
+    let latitude: Range<Float>
+    let longitude: Range<Float>
+}

--- a/Sources/App/Domains/ProjectionGrid.swift
+++ b/Sources/App/Domains/ProjectionGrid.swift
@@ -65,6 +65,10 @@ struct ProjectionGrid<Projection: Projectable>: Gridable {
         }
         return trueNorthDirection
     }
+    
+    func findBox(boundingBox bb: BoundingBoxWGS84) -> Optional<any Sequence<Int>> {
+        return nil
+    }
 }
 
 fileprivate extension ClosedRange where Bound == Float {

--- a/Sources/App/Domains/ProjectionGrid.swift
+++ b/Sources/App/Domains/ProjectionGrid.swift
@@ -24,13 +24,20 @@ struct ProjectionGrid<Projection: Projectable>: Gridable {
     }
     
     func findPoint(lat: Float, lon: Float) -> Int? {
+        guard let (x,y) = findPointXy(lat: lat, lon: lon) else {
+            return nil
+        }
+        return y * nx + x
+    }
+    
+    func findPointXy(lat: Float, lon: Float) -> (x: Int, y: Int)? {
         let pos = projection.forward(latitude: lat, longitude: lon)
         let x = Int(round((pos.x - xrange.lowerBound) / xrange.length * Float(nx-1)))
         let y = Int(round((pos.y - yrange.lowerBound) / yrange.length * Float(ny-1)))
         if y < 0 || x < 0 || y >= ny || x >= nx {
             return nil
         }
-        return y * nx + x
+        return (x, y)
     }
     
     func findPointInterpolated(lat: Float, lon: Float) -> GridPoint2DFraction? {
@@ -67,12 +74,35 @@ struct ProjectionGrid<Projection: Projectable>: Gridable {
     }
     
     func findBox(boundingBox bb: BoundingBoxWGS84) -> Optional<any Sequence<Int>> {
-        return nil
+        guard let sw = findPointXy(lat: bb.latitude.lowerBound, lon: bb.longitude.lowerBound),
+              let se = findPointXy(lat: bb.latitude.lowerBound, lon: bb.longitude.upperBound),
+              let nw = findPointXy(lat: bb.latitude.upperBound, lon: bb.longitude.lowerBound),
+              let ne = findPointXy(lat: bb.latitude.upperBound, lon: bb.longitude.upperBound) else {
+            return []
+        }
+        
+        let xRange = min(sw.x, nw.x) ..< max(se.x, ne.x)
+        let yRange = min(sw.y, nw.y) ..< max(se.y, ne.y)
+        
+        return ProjectionGridSlice(grid: self, yRange: yRange, xRange: xRange)
     }
 }
 
 fileprivate extension ClosedRange where Bound == Float {
     var length: Float {
         return upperBound - lowerBound
+    }
+}
+
+
+struct ProjectionGridSlice<Projection: Projectable> {
+    let grid: ProjectionGrid<Projection>
+    let yRange: Range<Int>
+    let xRange: Range<Int>
+}
+
+extension ProjectionGridSlice: Sequence {
+    func makeIterator() -> GridSliceXyIterator {
+        return GridSliceXyIterator(yRange: yRange, xRange: xRange, nx: grid.nx)
     }
 }

--- a/Sources/App/Domains/RegularGrid.swift
+++ b/Sources/App/Domains/RegularGrid.swift
@@ -14,6 +14,13 @@ struct RegularGrid: Gridable {
     }
     
     func findPoint(lat: Float, lon: Float) -> Int? {
+        guard let (x,y) = findPointXy(lat: lat, lon: lon) else {
+            return nil
+        }
+        return y * nx + x
+    }
+    
+    func findPointXy(lat: Float, lon: Float) -> (x: Int, y: Int)? {
         let x = Int(roundf((lon-lonMin) / dx))
         let y = Int(roundf((lat-latMin) / dy))
         
@@ -23,7 +30,7 @@ struct RegularGrid: Gridable {
         if yy < 0 || xx < 0 || yy >= ny || xx >= nx {
             return nil
         }
-        return yy * nx + xx
+        return (xx, yy)
     }
     
     func getCoordinates(gridpoint: Int) -> (latitude: Float, longitude: Float) {
@@ -48,11 +55,10 @@ struct RegularGrid: Gridable {
     }
     
     func findBox(boundingBox bb: BoundingBoxWGS84) -> Optional<any Sequence<Int>> {
-        let x1 = Int(roundf((bb.longitude.lowerBound-lonMin) / dx))
-        let x2 = Int(roundf((bb.longitude.upperBound-lonMin) / dx))
-        
-        let y1 = Int(roundf((bb.latitude.lowerBound-latMin) / dy))
-        let y2 = Int(roundf((bb.latitude.upperBound-latMin) / dy))
+        guard let (x1, y1) = findPointXy(lat: bb.latitude.lowerBound, lon: bb.longitude.lowerBound),
+              let (x2, y2) = findPointXy(lat: bb.latitude.upperBound, lon: bb.longitude.upperBound) else {
+            return []
+        }
         
         let xRange = x1 ..< x2
         let yRange = y1 > y2 ? y2 ..< y1 : y1 ..< y2

--- a/Sources/App/Domains/RegularGrid.swift
+++ b/Sources/App/Domains/RegularGrid.swift
@@ -47,7 +47,7 @@ struct RegularGrid: Gridable {
         return GridPoint2DFraction(gridpoint: Int(y) * nx + Int(x), xFraction: xFraction, yFraction: yFraction)
     }
     
-    func findBox(boundingBox bb: BoundingBoxWGS84) -> some Sequence<Int> {
+    func findBox(boundingBox bb: BoundingBoxWGS84) -> Optional<any Sequence<Int>> {
         let x1 = Int(roundf((bb.longitude.lowerBound-lonMin) / dx))
         let x2 = Int(roundf((bb.longitude.upperBound-lonMin) / dx))
         

--- a/Sources/App/Domains/RegularGrid.swift
+++ b/Sources/App/Domains/RegularGrid.swift
@@ -48,11 +48,11 @@ struct RegularGrid: Gridable {
     }
     
     func findBox(boundingBox bb: BoundingBoxWGS84) -> some Sequence<Int> {
-        let x1 = Int(bb.longitude.lowerBound / dx) - Int(lonMin / dx)
-        let x2 = Int(bb.longitude.upperBound / dx) - Int(lonMin / dx)
+        let x1 = Int(roundf((bb.longitude.lowerBound-lonMin) / dx))
+        let x2 = Int(roundf((bb.longitude.upperBound-lonMin) / dx))
         
-        let y1 = Int(bb.latitude.lowerBound / dy) - Int(latMin / dy)
-        let y2 = Int(bb.latitude.upperBound / dy) - Int(latMin / dy)
+        let y1 = Int(roundf((bb.latitude.lowerBound-latMin) / dy))
+        let y2 = Int(roundf((bb.latitude.upperBound-latMin) / dy))
         
         let xRange = x1 ..< x2
         let yRange = y1 ..< y2

--- a/Sources/App/Domains/RegularGrid.swift
+++ b/Sources/App/Domains/RegularGrid.swift
@@ -55,7 +55,7 @@ struct RegularGrid: Gridable {
         let y2 = Int(roundf((bb.latitude.upperBound-latMin) / dy))
         
         let xRange = x1 ..< x2
-        let yRange = y1 ..< y2
+        let yRange = y1 > y2 ? y2 ..< y1 : y1 ..< y2
         
         return RegularGridSlice(grid: self, yRange: yRange, xRange: xRange)
     }

--- a/Sources/App/Ecmwf/EcmwfReader.swift
+++ b/Sources/App/Ecmwf/EcmwfReader.swift
@@ -20,6 +20,12 @@ struct EcmwfReader: GenericReaderDerived, GenericReaderProtocol {
         self.options = options
     }
     
+    public init(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+        let reader = try GenericReader<Domain, Variable>(domain: domain, position: gridpoint)
+        self.reader = GenericReaderCached(reader: reader)
+        self.options = options
+    }
+    
     func prefetchData(raw: EcmwfVariable, time: TimerangeDtAndSettings) throws {
         try reader.prefetchData(variable: raw, time: time)
     }

--- a/Sources/App/Era5/CerraDomain.swift
+++ b/Sources/App/Era5/CerraDomain.swift
@@ -67,6 +67,12 @@ struct CerraReader: GenericReaderDerivedSimple, GenericReaderProtocol {
         self.options = options
     }
     
+    public init(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+        let reader = try GenericReader<Domain, Variable>(domain: domain, position: gridpoint)
+        self.reader = GenericReaderCached(reader: reader)
+        self.options = options
+    }
+    
     func prefetchData(variables: [CerraHourlyVariable], time: TimerangeDtAndSettings) throws {
         for variable in variables {
             switch variable {

--- a/Sources/App/Era5/DownloadEra5Command.swift
+++ b/Sources/App/Era5/DownloadEra5Command.swift
@@ -260,10 +260,10 @@ struct DownloadEra5Command: AsyncCommand {
                 // Read location one-by-one... Multi location support does not work with derived varibales
                 for (l, gridpoint) in locationRange.enumerated() {
                     let gridpointNext = min(gridpoint+1, writer.dim0-1)
-                    let readerNext = GenericReaderMulti<ForecastVariable>(domain: MultiDomains.era5, reader: [Era5Reader(reader: GenericReaderCached<CdsDomain, Era5Variable>(reader: try GenericReader<CdsDomain, Era5Variable>(domain: domain, position: gridpointNext)), options: options)])
+                    let readerNext = GenericReaderMulti<ForecastVariable, MultiDomains>(domain: MultiDomains.era5, reader: [Era5Reader(reader: GenericReaderCached<CdsDomain, Era5Variable>(reader: try GenericReader<CdsDomain, Era5Variable>(domain: domain, position: gridpointNext)), options: options)])
                     try readerNext.prefetchData(variables: [era5Variable], time: time)
                     
-                    let reader = GenericReaderMulti<ForecastVariable>(domain: MultiDomains.era5, reader: [Era5Reader(reader: GenericReaderCached<CdsDomain, Era5Variable>(reader: try GenericReader<CdsDomain, Era5Variable>(domain: domain, position: gridpoint)), options: options)])
+                    let reader = GenericReaderMulti<ForecastVariable, MultiDomains>(domain: MultiDomains.era5, reader: [Era5Reader(reader: GenericReaderCached<CdsDomain, Era5Variable>(reader: try GenericReader<CdsDomain, Era5Variable>(domain: domain, position: gridpoint)), options: options)])
                     
                     guard let dataFlat = try reader.getDaily(variable: era5Variable, params: units, time: time)?.data else {
                         fatalError("Could not get \(era5Variable)")

--- a/Sources/App/Era5/Era5Domain.swift
+++ b/Sources/App/Era5/Era5Domain.swift
@@ -403,6 +403,12 @@ struct Era5Factory {
         return .init(reader: GenericReaderCached(reader: reader), options: options)
     }
     
+    /// Build a single reader for a given CdsDomain
+    public static func makeReader(domain: CdsDomain, gridpoint: Int, options: GenericReaderOptions) throws -> Era5Reader<GenericReaderCached<CdsDomain, Era5Variable>> {
+        let reader = try GenericReader<CdsDomain, Era5Variable>(domain: domain, position: gridpoint)
+        return .init(reader: GenericReaderCached(reader: reader), options: options)
+    }
+    
     /**
      Build a combined ERA5 and ERA5-Land reader.
      Derived variables are calculated after combinding both variables to make it possible to calculate ET0 evapotransipiration with temperature from ERA5-Land, but radiation from ERA5

--- a/Sources/App/Gem/GemController.swift
+++ b/Sources/App/Gem/GemController.swift
@@ -103,6 +103,12 @@ struct GemReader: GenericReaderDerivedSimple, GenericReaderProtocol {
         self.options = options
     }
     
+    public init(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+        let reader = try GenericReader<Domain, Variable>(domain: domain, position: gridpoint)
+        self.reader = GenericReaderCached(reader: reader)
+        self.options = options
+    }
+    
     func prefetchData(derived: Derived, time: TimerangeDtAndSettings) throws {
         switch derived {
         case .surface(let surface):

--- a/Sources/App/Gfs/GfsController.swift
+++ b/Sources/App/Gfs/GfsController.swift
@@ -88,75 +88,38 @@ struct GfsPressureVariableDerived: PressureVariableRespresentable, GenericVariab
     }
 }
 
-typealias GfsVariableDerived = SurfaceAndPressureVariable<GfsVariableDerivedSurface, GfsPressureVariableDerived>
-
-typealias GfsVariableCombined = VariableOrDerived<GfsVariable, GfsVariableDerived>
-
-struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
-    typealias Domain = GfsDomain
-    
-    typealias Variable = GfsVariable
-    
-    typealias Derived = GfsVariableDerived
-    
-    typealias MixingVar = GfsVariableCombined
-    
-    let reader: GenericReaderMixerSameDomain<GenericReaderCached<GfsDomain, Variable>>
-    
-    let domain: Domain
-    
-    let options: GenericReaderOptions
-    
-    public init?(domain: Domain, lat: Float, lon: Float, elevation: Float, mode: GridSelectionMode, options: GenericReaderOptions) throws {
-        switch domain {
-        case .gfs013:
-            // Note gfs025_ensemble only offers precipitation probability at 3h
-            // A nicer implementation should use a dedicated variables enum
-            let readers: [GenericReaderCached<GfsDomain, Variable>] = try [GfsDomain.gfs025_ensemble, .gfs025, .gfs013].compactMap {
-                guard let reader = try GenericReader<GfsDomain, Variable>(domain: $0, lat: lat, lon: lon, elevation: elevation, mode: mode) else {
-                    return nil
-                }
-                return GenericReaderCached(reader: reader)
-            }
-            guard !readers.isEmpty else {
-                return nil
-            }
-            self.reader = GenericReaderMixerSameDomain(reader: readers)
-        case .gfs025:
-            fatalError("gfs025 should not been initilised in GfsMixer025_013")
-        case .gfs025_ensemble:
-            fatalError("gfs025_ensemble should not been initilised in GfsMixer025_013")
-        case .gfs025_ens:
-            guard let reader = try GenericReader<GfsDomain, Variable>(domain: .gfs025_ens, lat: lat, lon: lon, elevation: elevation, mode: mode) else {
-                return nil
-            }
-            self.reader = GenericReaderMixerSameDomain(reader: [GenericReaderCached(reader: reader)])
-        case .gfs05_ens:
-            guard let reader = try GenericReader<GfsDomain, Variable>(domain: .gfs05_ens, lat: lat, lon: lon, elevation: elevation, mode: mode) else {
-                return nil
-            }
-            self.reader = GenericReaderMixerSameDomain(reader: [GenericReaderCached(reader: reader)])
-        case .hrrr_conus:
-            // Combine HRRR hourly and 15 minutely data. This way, weather codes can be calculated using HRRR hourly and 15 minutely data.
-            // E.g. CAPE is not available for HRRR 15 minutely data.
-            let readers: [GenericReaderCached<GfsDomain, Variable>] = try [GfsDomain.hrrr_conus, .hrrr_conus_15min].compactMap {
-                guard let reader = try GenericReader<GfsDomain, Variable>(domain: $0, lat: lat, lon: lon, elevation: elevation, mode: mode) else {
-                    return nil
-                }
-                return GenericReaderCached(reader: reader)
-            }
-            guard !readers.isEmpty else {
-                return nil
-            }
-            self.reader = GenericReaderMixerSameDomain(reader: readers)
-        case .hrrr_conus_15min:
-            fatalError("hrrr_conus_15min should not been initilised in GfsMixer025_013")
-        }
-        self.domain = domain
-        self.options = options
+/// Read GFS domains and perform domain specific corrections
+struct GfsReaderLowLevel: GenericReaderProtocol {
+    var modelLat: Float {
+        reader.modelLat
     }
     
-    func get(raw: Variable, time: TimerangeDtAndSettings) throws -> DataAndUnit {
+    var modelLon: Float {
+        reader.modelLon
+    }
+    
+    var modelElevation: ElevationOrSea {
+        reader.modelElevation
+    }
+    
+    var targetElevation: Float {
+        reader.targetElevation
+    }
+    
+    var modelDtSeconds: Int {
+        reader.modelDtSeconds
+    }
+    
+    func getStatic(type: ReaderStaticVariable) throws -> Float? {
+        return try reader.getStatic(type: type)
+    }
+    
+    typealias MixingVar = GfsVariable
+    
+    let reader: GenericReaderCached<GfsDomain, GfsVariable>
+    let domain: GfsDomain
+    
+    func get(variable raw: GfsVariable, time: TimerangeDtAndSettings) throws -> DataAndUnit {
         /// HRRR domain has no cloud cover for pressure levels, calculate from RH
         if domain == .hrrr_conus, case let .pressure(pressure) = raw, pressure.variable == .cloud_cover {
             let rh = try reader.get(variable: .pressure(GfsPressureVariable(variable: .relative_humidity, level: pressure.level)), time: time)
@@ -185,10 +148,17 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
             return DataAndUnit(dhi, ghi.unit)
         }
         
+        /// Only GFS013 has showers
+        if domain != .gfs013, case let .surface(variable) = raw, variable == .showers {
+            // Use precip to return an array with 0, but preserve NaNs if the timerange is unavailable
+            let precip = try reader.get(variable: .surface(.precipitation), time: time)
+            return DataAndUnit(precip.data.map({ $0 * 0 }), precip.unit)
+        }
+        
         return try reader.get(variable: raw, time: time)
     }
     
-    func prefetchData(raw: Variable, time: TimerangeDtAndSettings) throws {
+    func prefetchData(variable raw: GfsVariable, time: TimerangeDtAndSettings) throws {
         /// HRRR domain has no cloud cover for pressure levels, calculate from RH
         if domain == .hrrr_conus, case let .pressure(pressure) = raw, pressure.variable == .cloud_cover {
             return try reader.prefetchData(variable: .pressure(GfsPressureVariable(variable: .relative_humidity, level: pressure.level)), time: time)
@@ -204,7 +174,53 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
             return try reader.prefetchData(variable: .surface(.shortwave_radiation), time: time)
         }
         
+        /// Only GFS013 has showers
+        if domain != .gfs013, case let .surface(variable) = raw, variable == .showers {
+            return try reader.prefetchData(variable: .surface(.precipitation), time: time)
+        }
+        
         try reader.prefetchData(variable: raw, time: time)
+    }
+}
+
+
+typealias GfsVariableDerived = SurfaceAndPressureVariable<GfsVariableDerivedSurface, GfsPressureVariableDerived>
+
+typealias GfsVariableCombined = VariableOrDerived<GfsVariable, GfsVariableDerived>
+
+struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
+    typealias Domain = GfsDomain
+    
+    typealias Variable = GfsVariable
+    
+    typealias Derived = GfsVariableDerived
+    
+    typealias MixingVar = GfsVariableCombined
+    
+    let reader: GenericReaderMixerSameDomain<GfsReaderLowLevel>
+        
+    let options: GenericReaderOptions
+    
+    public init?(domains: [Domain], lat: Float, lon: Float, elevation: Float, mode: GridSelectionMode, options: GenericReaderOptions) throws {
+        let readers: [GfsReaderLowLevel] = try domains.compactMap { domain in
+            guard let reader = try GenericReader<GfsDomain, Variable>(domain: domain, lat: lat, lon: lon, elevation: elevation, mode: mode) else {
+                return nil
+            }
+            return GfsReaderLowLevel(reader: GenericReaderCached(reader: reader), domain: domain)
+        }
+        guard !readers.isEmpty else {
+            return nil
+        }
+        self.reader = GenericReaderMixerSameDomain(reader: readers)
+        self.options = options
+    }
+    
+    func prefetchData(raw: GfsReaderLowLevel.MixingVar, time: TimerangeDtAndSettings) throws {
+        try reader.prefetchData(variable: raw, time: time)
+    }
+    
+    func get(raw: GfsReaderLowLevel.MixingVar, time: TimerangeDtAndSettings) throws -> DataAndUnit {
+        return try reader.get(variable: raw, time: time)
     }
     
     func prefetchData(derived: Derived, time: TimerangeDtAndSettings) throws {
@@ -273,9 +289,7 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
             case .rain:
                 try prefetchData(raw: .surface(.frozen_precipitation_percent), time: time)
                 try prefetchData(raw: .surface(.precipitation), time: time)
-                if domain == .gfs013 {
-                    try prefetchData(raw: .surface(.showers), time: time)
-                }
+                try prefetchData(raw: .surface(.showers), time: time)
             case .snowfall:
                 try prefetchData(raw: .surface(.frozen_precipitation_percent), time: time)
                 try prefetchData(raw: .surface(.precipitation), time: time)
@@ -466,22 +480,13 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
             case .rain:
                 let frozen_precipitation_percent = try get(raw: .surface(.frozen_precipitation_percent), time: time).data
                 let precipitation = try get(raw: .surface(.precipitation), time: time).data
-                if domain != .gfs013 {
-                    // showers are only in gfs013
-                    let rain = zip(frozen_precipitation_percent, precipitation).map({ (frozen_precipitation_percent, precipitation) in
-                        let snowfallWaterEqivalent = (frozen_precipitation_percent/100) * precipitation
-                        return max(precipitation - snowfallWaterEqivalent , 0)
-                    })
-                    return DataAndUnit(rain, .millimetre)
-                } else {
-                    let showers = try get(raw: .surface(.showers), time: time).data
-                    let rain = zip(frozen_precipitation_percent, zip(precipitation, showers)).map({ (frozen_precipitation_percent, arg1) in
-                        let (precipitation, showers) = arg1
-                        let snowfallWaterEqivalent = (frozen_precipitation_percent/100) * precipitation
-                        return max(precipitation - snowfallWaterEqivalent - showers, 0)
-                    })
-                    return DataAndUnit(rain, .millimetre)
-                }
+                let showers = try get(raw: .surface(.showers), time: time).data
+                let rain = zip(frozen_precipitation_percent, zip(precipitation, showers)).map({ (frozen_precipitation_percent, arg1) in
+                    let (precipitation, showers) = arg1
+                    let snowfallWaterEqivalent = (frozen_precipitation_percent/100) * precipitation
+                    return max(precipitation - snowfallWaterEqivalent - showers, 0)
+                })
+                return DataAndUnit(rain, .millimetre)
             case .relativehumidity_2m:
                 return try get(raw: .surface(.relative_humidity_2m), time: time)
             case .surface_pressure:
@@ -617,14 +622,5 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 return try get(raw: .pressure(GfsPressureVariable(variable: .relative_humidity, level: v.level)), time: time)
             }
         }
-    }
-}
-
-
-struct GfsMixer: GenericReaderMixer {
-    let reader: [GfsReader]
-    
-    static func makeReader(domain: GfsDomain, lat: Float, lon: Float, elevation: Float, mode: GridSelectionMode, options: GenericReaderOptions) throws -> GfsReader? {
-        return try GfsReader(domain: domain, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)
     }
 }

--- a/Sources/App/Gfs/GfsController.swift
+++ b/Sources/App/Gfs/GfsController.swift
@@ -215,6 +215,12 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
         self.options = options
     }
     
+    public init?(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+        let reader = try GenericReader<GfsDomain, Variable>(domain: domain, position: gridpoint)
+        self.reader = GenericReaderMixerSameDomain(reader: [GfsReaderLowLevel(reader: GenericReaderCached(reader: reader), domain: domain)])
+        self.options = options
+    }
+    
     func prefetchData(raw: GfsReaderLowLevel.MixingVar, time: TimerangeDtAndSettings) throws {
         try reader.prefetchData(variable: raw, time: time)
     }

--- a/Sources/App/GfsGraphCast/GfsGraphCastReader.swift
+++ b/Sources/App/GfsGraphCast/GfsGraphCastReader.swift
@@ -73,6 +73,12 @@ struct GfsGraphCastReader: GenericReaderDerived, GenericReaderProtocol {
         self.options = options
     }
     
+    public init(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+        let reader = try GenericReader<Domain, Variable>(domain: domain, position: gridpoint)
+        self.reader = GenericReaderCached(reader: reader)
+        self.options = options
+    }
+    
     func get(raw: GfsGraphCastVariable, time: TimerangeDtAndSettings) throws -> DataAndUnit {
         return try reader.get(variable: raw, time: time)
     }

--- a/Sources/App/GloFas/GloFasController.swift
+++ b/Sources/App/GloFas/GloFasController.swift
@@ -87,7 +87,6 @@ struct GloFasReader: GenericReaderDerivedSimple, GenericReaderProtocol {
 
 struct GloFasController {
     func query(_ req: Request) async throws -> Response {
-        /*
         try await req.ensureSubdomain("flood-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         try req.ensureApiKey("flood-api", apikey: params.apikey)
@@ -95,6 +94,9 @@ struct GloFasController {
         let allowedRange = Timestamp(1984, 1, 1) ..< currentTime.add(86400 * 230)
         
         let prepared = try params.prepareCoordinates(allowTimezones: false)
+        guard case .coordinates(let prepared) = prepared else {
+            throw ForecastapiError.generic(message: "Bounding box not supported")
+        }
         let domains = try GlofasDomainApi.load(commaSeparatedOptional: params.models) ?? [.best_match]
         guard let paramsDaily = try GloFasVariableOrDerived.load(commaSeparatedOptional: params.daily) else {
             throw ForecastapiError.generic(message: "Parameter 'daily' required")
@@ -157,8 +159,6 @@ struct GloFasController {
         let result = ForecastapiResult<GlofasDomainApi>(timeformat: params.timeformatOrDefault, results: locations)
         await req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))
         return try await result.response(format: params.format ?? .json)
-         */
-        fatalError()
     }
 }
 

--- a/Sources/App/GloFas/GloFasController.swift
+++ b/Sources/App/GloFas/GloFasController.swift
@@ -87,6 +87,7 @@ struct GloFasReader: GenericReaderDerivedSimple, GenericReaderProtocol {
 
 struct GloFasController {
     func query(_ req: Request) async throws -> Response {
+        /*
         try await req.ensureSubdomain("flood-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         try req.ensureApiKey("flood-api", apikey: params.apikey)
@@ -156,6 +157,8 @@ struct GloFasController {
         let result = ForecastapiResult<GlofasDomainApi>(timeformat: params.timeformatOrDefault, results: locations)
         await req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))
         return try await result.response(format: params.format ?? .json)
+         */
+        fatalError()
     }
 }
 

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
@@ -584,9 +584,9 @@ extension MultiDomains: ModelFlatbufferSerialisable {
         case .gfs_graphcast025:
             // TODO register graphcast 025
             return .gfs025
-        case .gfs_global025:
+        case .gfs025:
             return .gfs025
-        case .gfs_global013:
+        case .gfs013:
             // TODO registyer 013 domain
             return .gfs025
         }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
@@ -579,16 +579,13 @@ extension MultiDomains: ModelFlatbufferSerialisable {
         case .ecmwf_ifs025:
             return .ecmwfIfs025
         case .ecmwf_aifs025:
-            // TODO register AIFS 025
-            return .ecmwfIfs025
+            return .ecmwfAifs025
         case .gfs_graphcast025:
-            // TODO register graphcast 025
-            return .gfs025
+            return .gfsGraphcast025
         case .gfs025:
             return .gfs025
         case .gfs013:
-            // TODO registyer 013 domain
-            return .gfs025
+            return .gfs013
         }
     }
 }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
@@ -584,6 +584,11 @@ extension MultiDomains: ModelFlatbufferSerialisable {
         case .gfs_graphcast025:
             // TODO register graphcast 025
             return .gfs025
+        case .gfs_global025:
+            return .gfs025
+        case .gfs_global013:
+            // TODO registyer 013 domain
+            return .gfs025
         }
     }
 }

--- a/Sources/App/Helper/ForecastapiQuery.swift
+++ b/Sources/App/Helper/ForecastapiQuery.swift
@@ -126,36 +126,57 @@ struct ApiQueryParameter: Content, ApiUnitsSelectable {
         }
     }
     
+    enum ApiRequestGeometry {
+        case coordinates([CoordinatesAndTimeZonesAndDates])
+        case boundingBox(BoundingBoxWGS84, dates: [ApiQueryStartEndRanges], timezone: TimezoneWithOffset)
+    }
+    
     /// Reads coordinates, elevation, timezones and start/end dataparameter and prepares an array.
     /// For each element, an API response object will be returned later
-    func prepareCoordinates(allowTimezones: Bool) throws -> [CoordinatesAndTimeZonesAndDates] {
+    func prepareCoordinates(allowTimezones: Bool) throws -> ApiRequestGeometry {
         let dates = try getStartEndDates()
+        if let bb = try getBoundingBox() {
+            let timezones = allowTimezones ? try TimeZoneOrAuto.load(commaSeparatedOptional: timezone) ?? [] : []
+            guard timezones.count <= 1 else {
+                throw ForecastapiError.generic(message: "Only one timezone may be specified with bounding box queries")
+            }
+            let timezone: TimezoneWithOffset = try timezones.first.map({
+                switch $0 {
+                case .auto:
+                    throw ForecastapiError.generic(message: "Timezone 'auto' not supported with bounding box queries")
+                case .timezone(let t):
+                    return TimezoneWithOffset(timezone: t)
+                }
+            }) ?? TimezoneWithOffset.gmt
+            return .boundingBox(bb, dates: dates, timezone: timezone)
+        }
+        
         let coordinates = try getCoordinatesWithTimezone(allowTimezones: allowTimezones)
         
         /// If no start/end dates are set, leav it `nil`
         guard dates.count > 0 else {
-            return coordinates.map({
+            return .coordinates(coordinates.map({
                 CoordinatesAndTimeZonesAndDates(coordinate: $0.coordinate, timezone: $0.timezone, startEndDate: nil)
-            })
+            }))
         }
         /// Multiple coordinates, but one start/end date. Return the same date range for each coordinate
         if dates.count == 1 {
-            return coordinates.map({
+            return .coordinates(coordinates.map({
                 CoordinatesAndTimeZonesAndDates(coordinate: $0.coordinate, timezone: $0.timezone, startEndDate: dates[0])
-            })
+            }))
         }
         /// Single coordinate, but multiple dates. Return different date ranges, but always the same coordinate
         if coordinates.count == 1 {
-            return dates.map {
+            return .coordinates(dates.map {
                 CoordinatesAndTimeZonesAndDates(coordinate: coordinates[0].coordinate, timezone: coordinates[0].timezone, startEndDate: $0)
-            }
+            })
         }
         guard dates.count == coordinates.count else {
             throw ForecastapiError.coordinatesAndStartEndDatesCountMustBeTheSame
         }
-        return zip(coordinates, dates).map {
+        return .coordinates(zip(coordinates, dates).map {
             CoordinatesAndTimeZonesAndDates(coordinate: $0.0.coordinate, timezone: $0.0.timezone, startEndDate: $0.1)
-        }
+        })
     }
     
     /// Parse `&bounding_box=` parameter. Format: lat1, lon1, lat2, lon2

--- a/Sources/App/Helper/Intrinsics/Range2D.swift
+++ b/Sources/App/Helper/Intrinsics/Range2D.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Range, but with 2 dimensions
+struct Range2D<Element1: Comparable, Element2: Comparable> {
+    let y: Range<Element1>
+    let x: Range<Element2>
+    
+    init(_ y: Range<Element1>, _ x: Range<Element2>) {
+        self.y = y
+        self.x = x
+    }
+}
+
+extension Range2D: Sequence where Element1: Strideable, Element2: Strideable {
+    func makeIterator() -> Iterator {
+        return Iterator(range: self)
+    }
+    
+    struct Iterator: IteratorProtocol {
+        var y: Element1
+        var x: Element2
+        let range: Range2D
+        
+        init(range: Range2D) {
+            self.y = range.y.lowerBound
+            self.x = range.x.lowerBound
+            self.range = range
+        }
+        
+        mutating func next() -> (y: Element1, x: Element2)? {
+            let xNext = x.advanced(by: 1)
+            if xNext == range.x.upperBound {
+                let yNext = y.advanced(by: 1)
+                if yNext == range.y.upperBound {
+                    return nil
+                }
+                let currentX = x
+                let currentY = y
+                x = range.x.lowerBound
+                y = yNext
+                return (currentY, currentX)
+            }
+            let currentX = x
+            x = xNext
+            return (y, currentX)
+        }
+    }
+}

--- a/Sources/App/Helper/Intrinsics/Sequence2D.swift
+++ b/Sources/App/Helper/Intrinsics/Sequence2D.swift
@@ -1,19 +1,26 @@
 import Foundation
 
-/// Range, but with 2 dimensions
-struct Range2D {
-    let y: Range<Int>
-    let x: Range<Int>
+/// Sequence, but with 2 dimensions
+struct Sequence2D<S1: Sequence, S2: Sequence> {
+    let y: S1
+    let x: S2
     
-    init(_ y: Range<Int>, _ x: Range<Int>) {
+    init(_ y: S1, _ x: S2) {
         self.y = y
         self.x = x
     }
 }
 
-extension Range2D: Sequence {
-    func makeIterator() -> Iterator2D<Range<Int>, Range<Int>> {
+extension Sequence2D: Sequence {
+    func makeIterator() -> Iterator2D<S1, S2> {
         return Iterator2D(y, x)
+    }
+}
+
+extension Sequence {
+    /// Iterate over 2 dimensions. The second sequence is iterated self.count times
+    func iterate2D<S: Sequence>(over other: S) -> Sequence2D<Self, S> {
+        return Sequence2D(self, other)
     }
 }
 

--- a/Sources/App/Helper/Reader/GenericReaderMulti.swift
+++ b/Sources/App/Helper/Reader/GenericReaderMulti.swift
@@ -43,6 +43,10 @@ struct GenericReaderMulti<Variable: GenericVariableMixable> {
         self.reader = reader
     }
     
+    public static func getReadersFor(domain: MultiDomainMixerDomain, box: BoundingBoxWGS84, options: GenericReaderOptions) throws -> [Self] {
+        fatalError()
+    }
+    
     func prefetchData(variable: Variable, time: TimerangeDtAndSettings) throws {
         for reader in reader {
             if time.dtSeconds > reader.modelDtSeconds {

--- a/Sources/App/Helper/Reader/GenericReaderMulti.swift
+++ b/Sources/App/Helper/Reader/GenericReaderMulti.swift
@@ -66,6 +66,60 @@ struct GenericReaderMulti<Variable: GenericVariableMixable> {
         })
     }
     
+    /// Prepare readers for Point, MultiPoint and BoundingBox queries
+    public static func prepareReaders<Domain: MultiDomainMixerDomain>(domains: [Domain], params: ApiQueryParameter, currentTime: Timestamp, forecastDay: Int, forecastDaysMax: Int, pastDaysMax: Int, allowedRange: Range<Timestamp>) throws -> [(locationId: Int, timezone: TimezoneWithOffset, time: ForecastApiTimeRange, perModel: [(domain: Domain, reader: () throws -> (Self?))])] {
+        let options = params.readerOptions
+        let prepared = try params.prepareCoordinates(allowTimezones: true)
+        
+        switch prepared {
+        case .coordinates(let coordinates):
+            return try coordinates.map { prepared in
+                let coordinates = prepared.coordinate
+                let timezone = prepared.timezone
+                let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: forecastDay, forecastDaysMax: forecastDaysMax, startEndDate: prepared.startEndDate, allowedRange: allowedRange, pastDaysMax: pastDaysMax)
+                return (coordinates.locationId, timezone, time, domains.compactMap { domain in
+                    return (domain, {
+                        return try Self.init(domain: domain, lat: coordinates.latitude, lon: coordinates.longitude, elevation: coordinates.elevation, mode: params.cell_selection ?? .land, options: options)
+                    })
+                })
+            }
+        case .boundingBox(let bbox, dates: let dates, timezone: let timezone):
+            return try domains.flatMap ({ domain in
+                guard let grid = domain.genericDomain?.grid else {
+                    throw ForecastapiError.generic(message: "Bounbing box calls not supported for domain \(domain)")
+                }
+                guard let gridpoionts = (grid as? RegularGrid)?.findBox(boundingBox: bbox) else {
+                    throw ForecastapiError.generic(message: "Bounbing box calls not supported for grid of domain \(domain)")
+                }
+                
+                if dates.count == 0 {
+                    let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: forecastDay, forecastDaysMax: forecastDaysMax, startEndDate: nil, allowedRange: allowedRange, pastDaysMax: pastDaysMax)
+                    return gridpoionts.enumerated().map( { (locationId, gridpoint) in
+                        return (locationId, timezone, time, [(domain, { () -> Self? in
+                            guard let reader = try domain.getReader(gridpoint: gridpoint, options: options) else {
+                                return nil
+                            }
+                            return Self.init(domain: domain, reader: [reader])
+                        })])
+                    })
+                }
+                
+                return try dates.flatMap({ date -> [(Int, TimezoneWithOffset, ForecastApiTimeRange, [(Domain, () throws -> Self?)])] in
+                    let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: forecastDay, forecastDaysMax: forecastDaysMax, startEndDate: date, allowedRange: allowedRange, pastDaysMax: pastDaysMax)
+                    let readers = try Self.getReadersFor(domain: domain, box: bbox, options: options)
+                    return gridpoionts.enumerated().map( { (locationId, gridpoint) in
+                        return (locationId, timezone, time, [(domain, { () -> Self? in
+                            guard let reader = try domain.getReader(gridpoint: gridpoint, options: options) else {
+                                return nil
+                            }
+                            return Self.init(domain: domain, reader: [reader])
+                        })])
+                    })
+                })
+            })
+        }
+    }
+    
     func prefetchData(variable: Variable, time: TimerangeDtAndSettings) throws {
         for reader in reader {
             if time.dtSeconds > reader.modelDtSeconds {

--- a/Sources/App/Helper/Reader/GenericReaderMulti.swift
+++ b/Sources/App/Helper/Reader/GenericReaderMulti.swift
@@ -43,7 +43,7 @@ struct GenericReaderMulti<Variable: GenericVariableMixable> {
         self.reader = reader
     }
     
-    public static func getReadersFor(domain: MultiDomainMixerDomain, box: BoundingBoxWGS84, options: GenericReaderOptions) throws -> [Self] {
+    public static func getReadersFor(domain: MultiDomainMixerDomain, box: BoundingBoxWGS84, options: GenericReaderOptions) throws -> [() throws -> (Self)] {
         fatalError()
     }
     

--- a/Sources/App/Helper/Reader/GenericReaderProvider.swift
+++ b/Sources/App/Helper/Reader/GenericReaderProvider.swift
@@ -30,10 +30,10 @@ extension GenericReaderProvider {
         case .boundingBox(let bbox, dates: let dates, timezone: let timezone):
             return try domains.flatMap ({ domain in
                 guard let grid = domain.genericDomain?.grid else {
-                    throw ForecastapiError.generic(message: "Bounbing box calls not supported for domain \(domain)")
+                    throw ForecastapiError.generic(message: "Bounding box calls not supported for domain \(domain)")
                 }
                 guard let gridpoionts = (grid as? RegularGrid)?.findBox(boundingBox: bbox) else {
-                    throw ForecastapiError.generic(message: "Bounbing box calls not supported for grid of domain \(domain)")
+                    throw ForecastapiError.generic(message: "Bounding box calls not supported for grid of domain \(domain)")
                 }
                 
                 if dates.count == 0 {

--- a/Sources/App/Helper/Reader/GenericReaderProvider.swift
+++ b/Sources/App/Helper/Reader/GenericReaderProvider.swift
@@ -1,0 +1,74 @@
+
+
+/// Can generate a reader with an associated domain -> Could be simplified later once all controller use a comon class to pass variables instead of more protocols
+protocol GenericReaderProvider {
+    associatedtype Domain: GenericDomainProvider
+    
+    init?(domain: Domain, lat: Float, lon: Float, elevation: Float, mode: GridSelectionMode, options: GenericReaderOptions) throws
+    
+    init?(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws
+}
+
+extension GenericReaderProvider {
+    /// Prepare readers for Point, MultiPoint and BoundingBox queries
+    public static func prepareReaders(domains: [Domain], params: ApiQueryParameter, currentTime: Timestamp, forecastDay: Int, forecastDaysMax: Int, pastDaysMax: Int, allowedRange: Range<Timestamp>) throws -> [(locationId: Int, timezone: TimezoneWithOffset, time: ForecastApiTimeRange, perModel: [(domain: Domain, reader: () throws -> (Self?))])] {
+        let options = params.readerOptions
+        let prepared = try params.prepareCoordinates(allowTimezones: true)
+        
+        switch prepared {
+        case .coordinates(let coordinates):
+            return try coordinates.map { prepared in
+                let coordinates = prepared.coordinate
+                let timezone = prepared.timezone
+                let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: forecastDay, forecastDaysMax: forecastDaysMax, startEndDate: prepared.startEndDate, allowedRange: allowedRange, pastDaysMax: pastDaysMax)
+                return (coordinates.locationId, timezone, time, domains.compactMap { domain in
+                    return (domain, {
+                        return try Self.init(domain: domain, lat: coordinates.latitude, lon: coordinates.longitude, elevation: coordinates.elevation, mode: params.cell_selection ?? .land, options: options)
+                    })
+                })
+            }
+        case .boundingBox(let bbox, dates: let dates, timezone: let timezone):
+            return try domains.flatMap ({ domain in
+                guard let grid = domain.genericDomain?.grid else {
+                    throw ForecastapiError.generic(message: "Bounbing box calls not supported for domain \(domain)")
+                }
+                guard let gridpoionts = (grid as? RegularGrid)?.findBox(boundingBox: bbox) else {
+                    throw ForecastapiError.generic(message: "Bounbing box calls not supported for grid of domain \(domain)")
+                }
+                
+                if dates.count == 0 {
+                    let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: forecastDay, forecastDaysMax: forecastDaysMax, startEndDate: nil, allowedRange: allowedRange, pastDaysMax: pastDaysMax)
+                    return gridpoionts.enumerated().map( { (locationId, gridpoint) in
+                        return (locationId, timezone, time, [(domain, { () -> Self? in
+                            guard let reader = try Self.init(domain: domain, gridpoint: gridpoint, options: options) else {
+                                return nil
+                            }
+                            return reader
+                        })])
+                    })
+                }
+                
+                return try dates.flatMap({ date -> [(Int, TimezoneWithOffset, ForecastApiTimeRange, [(Domain, () throws -> Self?)])] in
+                    let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: forecastDay, forecastDaysMax: forecastDaysMax, startEndDate: date, allowedRange: allowedRange, pastDaysMax: pastDaysMax)
+                    return gridpoionts.enumerated().map( { (locationId, gridpoint) in
+                        return (locationId, timezone, time, [(domain, { () -> Self? in
+                            guard let reader = try Self.init(domain: domain, gridpoint: gridpoint, options: options) else {
+                                return nil
+                            }
+                            return reader
+                        })])
+                    })
+                })
+            })
+        }
+    }
+}
+
+protocol GenericDomainProvider {
+    var genericDomain: GenericDomain? { get }
+}
+
+extension GenericDomain where Self: GenericDomainProvider {
+    var genericDomain: GenericDomain? { self }
+}
+

--- a/Sources/App/Helper/Reader/GenericReaderProvider.swift
+++ b/Sources/App/Helper/Reader/GenericReaderProvider.swift
@@ -32,13 +32,15 @@ extension GenericReaderProvider {
                 guard let grid = domain.genericDomain?.grid else {
                     throw ForecastapiError.generic(message: "Bounding box calls not supported for domain \(domain)")
                 }
-                guard let gridpoionts = (grid as? RegularGrid)?.findBox(boundingBox: bbox) else {
+                guard let gridpoionts = grid.findBox(boundingBox: bbox) else {
                     throw ForecastapiError.generic(message: "Bounding box calls not supported for grid of domain \(domain)")
                 }
                 
                 if dates.count == 0 {
                     let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: forecastDayDefault, forecastDaysMax: forecastDaysMax, startEndDate: nil, allowedRange: allowedRange, pastDaysMax: pastDaysMax)
-                    return gridpoionts.enumerated().map( { (locationId, gridpoint) in
+                    var locationId = -1
+                    return gridpoionts.map( { gridpoint in
+                        locationId += 1
                         return (locationId, timezone, time, [(domain, { () -> Self? in
                             guard let reader = try Self.init(domain: domain, gridpoint: gridpoint, options: options) else {
                                 return nil
@@ -50,7 +52,9 @@ extension GenericReaderProvider {
                 
                 return try dates.flatMap({ date -> [(Int, TimezoneWithOffset, ForecastApiTimeRange, [(DomainProvider, () throws -> Self?)])] in
                     let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: forecastDayDefault, forecastDaysMax: forecastDaysMax, startEndDate: date, allowedRange: allowedRange, pastDaysMax: pastDaysMax)
-                    return gridpoionts.enumerated().map( { (locationId, gridpoint) in
+                    var locationId = -1
+                    return gridpoionts.map( { gridpoint in
+                        locationId += 1
                         return (locationId, timezone, time, [(domain, { () -> Self? in
                             guard let reader = try Self.init(domain: domain, gridpoint: gridpoint, options: options) else {
                                 return nil

--- a/Sources/App/Helper/Reader/GenericReaderProvider.swift
+++ b/Sources/App/Helper/Reader/GenericReaderProvider.swift
@@ -2,16 +2,16 @@
 
 /// Can generate a reader with an associated domain -> Could be simplified later once all controller use a comon class to pass variables instead of more protocols
 protocol GenericReaderProvider {
-    associatedtype Domain: GenericDomainProvider
+    associatedtype DomainProvider: GenericDomainProvider
     
-    init?(domain: Domain, lat: Float, lon: Float, elevation: Float, mode: GridSelectionMode, options: GenericReaderOptions) throws
+    init?(domain: DomainProvider, lat: Float, lon: Float, elevation: Float, mode: GridSelectionMode, options: GenericReaderOptions) throws
     
-    init?(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws
+    init?(domain: DomainProvider, gridpoint: Int, options: GenericReaderOptions) throws
 }
 
 extension GenericReaderProvider {
     /// Prepare readers for Point, MultiPoint and BoundingBox queries
-    public static func prepareReaders(domains: [Domain], params: ApiQueryParameter, currentTime: Timestamp, forecastDayDefault: Int, forecastDaysMax: Int, pastDaysMax: Int, allowedRange: Range<Timestamp>) throws -> [(locationId: Int, timezone: TimezoneWithOffset, time: ForecastApiTimeRange, perModel: [(domain: Domain, reader: () throws -> (Self?))])] {
+    public static func prepareReaders(domains: [DomainProvider], params: ApiQueryParameter, currentTime: Timestamp, forecastDayDefault: Int, forecastDaysMax: Int, pastDaysMax: Int, allowedRange: Range<Timestamp>) throws -> [(locationId: Int, timezone: TimezoneWithOffset, time: ForecastApiTimeRange, perModel: [(domain: DomainProvider, reader: () throws -> (Self?))])] {
         let options = params.readerOptions
         let prepared = try params.prepareCoordinates(allowTimezones: true)
         
@@ -48,7 +48,7 @@ extension GenericReaderProvider {
                     })
                 }
                 
-                return try dates.flatMap({ date -> [(Int, TimezoneWithOffset, ForecastApiTimeRange, [(Domain, () throws -> Self?)])] in
+                return try dates.flatMap({ date -> [(Int, TimezoneWithOffset, ForecastApiTimeRange, [(DomainProvider, () throws -> Self?)])] in
                     let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: forecastDayDefault, forecastDaysMax: forecastDaysMax, startEndDate: date, allowedRange: allowedRange, pastDaysMax: pastDaysMax)
                     return gridpoionts.enumerated().map( { (locationId, gridpoint) in
                         return (locationId, timezone, time, [(domain, { () -> Self? in

--- a/Sources/App/Icon/IconReader.swift
+++ b/Sources/App/Icon/IconReader.swift
@@ -19,7 +19,7 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
         self.options = options
     }
     
-    public init?(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+    public init(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
         let reader = try GenericReader<Domain, Variable>(domain: domain, position: gridpoint)
         self.reader = GenericReaderCached(reader: reader)
         self.options = options

--- a/Sources/App/Icon/IconReader.swift
+++ b/Sources/App/Icon/IconReader.swift
@@ -19,6 +19,12 @@ struct IconReader: GenericReaderDerived, GenericReaderProtocol {
         self.options = options
     }
     
+    public init?(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+        let reader = try GenericReader<Domain, Variable>(domain: domain, position: gridpoint)
+        self.reader = GenericReaderCached(reader: reader)
+        self.options = options
+    }
+    
     func get(variable: VariableOrDerived<IconVariable, IconVariableDerived>, time: TimerangeDtAndSettings) throws -> DataAndUnit {
         switch variable {
         case .raw(let raw):

--- a/Sources/App/IconWave/IconWaveController.swift
+++ b/Sources/App/IconWave/IconWaveController.swift
@@ -61,7 +61,7 @@ struct IconWaveController {
             let currentTimeRange = TimerangeDt(start: currentTime.floor(toNearest: 3600), nTime: 1, dtSeconds: 3600)
             
             let readers: [ForecastapiResult<IconWaveDomainApi>.PerModel] = try domains.compactMap { domain in
-                guard let reader = try GenericReaderMulti<IconWaveVariable>(domain: domain, lat: coordinates.latitude, lon: coordinates.longitude, elevation: .nan, mode: params.cell_selection ?? .sea, options: params.readerOptions) else {
+                guard let reader = try GenericReaderMulti<IconWaveVariable, IconWaveDomainApi>(domain: domain, lat: coordinates.latitude, lon: coordinates.longitude, elevation: .nan, mode: params.cell_selection ?? .sea, options: params.readerOptions) else {
                     return nil
                 }
                 

--- a/Sources/App/IconWave/IconWaveController.swift
+++ b/Sources/App/IconWave/IconWaveController.swift
@@ -4,11 +4,11 @@ import Vapor
 
 enum IconWaveDomainApi: String, CaseIterable, RawRepresentableString, MultiDomainMixerDomain {
     var genericDomain: (any GenericDomain)? {
-        fatalError()
+        return nil
     }
     
     func getReader(gridpoint: Int, options: GenericReaderOptions) throws -> (any GenericReaderProtocol)? {
-        fatalError()
+        return nil
     }
     
     case best_match
@@ -37,7 +37,6 @@ enum IconWaveDomainApi: String, CaseIterable, RawRepresentableString, MultiDomai
 
 struct IconWaveController {
     func query(_ req: Request) async throws -> Response {
-        /*
         try await req.ensureSubdomain("marine-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         try req.ensureApiKey("marine-api", apikey: params.apikey)
@@ -45,6 +44,9 @@ struct IconWaveController {
         let allowedRange = Timestamp(1940, 1, 1) ..< currentTime.add(86400 * 11)
         
         let prepared = try params.prepareCoordinates(allowTimezones: true)
+        guard case .coordinates(let prepared) = prepared else {
+            throw ForecastapiError.generic(message: "Bounding box not supported")
+        }
         let domains = try IconWaveDomainApi.load(commaSeparatedOptional: params.models) ?? [.best_match]
         let paramsHourly = try IconWaveVariable.load(commaSeparatedOptional: params.hourly)
         let paramsCurrent = try IconWaveVariable.load(commaSeparatedOptional: params.current)
@@ -122,8 +124,7 @@ struct IconWaveController {
         }
         let result = ForecastapiResult<IconWaveDomainApi>(timeformat: params.timeformatOrDefault, results: locations)
         await req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))
-        return try await result.response(format: params.format ?? .json)*/
-        fatalError()
+        return try await result.response(format: params.format ?? .json)
     }
 }
 

--- a/Sources/App/IconWave/IconWaveController.swift
+++ b/Sources/App/IconWave/IconWaveController.swift
@@ -3,6 +3,14 @@ import Vapor
 
 
 enum IconWaveDomainApi: String, CaseIterable, RawRepresentableString, MultiDomainMixerDomain {
+    var genericDomain: (any GenericDomain)? {
+        fatalError()
+    }
+    
+    func getReader(gridpoint: Int, options: GenericReaderOptions) throws -> (any GenericReaderProtocol)? {
+        fatalError()
+    }
+    
     case best_match
     case ewam
     case gwam

--- a/Sources/App/IconWave/IconWaveController.swift
+++ b/Sources/App/IconWave/IconWaveController.swift
@@ -29,6 +29,7 @@ enum IconWaveDomainApi: String, CaseIterable, RawRepresentableString, MultiDomai
 
 struct IconWaveController {
     func query(_ req: Request) async throws -> Response {
+        /*
         try await req.ensureSubdomain("marine-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         try req.ensureApiKey("marine-api", apikey: params.apikey)
@@ -113,7 +114,8 @@ struct IconWaveController {
         }
         let result = ForecastapiResult<IconWaveDomainApi>(timeformat: params.timeformatOrDefault, results: locations)
         await req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))
-        return try await result.response(format: params.format ?? .json)
+        return try await result.response(format: params.format ?? .json)*/
+        fatalError()
     }
 }
 

--- a/Sources/App/MetNo/MetNoController.swift
+++ b/Sources/App/MetNo/MetNoController.swift
@@ -22,6 +22,12 @@ struct MetNoReader: GenericReaderDerivedSimple, GenericReaderProtocol {
         self.options = options
     }
     
+    public init(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+        let reader = try GenericReader<Domain, Variable>(domain: domain, position: gridpoint)
+        self.reader = GenericReaderCached(reader: reader)
+        self.options = options
+    }
+    
     func prefetchData(derived: MetNoVariableDerived, time: TimerangeDtAndSettings) throws {
         switch derived {
         case .apparent_temperature:

--- a/Sources/App/MeteoFrance/MeteoFranceController.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceController.swift
@@ -139,6 +139,12 @@ struct MeteoFranceReader: GenericReaderDerived, GenericReaderProtocol {
         self.options = options
     }
     
+    public init(domain: Domain, gridpoint: Int, options: GenericReaderOptions) throws {
+        let reader = try GenericReader<Domain, Variable>(domain: domain, position: gridpoint)
+        self.reader = GenericReaderCached(reader: reader)
+        self.options = options
+    }
+    
     func get(raw: MeteoFranceVariable, time: TimerangeDtAndSettings) throws -> DataAndUnit {
         return try reader.get(variable: raw, time: time)
     }

--- a/Sources/App/SeasonalForecast/SeasonalForecastController.swift
+++ b/Sources/App/SeasonalForecast/SeasonalForecastController.swift
@@ -148,6 +148,7 @@ extension SeasonalForecastReader {
  */
 struct SeasonalForecastController {
     func query(_ req: Request) async throws -> Response {
+        /*
         try await req.ensureSubdomain("seasonal-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         try req.ensureApiKey("seasonal-api", apikey: params.apikey)
@@ -243,7 +244,8 @@ struct SeasonalForecastController {
         }
         let result = ForecastapiResult<SeasonalForecastDomainApi>(timeformat: params.timeformatOrDefault, results: locations)
         await req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))
-        return try await result.response(format: params.format ?? .json)
+        return try await result.response(format: params.format ?? .json)*/
+        fatalError()
     }
 }
 

--- a/Sources/App/SeasonalForecast/SeasonalForecastController.swift
+++ b/Sources/App/SeasonalForecast/SeasonalForecastController.swift
@@ -148,7 +148,6 @@ extension SeasonalForecastReader {
  */
 struct SeasonalForecastController {
     func query(_ req: Request) async throws -> Response {
-        /*
         try await req.ensureSubdomain("seasonal-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         try req.ensureApiKey("seasonal-api", apikey: params.apikey)
@@ -156,6 +155,9 @@ struct SeasonalForecastController {
         let allowedRange = Timestamp(2022, 6, 8) ..< currentTime.add(86400 * 400)
         
         let prepared = try params.prepareCoordinates(allowTimezones: false)
+        guard case .coordinates(let prepared) = prepared else {
+            throw ForecastapiError.generic(message: "Bounding box not supported")
+        }
         /// Will be configurable by API later
         let domains = [SeasonalForecastDomainApi.cfsv2]
         
@@ -244,8 +246,7 @@ struct SeasonalForecastController {
         }
         let result = ForecastapiResult<SeasonalForecastDomainApi>(timeformat: params.timeformatOrDefault, results: locations)
         await req.incrementRateLimiter(weight: result.calculateQueryWeight(nVariablesModels: nVariables))
-        return try await result.response(format: params.format ?? .json)*/
-        fatalError()
+        return try await result.response(format: params.format ?? .json)
     }
 }
 

--- a/Tests/AppTests/DomainTests.swift
+++ b/Tests/AppTests/DomainTests.swift
@@ -13,8 +13,8 @@ final class DomainTests: XCTestCase {
         XCTAssertTrue(RegularGridSlice(grid: grid, yRange: 1..<1, xRange: 4..<6).map{$0}.isEmpty)
         
         let slice = grid.findBox(boundingBox: BoundingBoxWGS84(latitude: 10.4..<10.6, longitude: 10.7..<10.9)) as! RegularGridSlice
-        XCTAssertEqual(slice.yRange, 4..<5)
-        XCTAssertEqual(slice.xRange, 7..<8)
-        XCTAssertEqual(slice.map{$0}, [14, 15, 24, 25])
+        XCTAssertEqual(slice.yRange, 4..<6)
+        XCTAssertEqual(slice.xRange, 7..<9)
+        XCTAssertEqual(slice.map{$0}, [47, 48, 57, 58])
     }
 }

--- a/Tests/AppTests/DomainTests.swift
+++ b/Tests/AppTests/DomainTests.swift
@@ -5,5 +5,16 @@ import XCTest
 
 
 final class DomainTests: XCTestCase {
-    
+    func testRegularGridSlice() {
+        let grid = RegularGrid(nx: 10, ny: 10, latMin: 10, lonMin: 10, dx: 0.1, dy: 0.1)
+        let sub = RegularGridSlice(grid: grid, yRange: 1..<3, xRange: 4..<6)
+        XCTAssertEqual(sub.map{$0}, [14, 15, 24, 25])
+        XCTAssertTrue(RegularGridSlice(grid: grid, yRange: 1..<3, xRange: 4..<4).map{$0}.isEmpty)
+        XCTAssertTrue(RegularGridSlice(grid: grid, yRange: 1..<1, xRange: 4..<6).map{$0}.isEmpty)
+        
+        let slice = grid.findBox(boundingBox: BoundingBoxWGS84(latitude: 10.4..<10.6, longitude: 10.7..<10.9)) as! RegularGridSlice
+        XCTAssertEqual(slice.yRange, 4..<5)
+        XCTAssertEqual(slice.xRange, 7..<8)
+        XCTAssertEqual(slice.map{$0}, [14, 15, 24, 25])
+    }
 }

--- a/Tests/AppTests/IntrinsicsTests.swift
+++ b/Tests/AppTests/IntrinsicsTests.swift
@@ -1,0 +1,14 @@
+import Foundation
+@testable import App
+import XCTest
+
+/// Test low level stuff
+final class IntrinsicsTests: XCTestCase {
+    func test2DSequence() async {
+        let seq2d = (1..<3).iterate2D(over: 10..<12)
+        let res = seq2d.map({ "\($0)" })
+        XCTAssertEqual(res, ["(y: 1, x: 10)", "(y: 1, x: 11)", "(y: 2, x: 10)", "(y: 2, x: 11)"])
+        XCTAssertTrue((0..<10).iterate2D(over: 0..<0).map{"\($0)"}.isEmpty)
+        XCTAssertTrue((0..<0).iterate2D(over: 0..<10).map{"\($0)"}.isEmpty)
+    }
+}


### PR DESCRIPTION
Limited support to get forecasts for a bounding box. Does not support combinations of multiple domains (best_match / seamless).

URL parameter: `&bounding_box=47,-85,47.5,-84.5` (latitude1, longitude1, latitude2, longitude2). 

Selects all grid-cells within the specified box, however, the right and top edge will be excluded. E.g. A latitude-range of `40°..<45°` would not include any grid-points on the 45° edge. This is important to make multiple API calls to get combine larger areas. The following API call can then get data from `45°..<50°` latitude. 

For non-regular projections, a larger box that contains more coordinates than initially requested might be returned.

The response format is the same as multiple single coordinate calls: An array of JSON objects or FlatBuffer messages. 

The underlaying database is optimised for time-series data and trying to create a map is the worst case performance scenario. Bounding box API calls will weighted by the number of included grid-cells. Maybe at some point in the future, an additional database "view" optimised for spatial API queries will be added to better support use-cases like maps.

Examples
- HRRR: /v1/forecast?hourly=temperature_2m&models=gfs_hrrr&bounding_box=47,-85,47.5,-84.5
- GFS025 pressure level data: /v1/forecast?hourly=temperature_850hPa&models=gfs025&bounding_box=47,-85,47.5,-84.5
- CAMS Europe air quality: /v1/air-quality?hourly=pm10&models=cams_europe&bounding_box=47,5,48,6