### PR TITLE
New MeteoFrance API to access GRIB files as packages again

### DIFF
--- a/Sources/App/Helper/Download/Curl+Grib.swift
+++ b/Sources/App/Helper/Download/Curl+Grib.swift
@@ -54,7 +54,7 @@ extension Curl {
     }
     
     /// Stream GRIB messages. The grib stream might be restarted on error.
-    func withGribStream<T>(url: String, bzip2Decode: Bool, range: String? = nil, minSize: Int? = nil, nConcurrent: Int = 1, deadLineHours: Double? = nil, body: (AnyAsyncSequence<GribMessage>) async throws -> (T)) async throws -> T {
+    func withGribStream<T>(url: String, bzip2Decode: Bool, range: String? = nil, minSize: Int? = nil, nConcurrent: Int = 1, deadLineHours: Double? = nil, headers: [(String, String)] = [], body: (AnyAsyncSequence<GribMessage>) async throws -> (T)) async throws -> T {
         let deadline = deadLineHours.map { Date().addingTimeInterval(TimeInterval($0 * 3600)) } ?? deadline
         let timeout = TimeoutTracker(logger: logger, deadline: deadline)
         
@@ -73,7 +73,7 @@ extension Curl {
         
         while true {
             // Start the download and wait for the header
-            let response = try await initiateDownload(url: url, range: range, minSize: minSize, deadline: deadline, nConcurrent: nConcurrent, waitAfterLastModifiedBeforeDownload: waitAfterLastModifiedBeforeDownload)
+            let response = try await initiateDownload(url: url, range: range, minSize: minSize, deadline: deadline, nConcurrent: nConcurrent, waitAfterLastModifiedBeforeDownload: waitAfterLastModifiedBeforeDownload, headers: headers)
             
             // Retry failed file transfers after this point
             do {

--- a/Sources/App/Helper/InterpolationInplace.swift
+++ b/Sources/App/Helper/InterpolationInplace.swift
@@ -297,8 +297,8 @@ extension Array where Element == Float {
 
                 /// clearness index at point C. At low radiation levels it is impossible to estimate KT indices, set to NaN
                 var ktC = solC <= 0.005 ? .nan : Swift.min(C / solC, 1100)
-                /// Clearness index at point B, or use `ktC` for low radiation levels
-                var ktB = solB <= 0.005 ? ktC : Swift.min(B / solB, 1100)
+                /// Clearness index at point B, or use `ktC` for low radiation levels. B could be NaN if data is immediately missing in the bedinning of a time-series
+                var ktB = solB <= 0.005 || B.isNaN ? ktC : Swift.min(B / solB, 1100)
                 if ktC.isNaN && ktB > 0 {
                     ktC = ktB
                 }
@@ -311,7 +311,8 @@ extension Array where Element == Float {
                     let posA = posB - width
                     /// Solar factor for point A is already deaveraged unlike point C and D
                     let solA = solar2d[sPos, posA - sLow]
-                    ktA = solA <= 0.005 ? ktB : Swift.min(self[l * nTime + posA] / solA, 1100)
+                    let A = self[l * nTime + posA]
+                    ktA = solA <= 0.005 || A.isNaN ? ktB : Swift.min(A / solA, 1100)
                 }
 
                 if ktC.isNaN && ktA > 0 {

--- a/Sources/App/Helper/Writer/GenericVariableHandle.swift
+++ b/Sources/App/Helper/Writer/GenericVariableHandle.swift
@@ -182,7 +182,7 @@ actor VariablePerMemberStorage<V: Hashable> {
 
 /// Keep values from previous timestep. Actori isolated, because of concurrent data conversion
 actor GribDeaverager {
-    var data = [String: (step: Int, data: [Float])]()
+    var data: [String: (step: Int, data: [Float])]
     
     /// Set new value and get previous value out
     func set(variable: GenericVariable, member: Int, step: Int, data d: [Float]) -> (step: Int, data: [Float])? {
@@ -190,6 +190,15 @@ actor GribDeaverager {
         let previous = data[key]
         data[key] = (step, d)
         return previous
+    }
+    
+    /// Make a deep copy
+    func copy() -> GribDeaverager {
+        return .init(data: data)
+    }
+    
+    public init(data: [String : (step: Int, data: [Float])] = [String: (step: Int, data: [Float])]()) {
+        self.data = data
     }
     
     /// Returns false if step should be skipped

--- a/Sources/App/Helper/Writer/GenericVariableHandle.swift
+++ b/Sources/App/Helper/Writer/GenericVariableHandle.swift
@@ -205,7 +205,7 @@ actor GribDeaverager {
     func deaccumulateIfRequired(variable: GenericVariable, member: Int, stepType: String, stepRange: String, grib2d: inout GribArray2D) async -> Bool {
         // Deaccumulate precipitation
         if stepType == "accum" {
-            guard let (startStep, currentStep) = stepRange.splitTo2Integer() else {
+            guard let (startStep, currentStep) = stepRange.splitTo2Integer(), startStep != currentStep else {
                 return false
             }
             // Store data for next timestep
@@ -220,7 +220,7 @@ actor GribDeaverager {
         
         // Deaverage data
         if stepType == "avg" {
-            guard let (startStep, currentStep) = stepRange.splitTo2Integer() else {
+            guard let (startStep, currentStep) = stepRange.splitTo2Integer(), startStep != currentStep else {
                 return false
             }
             // Store data for next timestep

--- a/Sources/App/MeteoFrance/MeteoFranceDomain.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDomain.swift
@@ -115,10 +115,83 @@ enum MeteoFranceDomain: String, GenericDomain, CaseIterable {
         }
     }
     
+    var mfApiGridName: String {
+        switch self {
+        case .arpege_europe:
+            return "0.1"
+        case .arpege_world:
+            return "0.25"
+        case .arome_france:
+            return "0.025"
+        case .arome_france_hd:
+            return "0.01"
+        case .arome_france_15min:
+            return ""
+        case .arome_france_hd_15min:
+            return ""
+        }
+    }
+    
+    var mfApiPackageTimes: [String] {
+        switch self {
+        case .arpege_europe:
+            return ["000H012H", "013H024H", "025H036H", "025H036H", "049H060H", "061H072H", "073H084H", "085H096H", "097H102H"]
+        case .arpege_world:
+            return ["000H024H", "025H048H", "049H072H", "073H102H"]
+        case .arome_france:
+            return ["00H06H","07H12H","13H18H","19H24H","25H30H","31H36H","37H42H","43H48H","49H51H"]
+        case .arome_france_hd:
+            return (0...51).map{"\($0.zeroPadded(len: 2))H"}
+        case .arome_france_15min:
+            return []
+        case .arome_france_hd_15min:
+            return []
+        }
+    }
+    
+    var mfApiPackagesSurface: [String] {
+        switch self {
+        case .arpege_europe:
+            return []
+        case .arpege_world:
+            return []
+        case .arome_france:
+            return ["SP1", "SP2", "SP3", "HP1"] // "IP1"
+        case .arome_france_hd:
+            return ["SP1", "SP2", "HP1"]
+        case .arome_france_15min:
+            return []
+        case .arome_france_hd_15min:
+            return []
+        }
+    }
+    
     enum Family: String {
         case arpege
         case arome
         case aromepi
+        
+        var mfApiDDP: String {
+            switch self {
+            case .arpege:
+                return "ARPAGE"
+            case .arome:
+                return "AROME"
+            case .aromepi:
+                return ""
+            }
+        }
+        
+        var mfApiProductName: String {
+            switch self {
+            case .arpege:
+                return "productARP"
+            case .arome:
+                return "productARO"
+            case .aromepi:
+                return ""
+            }
+        }
     }
     
     var family: Family {

--- a/Sources/App/MeteoFrance/MeteoFranceDomain.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDomain.swift
@@ -151,14 +151,29 @@ enum MeteoFranceDomain: String, GenericDomain, CaseIterable {
     
     var mfApiPackagesSurface: [String] {
         switch self {
-        case .arpege_europe:
-            return []
-        case .arpege_world:
-            return []
+        case .arpege_europe, .arpege_world:
+            return ["SP1", "SP2", "HP1"]
         case .arome_france:
             return ["SP1", "SP2", "SP3", "HP1"] // "IP1"
         case .arome_france_hd:
             return ["SP1", "SP2", "HP1"]
+        case .arome_france_15min:
+            return []
+        case .arome_france_hd_15min:
+            return []
+        }
+    }
+    
+    var mfApiPackagesPressure: [String] {
+        switch self {
+        case .arpege_europe:
+            return ["IP1"]
+        case .arpege_world:
+            return ["IP1"]
+        case .arome_france:
+            return ["IP1"]
+        case .arome_france_hd:
+            return []
         case .arome_france_15min:
             return []
         case .arome_france_hd_15min:
@@ -174,7 +189,7 @@ enum MeteoFranceDomain: String, GenericDomain, CaseIterable {
         var mfApiDDP: String {
             switch self {
             case .arpege:
-                return "ARPAGE"
+                return "ARPEGE"
             case .arome:
                 return "AROME"
             case .aromepi:

--- a/Sources/App/MeteoFrance/MeteoFranceDomain.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDomain.swift
@@ -146,7 +146,7 @@ enum MeteoFranceDomain: String, GenericDomain, CaseIterable {
     var mfApiPackageTimes: [String] {
         switch self {
         case .arpege_europe:
-            return ["000H012H", "013H024H", "025H036H", "025H036H", "049H060H", "061H072H", "073H084H", "085H096H", "097H102H"]
+            return ["000H012H", "013H024H", "025H036H", "037H048H", "049H060H", "061H072H", "073H084H", "085H096H", "097H102H"]
         case .arpege_world:
             return ["000H024H", "025H048H", "049H072H", "073H102H"]
         case .arome_france:

--- a/Sources/App/MeteoFrance/MeteoFranceDomain.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDomain.swift
@@ -154,7 +154,7 @@ enum MeteoFranceDomain: String, GenericDomain, CaseIterable {
         case .arpege_europe, .arpege_world:
             return ["SP1", "SP2", "HP1"]
         case .arome_france:
-            return ["SP1", "SP2", "SP3", "HP1"] // "IP1"
+            return ["SP1", "SP2", "SP3", "HP1"]
         case .arome_france_hd:
             return ["SP1", "SP2", "HP1"]
         case .arome_france_15min:

--- a/Sources/App/MeteoFrance/MeteoFranceDomain.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDomain.swift
@@ -98,6 +98,17 @@ enum MeteoFranceDomain: String, GenericDomain, CaseIterable {
         }
     }
     
+    var timeoutHours: Double {
+        switch self {
+        case .arpege_europe, .arpege_world:
+            return 5.5
+        case .arome_france, .arome_france_hd:
+            return 2.5
+        case .arome_france_15min, .arome_france_hd_15min:
+            return 1.5
+        }
+    }
+    
     var mfApiName: String {
         switch self {
         case .arpege_europe:

--- a/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
@@ -137,8 +137,8 @@ struct MeteoFranceDownload: AsyncCommand {
             fatalError("Please specify environment variable 'METEOFRANCE_API_KEY'")
         }
         let logger = application.logger
-        let deadLineHours: Double = 5.5
-        Process.alarm(seconds: Int(deadLineHours+1) * 3600)
+        let deadLineHours = domain.timeoutHours
+        Process.alarm(seconds: Int(deadLineHours+0.5) * 3600)
         defer { Process.alarm(seconds: 0) }
         
         let grid = domain.grid
@@ -323,7 +323,7 @@ struct MeteoFranceDownload: AsyncCommand {
             fatalError("Please specify environment variable 'METEOFRANCE_API_KEY'")
         }
         let logger = application.logger
-        let deadLineHours: Double = 5.5
+        let deadLineHours = domain.timeoutHours
         Process.alarm(seconds: Int(deadLineHours+1) * 3600)
         defer { Process.alarm(seconds: 0) }
         

--- a/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
@@ -108,7 +108,193 @@ struct MeteoFranceDownload: AsyncCommand {
         try OmFileWriter(dim0: domain.grid.ny, dim1: domain.grid.nx, chunk0: 20, chunk1: 20).write(file: surfaceElevationFileOm, compressionType: .p4nzdec256, scalefactor: 1, all: grib2d.array.data)
     }
     
+    func download3(application: Application, domain: MeteoFranceDomain, run: Timestamp, variables: [MeteoFranceVariableDownloadable], concurrent: Int) async throws -> [GenericVariableHandle] {
+        guard let apikey = Environment.get("METEOFRANCE_API_KEY")?.split(separator: ",").map(String.init) else {
+            fatalError("Please specify environment variable 'METEOFRANCE_API_KEY'")
+        }
+        let logger = application.logger
+        let deadLineHours: Double = 5.5
+        Process.alarm(seconds: Int(deadLineHours+1) * 3600)
+        defer { Process.alarm(seconds: 0) }
+        
+        let grid = domain.grid
+        var grib2d = GribArray2D(nx: grid.nx, ny: grid.ny)
+        
+        let nLocationsPerChunk = OmFileSplitter(domain).nLocationsPerChunk
+        let writer = OmFileWriter(dim0: 1, dim1: grid.count, chunk0: 1, chunk1: nLocationsPerChunk)
+        var handles = [GenericVariableHandle]()
+        
+        let previous = GribDeaverager()
+        
+        let packages = ["IP1"]//"SP1", "SP2", "SP3", "HP1"]
+        let packageTimes = ["00H06H","07H12H","13H18H","19H24H","25H30H","31H36H","37H42H","43H48H","49H51H"]
+        //https://public-api.meteofrance.fr/previnum/DPPaquetAROME/v1/models/AROME/grids/0.025/packages/SP2/productARO?referencetime=2024-06-20T21%3A00%3A00Z&time=00H06H&format=grib2
+        
+        for packageTime in packageTimes {
+            for package in packages {
+                let url = "https://public-api.meteofrance.fr/previnum/DPPaquetAROME/v1/models/AROME/grids/0.025/packages/\(package)/productARO?referencetime=\(run.iso8601_YYYY_MM_dd_HH_mm):00Z&time=\(packageTime)&format=grib2"
+                
+                /// MeteoFrance servers close the HTTP connection unclean, resulting in `connection reset by peer` errors
+                /// Use a new HTTP client with new connections for every request
+                let client = application.makeNewHttpClient()
+                let curl = Curl(logger: logger, client: client, deadLineHours: deadLineHours, waitAfterLastModified: TimeInterval(2*60))
+                let h = try await curl.withGribStream(url: url, bzip2Decode: false, headers: [("apikey", apikey.randomElement() ?? "")]) { stream in
+                    return stream.mapStream(nConcurrent: concurrent) { message -> GenericVariableHandle? in
+                        guard let shortName = message.get(attribute: "shortName"),
+                              let stepRange = message.get(attribute: "stepRange"),
+                              let stepType = message.get(attribute: "stepType"),
+                              let levelStr = message.get(attribute: "level"),
+                              let typeOfLevel = message.get(attribute: "typeOfLevel"),
+                              let parameterName = message.get(attribute: "parameterName"),
+                              let parameterUnits = message.get(attribute: "parameterUnits"),
+                              let validityTime = message.get(attribute: "validityTime"),
+                              let validityDate = message.get(attribute: "validityDate")
+                        else {
+                            fatalError("could not get attributes")
+                        }
+                        let timestamp = try Timestamp.from(yyyymmdd: "\(validityDate)\(Int(validityTime)!.zeroPadded(len: 4))")
+                        guard let variable = getVariable(shortName: shortName, levelStr: levelStr, parameterName: parameterName, typeOfLevel: typeOfLevel) else {
+                            logger.warning("Unmapped GRIB message \(shortName) level=\(levelStr) [\(typeOfLevel)] \(stepRange) \(stepType) '\(parameterName)' \(parameterUnits)")
+                            return nil
+                        }
+                        
+                        let writer = OmFileWriter(dim0: 1, dim1: domain.grid.count, chunk0: 1, chunk1: nLocationsPerChunk)
+                        var grib2d = GribArray2D(nx: domain.grid.nx, ny: domain.grid.ny)
+                        //message.dumpAttributes()
+                        try grib2d.load(message: message)
+                        if domain.isGlobal {
+                            grib2d.array.shift180LongitudeAndFlipLatitude()
+                        } else {
+                            grib2d.array.flipLatitude()
+                        }
+                        
+                        // Scaling before compression with scalefactor
+                        if let fma = variable.multiplyAdd {
+                            grib2d.array.data.multiplyAdd(multiply: fma.multiply, add: fma.add)
+                        }
+                        
+                        // Deaccumulate precipitation
+                        guard await previous.deaccumulateIfRequired(variable: variable, member: 0, stepType: stepType, stepRange: stepRange, grib2d: &grib2d) else {
+                            return nil
+                        }
+                        
+                        logger.info("Compressing and writing data to \(timestamp.format_YYYYMMddHH) \(variable)")
+                        let fn = try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: variable.scalefactor, all: grib2d.array.data)
+                        return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn, skipHour0: stepType == "accum" || stepType == "avg")
+                    }
+                }.collect().compactMap({$0})
+                handles.append(contentsOf: h)
+            }
+        }
+        //await curl.printStatistics()
+        return handles
+    }
+    
+    func getVariable(shortName: String, levelStr: String, parameterName: String, typeOfLevel: String) -> MeteoFranceVariableDownloadable? {
+        
+        switch (parameterName, levelStr) {
+        case ("Total cloud cover", "0"):
+            return MeteoFranceSurfaceVariable.cloud_cover
+        default:
+            break
+        }
+        
+        if typeOfLevel == "isobaricInhPa" {
+            guard let level = Int(levelStr) else {
+                fatalError("Could not parse level str \(levelStr)")
+            }
+            switch shortName {
+            case "t":
+                return MeteoFrancePressureVariable(variable: .temperature, level: level)
+            case "u":
+                return MeteoFrancePressureVariable(variable: .wind_u_component, level: level)
+            case "v":
+                return MeteoFrancePressureVariable(variable: .wind_v_component, level: level)
+            case "r":
+                return MeteoFrancePressureVariable(variable: .relative_humidity, level: level)
+            case "z":
+                return MeteoFrancePressureVariable(variable: .geopotential_height, level: level)
+            default:
+                break
+            }
+        }
+        
+        switch (shortName, typeOfLevel, levelStr) {
+        case ("t", "heightAboveGround", "20"):
+            return MeteoFranceSurfaceVariable.temperature_20m
+        case ("t", "heightAboveGround", "50"):
+            return MeteoFranceSurfaceVariable.temperature_50m
+        case ("t", "heightAboveGround", "100"):
+            return MeteoFranceSurfaceVariable.temperature_100m
+        case ("t", "heightAboveGround", "150"):
+            return MeteoFranceSurfaceVariable.temperature_150m
+        case ("t", "heightAboveGround", "200"):
+            return MeteoFranceSurfaceVariable.temperature_200m
+        case ("u", "heightAboveGround", "20"):
+            return MeteoFranceSurfaceVariable.wind_u_component_20m
+        case ("u", "heightAboveGround", "50"):
+            return MeteoFranceSurfaceVariable.wind_u_component_50m
+        case ("100u", "heightAboveGround", "100"):
+            return MeteoFranceSurfaceVariable.wind_u_component_100m
+        case ("u", "heightAboveGround", "150"):
+            return MeteoFranceSurfaceVariable.wind_u_component_150m
+        case ("200u", "heightAboveGround", "200"):
+            return MeteoFranceSurfaceVariable.wind_u_component_200m
+        case ("v", "heightAboveGround", "20"):
+            return MeteoFranceSurfaceVariable.wind_v_component_20m
+        case ("v", "heightAboveGround", "50"):
+            return MeteoFranceSurfaceVariable.wind_v_component_50m
+        case ("100v", "heightAboveGround", "100"):
+            return MeteoFranceSurfaceVariable.wind_v_component_100m
+        case ("v", "heightAboveGround", "150"):
+            return MeteoFranceSurfaceVariable.wind_v_component_150m
+        case ("200v", "heightAboveGround", "200"):
+            return MeteoFranceSurfaceVariable.wind_v_component_200m
+            
+        default:
+            break
+        }
+        
+        switch (shortName, levelStr) {
+        case ("2t", "2"):
+            return MeteoFranceSurfaceVariable.temperature_2m
+        case ("2r", "2"):
+            return MeteoFranceSurfaceVariable.relative_humidity_2m
+        case ("tp", "0"):
+            return MeteoFranceSurfaceVariable.precipitation
+        case ("prmsl", "0"):
+              return MeteoFranceSurfaceVariable.pressure_msl
+        case ("10v", "10"):
+              return MeteoFranceSurfaceVariable.wind_v_component_10m
+        case ("10u", "10"):
+              return MeteoFranceSurfaceVariable.wind_u_component_10m
+        case ("clct", "0"):
+              return MeteoFranceSurfaceVariable.cloud_cover
+        case ("snow_gsp", "0"):
+              return MeteoFranceSurfaceVariable.snowfall_water_equivalent
+        case ("10fg", "10"):
+            return MeteoFranceSurfaceVariable.wind_gusts_10m
+        case ("ssrd", "0"):
+            return MeteoFranceSurfaceVariable.shortwave_radiation
+        case ("lcc", "0"):
+            return MeteoFranceSurfaceVariable.cloud_cover_low
+        case ("mcc", "0"):
+            return MeteoFranceSurfaceVariable.cloud_cover_mid
+        case ("hcc", "0"):
+            return MeteoFranceSurfaceVariable.cloud_cover_high
+        case ("CAPE_INS", "0"):
+            return MeteoFranceSurfaceVariable.cape
+        case ("tsnowp", "0"):
+            return MeteoFranceSurfaceVariable.snowfall_water_equivalent
+        default: return nil
+        }
+    }
+    
     func download2(application: Application, domain: MeteoFranceDomain, run: Timestamp, variables: [MeteoFranceVariableDownloadable]) async throws -> [GenericVariableHandle] {
+        if [MeteoFranceDomain.arome_france].contains(domain) {
+            return try await download3(application: application, domain: domain, run: run, variables: variables, concurrent: 4)
+        }
+        
         guard let apikey = Environment.get("METEOFRANCE_API_KEY")?.split(separator: ",").map(String.init) else {
             fatalError("Please specify environment variable 'METEOFRANCE_API_KEY'")
         }

--- a/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
@@ -230,6 +230,9 @@ struct MeteoFranceDownload: AsyncCommand {
             guard let level = Int(levelStr) else {
                 fatalError("Could not parse level str \(levelStr)")
             }
+            if level < 10 {
+                return nil
+            }
             switch shortName {
             case "t":
                 return MeteoFrancePressureVariable(variable: .temperature, level: level)

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -51,14 +51,13 @@ extension Application {
     }
     
     /// Create a new HTTP client instance. `shutdown` must be called after using it
-    func makeNewHttpClient() -> HTTPClient {
+    func makeNewHttpClient(httpVersion: HTTPClient.Configuration.HTTPVersion = .automatic) -> HTTPClient {
         // try again with very high timeouts, so only the curl internal timers are used
-        let configuration = HTTPClient.Configuration(
+        var configuration = HTTPClient.Configuration(
             redirectConfiguration: .follow(max: 5, allowCycles: false),
             timeout: .init(connect: .seconds(30), read: .minutes(5)),
             connectionPool: .init(idleTimeout: .minutes(10)))
-        // NCEP server still struggle with H2
-        //configuration.httpVersion = .http1Only
+        configuration.httpVersion = httpVersion
         
         return HTTPClient(
             eventLoopGroupProvider: .shared(eventLoopGroup),

--- a/Tests/AppTests/ArrayTests.swift
+++ b/Tests/AppTests/ArrayTests.swift
@@ -83,7 +83,7 @@ final class ArrayTests: XCTestCase {
         // this location is exactly at a point where sofac is diverging to 0 on the first step to interpolate
         let coords = IconDomains.icon.grid.getCoordinates(gridpoint: 1256 + 2879 * 1132)
         let grid = RegularGrid(nx: 1, ny: 1, latMin: coords.latitude, lonMin: coords.longitude, dx: 1, dy: 1)
-        let time = TimerangeDt(start: Timestamp(2022,08,16), nTime: data.count, dtSeconds: 3600)
+        var time = TimerangeDt(start: Timestamp(2022,08,16), nTime: data.count, dtSeconds: 3600)
         data.interpolateInplaceSolarBackwards(skipFirst: 1, time: time, grid: grid, locationRange: 0..<1)
         
         XCTAssertEqualArray(data[79..<181], [2.7751129, 12.565333, 29.92181, 68.30576, 131.8756, 208.47153, 294.43616, 375.1984, 409.64493, 379.91507, 308.65784, 221.19334, 128.86157, 52.262794, 9.649313, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.114281915, 0.58105505, 1.2083836, 2.049771, 3.058337, 3.6581643, 3.113253, 1.8148575, 0.87113553, 0.9296356, 1.2847356, 1.2012333, 0.62843615, 0.14723891, 0.0017813047, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.024401145, 0.0, 3.7263098, 48.388783, 136.54715, 215.34631, 230.58772, 197.1857, 151.3438, 107.45953, 63.816956, 32.818916, 16.335684, 7.1231337, 1.4328097, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.870412, 13.837922, 38.44829, 115.605644, 251.0613, 378.11237, 428.5317, 416.82214, 379.8396, 334.78162, 273.56696, 201.93892, 125.62505, 57.04836, 11.268686, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 6.6770487, 39.30699, 84.17851, 133.38658, 185.12206, 228.63828], accuracy: 0.001)
@@ -94,6 +94,11 @@ final class ArrayTests: XCTestCase {
         data.interpolateInplaceSolarBackwards(skipFirst: 1, time: time, grid: grid, locationRange: 0..<1)
         XCTAssertEqualArray(data[79..<181], [2.7751129, 12.565333, 29.92181, 68.30576, 131.8756, 208.47153, 294.43616, 375.1984, 409.64493, 379.91507, 308.65784, 221.19334, 128.86157, 52.262794, 9.649313, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.114281915, 0.58105505, 1.2083836, 2.049771, 3.058337, 3.6581643, 3.113253, 1.8148575, 0.87113553, 0.9296356, 1.2847356, 1.2012333, 0.62843615, 0.14723891, 0.0017813047, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.024401145, 0.0, 3.7263098, 48.388783, 136.54715, 215.34631, 230.58772, 197.1857, 151.3438, 107.45953, 63.816956, 32.818916, 16.335684, 7.1231337, 1.4328097, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.024332, 67.70339, 140.62544, 208.97667, 268.2166, 314.4697, 346.27148, 361.9829, 358.3321, 333.28455, 287.1204, 223.18909, 147.80145, 71.60986, 14.433392, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 7.8246827, 46.422653, 97.88847, 146.12347, 187.83421, 220.17207], accuracy: 0.001)
         
+        /// Immediately 3 hourly data. Note: the left-most values only rely on the clearness index of the first point
+        data = [.nan, .nan, .nan, 320.9375, .nan, .nan, 246.95312, .nan, .nan, 2.578125, .nan, .nan, 0.0, .nan, .nan, 0.0]
+        time = TimerangeDt(start: Timestamp(2022,08,16,12), nTime: data.count, dtSeconds: 3600)
+        data.interpolateInplaceSolarBackwards(skipFirst: 1, time: time, grid: grid, locationRange: 0..<1)
+        XCTAssertEqualArray(data, [.nan, 316.6924, 327.28204, 319.8192, 304.3659, 271.0651, 201.56267, 101.99449, 25.591284, 0.6671406, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], accuracy: 0.001)
     }
     
     func testRangeFraction() {


### PR DESCRIPTION
MeteoFrance changed the API again removing some variables. They introduced a new/old package based API to get larger GRIB files that contain all variables like solar radiation and pressure level data again.

The following APIs need to be enabled for en API key:
- https://portail-api.meteofrance.fr/web/en/api/PaquetAROME
- https://portail-api.meteofrance.fr/web/en/api/PaquetARPEGE

Docs:
- AROME: https://donneespubliques.meteofrance.fr/client/document/descriptiontechnique_paquetsarome_donneespubliques_v2_20240402_367.pdf
- ARPEGE: https://donneespubliques.meteofrance.fr/client/document/descriptiontechnique_paquetsarpege_donneespubliques_v2_20240402_368.pdf

fixes #871