### PR TITLE
Add Dart client SDK to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Do you use Open-Meteo? Please open a pull request and add your repository or app
 - PHP Symfony 6.2 https://gitlab.com/flibidi67/open-meteo
 - PHP for Geocoding API: https://gitlab.com/flibidi67/open-meteo-geocoding
 - Android library for Geocoding API: https://github.com/woheller69/OmGeoDialog
+- Dart / Flutter: https://github.com/neursh/open-meteo-dart
 - Rust: https://github.com/angelodlfrtr/open-meteo-rs
 
 Contributions welcome! Writing a SDK for Open-Meteo is more than welcome and a great way to help users.


### PR DESCRIPTION
The package now supported FlatBuffer as the main method for requesting Open Meteo's API with all features supported. Example:

```dart
import 'package:open_meteo/models/weather.dart';
import 'package:open_meteo/open_meteo.dart';

void main() async {
  Weather weather = Weather(
    latitude: 52.52,
    longitude: 13.41,
    temperature_unit: TemperatureUnit.celsius,
  );
  WeatherResponse result = await weather.request(
    current: [Current.temperature_2m],
  );
  WeatherParameterData temperature =
      result.currentWeatherData![Current.temperature_2m]!;
  double currentTemperature = temperature.data.values.first;

  print(currentTemperature);
}
```

The request URL used in the example:
```
https://api.open-meteo.com/v1/forecast?current=temperature_2m&temperature_unit=celsius&latitude=52.52&longitude=13.41&timeformat=unixtime&timezone=auto&format=flatbuffers
```

Repository: https://github.com/neursh/open-meteo-dart

Package link: https://pub.dev/packages/open_meteo