### PR TITLE
feat: Adjustable temporal resolution and data aggregation support

### DIFF
--- a/Sources/App/Cams/CamsController.swift
+++ b/Sources/App/Cams/CamsController.swift
@@ -67,7 +67,7 @@ struct CamsController {
                 guard let reader = try readerAndDomain.reader() else {
                     return nil
                 }
-                let hourlyDt = (params.time_interval ?? .hourly).dtSeconds ?? reader.modelDtSeconds
+                let hourlyDt = (params.temporal_resolution ?? .hourly).dtSeconds ?? reader.modelDtSeconds
                 let timeHourlyRead = time.hourlyRead.with(dtSeconds: hourlyDt)
                 let timeHourlyDisplay = time.hourlyDisplay.with(dtSeconds: hourlyDt)
                 let domain = readerAndDomain.domain

--- a/Sources/App/Cams/CamsController.swift
+++ b/Sources/App/Cams/CamsController.swift
@@ -67,13 +67,16 @@ struct CamsController {
                 guard let reader = try readerAndDomain.reader() else {
                     return nil
                 }
+                let hourlyDt = (params.time_interval ?? .hourly).dtSeconds ?? reader.modelDtSeconds
+                let timeHourlyRead = time.hourlyRead.with(dtSeconds: hourlyDt)
+                let timeHourlyDisplay = time.hourlyDisplay.with(dtSeconds: hourlyDt)
                 let domain = readerAndDomain.domain
                 
                 let hourlyFn: (() throws -> ApiSection<ForecastapiResult<CamsQuery.Domain>.SurfacePressureAndHeightVariable>)? = paramsHourly.map { variables in
                     return {
-                        return .init(name: "hourly", time: time.hourlyDisplay, columns: try variables.map { variable in
-                            let d = try reader.get(variable: variable, time: time.hourlyRead.toSettings()).convertAndRound(params: params)
-                            assert(time.hourlyRead.count == d.data.count)
+                        return .init(name: "hourly", time: timeHourlyDisplay, columns: try variables.map { variable in
+                            let d = try reader.get(variable: variable, time: timeHourlyRead.toSettings()).convertAndRound(params: params)
+                            assert(timeHourlyRead.count == d.data.count)
                             return .init(variable: .surface(variable), unit: d.unit, variables: [.float(d.data)])
                         })
                     }
@@ -98,7 +101,7 @@ struct CamsController {
                             try reader.prefetchData(variables: paramsCurrent, time: currentTimeRange.toSettings())
                         }
                         if let paramsHourly {
-                            try reader.prefetchData(variables: paramsHourly, time: time.hourlyRead.toSettings())
+                            try reader.prefetchData(variables: paramsHourly, time: timeHourlyRead.toSettings())
                         }
                     },
                     current: currentFn,

--- a/Sources/App/Controllers/EnsembleController.swift
+++ b/Sources/App/Controllers/EnsembleController.swift
@@ -30,7 +30,11 @@ public struct EnsembleApiController {
                 guard let reader = try readerAndDomain.reader() else {
                     return nil
                 }
+                let hourlyDt = (params.time_interval ?? .hourly).dtSeconds ?? reader.modelDtSeconds
+                let timeHourlyRead = time.hourlyRead.with(dtSeconds: hourlyDt)
+                let timeHourlyDisplay = time.hourlyDisplay.with(dtSeconds: hourlyDt)
                 let domain = readerAndDomain.domain
+                
                 return .init(
                     model: domain,
                     latitude: reader.modelLat,
@@ -40,7 +44,7 @@ public struct EnsembleApiController {
                         if let hourlyVariables = paramsHourly {
                             for variable in hourlyVariables {
                                 for member in 0..<reader.domain.countEnsembleMember {
-                                    try reader.prefetchData(variable: variable, time: time.hourlyRead.toSettings(ensembleMemberLevel: member))
+                                    try reader.prefetchData(variable: variable, time: timeHourlyRead.toSettings(ensembleMemberLevel: member))
                                 }
                             }
                         }
@@ -48,18 +52,18 @@ public struct EnsembleApiController {
                     current: nil,
                     hourly: paramsHourly.map { variables in
                         return {
-                            return .init(name: "hourly", time: time.hourlyDisplay, columns: try variables.map { variable in
+                            return .init(name: "hourly", time: timeHourlyDisplay, columns: try variables.map { variable in
                                 var unit: SiUnit? = nil
                                 let allMembers: [ApiArray] = try (0..<reader.domain.countEnsembleMember).compactMap { member in
-                                    guard let d = try reader.get(variable: variable, time: time.hourlyRead.toSettings(ensembleMemberLevel: member))?.convertAndRound(params: params) else {
+                                    guard let d = try reader.get(variable: variable, time: timeHourlyRead.toSettings(ensembleMemberLevel: member))?.convertAndRound(params: params) else {
                                         return nil
                                     }
                                     unit = d.unit
-                                    assert(time.hourlyRead.count == d.data.count)
+                                    assert(timeHourlyRead.count == d.data.count)
                                     return ApiArray.float(d.data)
                                 }
                                 guard allMembers.count > 0 else {
-                                    return ApiColumn(variable: variable.resultVariable, unit: .undefined, variables: .init(repeating: ApiArray.float([Float](repeating: .nan, count: time.hourlyRead.count)), count: reader.domain.countEnsembleMember))
+                                    return ApiColumn(variable: variable.resultVariable, unit: .undefined, variables: .init(repeating: ApiArray.float([Float](repeating: .nan, count: timeHourlyRead.count)), count: reader.domain.countEnsembleMember))
                                 }
                                 return .init(variable: variable.resultVariable, unit: unit ?? .undefined, variables: allMembers)
                             })

--- a/Sources/App/Controllers/EnsembleController.swift
+++ b/Sources/App/Controllers/EnsembleController.swift
@@ -30,7 +30,7 @@ public struct EnsembleApiController {
                 guard let reader = try readerAndDomain.reader() else {
                     return nil
                 }
-                let hourlyDt = (params.time_interval ?? .hourly).dtSeconds ?? reader.modelDtSeconds
+                let hourlyDt = (params.temporal_resolution ?? .hourly).dtSeconds ?? reader.modelDtSeconds
                 let timeHourlyRead = time.hourlyRead.with(dtSeconds: hourlyDt)
                 let timeHourlyDisplay = time.hourlyDisplay.with(dtSeconds: hourlyDt)
                 let domain = readerAndDomain.domain

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -140,7 +140,7 @@ struct WeatherApiController {
                 guard let reader = try readerAndDomain.reader() else {
                     return nil
                 }
-                let hourlyDt = (params.timeinterval ?? .hourly).dtSeconds ?? reader.modelDtSeconds
+                let hourlyDt = (params.time_interval ?? .hourly).dtSeconds ?? reader.modelDtSeconds
                 let timeHourlyRead = time.hourlyRead.with(dtSeconds: hourlyDt)
                 let timeHourlyDisplay = time.hourlyDisplay.with(dtSeconds: hourlyDt)
                 let domain = readerAndDomain.domain

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -140,7 +140,7 @@ struct WeatherApiController {
                 guard let reader = try readerAndDomain.reader() else {
                     return nil
                 }
-                let hourlyDt = (params.time_interval ?? .hourly).dtSeconds ?? reader.modelDtSeconds
+                let hourlyDt = (params.temporal_resolution ?? .hourly).dtSeconds ?? reader.modelDtSeconds
                 let timeHourlyRead = time.hourlyRead.with(dtSeconds: hourlyDt)
                 let timeHourlyDisplay = time.hourlyDisplay.with(dtSeconds: hourlyDt)
                 let domain = readerAndDomain.domain

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -140,6 +140,9 @@ struct WeatherApiController {
                 guard let reader = try readerAndDomain.reader() else {
                     return nil
                 }
+                let hourlyDt = (params.timeinterval ?? .hourly).dtSeconds ?? reader.modelDtSeconds
+                let timeHourlyRead = time.hourlyRead.with(dtSeconds: hourlyDt)
+                let timeHourlyDisplay = time.hourlyDisplay.with(dtSeconds: hourlyDt)
                 let domain = readerAndDomain.domain
                 
                 return .init(
@@ -163,7 +166,7 @@ struct WeatherApiController {
                         if let paramsHourly {
                             for variable in paramsHourly {
                                 let (v, previousDay) = variable.variableAndPreviousDay
-                                try reader.prefetchData(variable: v, time: time.hourlyRead.toSettings(previousDay: previousDay))
+                                try reader.prefetchData(variable: v, time: timeHourlyRead.toSettings(previousDay: previousDay))
                             }
                         }
                         if let paramsDaily {
@@ -183,12 +186,12 @@ struct WeatherApiController {
                     },
                     hourly: paramsHourly.map { variables in
                         return {
-                            return .init(name: "hourly", time: time.hourlyDisplay, columns: try variables.map { variable in
+                            return .init(name: "hourly", time: timeHourlyDisplay, columns: try variables.map { variable in
                                 let (v, previousDay) = variable.variableAndPreviousDay
-                                guard let d = try reader.get(variable: v, time: time.hourlyRead.toSettings(previousDay: previousDay))?.convertAndRound(params: params) else {
-                                    return .init(variable: variable.resultVariable, unit: .undefined, variables: [.float([Float](repeating: .nan, count: time.hourlyRead.count))])
+                                guard let d = try reader.get(variable: v, time: timeHourlyRead.toSettings(previousDay: previousDay))?.convertAndRound(params: params) else {
+                                    return .init(variable: variable.resultVariable, unit: .undefined, variables: [.float([Float](repeating: .nan, count: timeHourlyRead.count))])
                                 }
-                                assert(time.hourlyRead.count == d.data.count)
+                                assert(timeHourlyRead.count == d.data.count)
                                 return .init(variable: variable.resultVariable, unit: d.unit, variables: [.float(d.data)])
                             })
                         }

--- a/Sources/App/Helper/Aggregation.swift
+++ b/Sources/App/Helper/Aggregation.swift
@@ -1,0 +1,42 @@
+extension Array where Element == Float {
+    /// Aggregate data
+    /// timeOld = 1h
+    /// timeNew = 3h
+    func aggregate(type: ReaderInterpolation, timeOld: TimerangeDt, timeNew: TimerangeDt) -> [Float] {
+        let steps = timeNew.dtSeconds / timeOld.dtSeconds
+        let backSeconds = -1 * timeOld.dtSeconds * (steps - 1)
+        precondition(timeNew.dtSeconds % timeOld.dtSeconds == 0)
+        switch type {
+        case .linear, .linearDegrees, .hermite(_), .backwards:
+            // take instantanous value
+            return timeNew.map({ t in
+                guard let i = timeOld.index(of: t) else {
+                    return .nan
+                }
+                return self[i]
+            })
+        case .solar_backwards_averaged:
+            /// Average past steps
+            return timeNew.map({ t in
+                guard let start = timeOld.index(of: t.add(backSeconds)) else {
+                    return .nan
+                }
+                guard let end = timeOld.index(of: t) else {
+                    return .nan
+                }
+                return self[start...end].mean()
+            })
+        case .backwards_sum:
+            /// Sum past steps
+            return timeNew.map({ t in
+                guard let start = timeOld.index(of: t.add(backSeconds)) else {
+                    return .nan
+                }
+                guard let end = timeOld.index(of: t) else {
+                    return .nan
+                }
+                return self[start...end].reduce(0, +)
+            })
+        }
+    }
+}

--- a/Sources/App/Helper/ForecastapiQuery.swift
+++ b/Sources/App/Helper/ForecastapiQuery.swift
@@ -15,6 +15,26 @@ extension ClosedRange where Element == Timestamp {
     }
 }
 
+enum ApiTimeIntervalEnum: String, Codable {
+    case original
+    case hourly
+    case hourly3
+    case hourly6
+    
+    var dtSeconds: Int? {
+        switch self {
+        case .original:
+            return nil
+        case .hourly:
+            return 3600
+        case .hourly3:
+            return 3*3600
+        case .hourly6:
+            return 6*3600
+        }
+    }
+}
+
 /// All API parameter that are accepted and decoded via GET
 struct ApiQueryParameter: Content, ApiUnitsSelectable {
     let latitude: [String]
@@ -36,6 +56,7 @@ struct ApiQueryParameter: Content, ApiUnitsSelectable {
     let precipitation_unit: PrecipitationUnit?
     let length_unit: LengthUnit?
     let timeformat: Timeformat?
+    let timeinterval: ApiTimeIntervalEnum?
     
     let bounding_box: [String]
     

--- a/Sources/App/Helper/ForecastapiQuery.swift
+++ b/Sources/App/Helper/ForecastapiQuery.swift
@@ -16,7 +16,7 @@ extension ClosedRange where Element == Timestamp {
 }
 
 /// Option to overwrite the temporal output resolution instead of always getting 1-hourly data.
-enum ApiTimeIntervalEnum: String, Codable {
+enum ApiTemporalResolution: String, Codable {
     case native
     case hourly
     case hourly_1
@@ -58,7 +58,7 @@ struct ApiQueryParameter: Content, ApiUnitsSelectable {
     let precipitation_unit: PrecipitationUnit?
     let length_unit: LengthUnit?
     let timeformat: Timeformat?
-    let time_interval: ApiTimeIntervalEnum?
+    let temporal_resolution: ApiTemporalResolution?
     
     let bounding_box: [String]
     

--- a/Sources/App/Helper/ForecastapiQuery.swift
+++ b/Sources/App/Helper/ForecastapiQuery.swift
@@ -15,21 +15,23 @@ extension ClosedRange where Element == Timestamp {
     }
 }
 
+/// Option to overwrite the temporal output resolution instead of always getting 1-hourly data.
 enum ApiTimeIntervalEnum: String, Codable {
-    case original
+    case native
     case hourly
-    case hourly3
-    case hourly6
+    case hourly_1
+    case hourly_3
+    case hourly_6
     
     var dtSeconds: Int? {
         switch self {
-        case .original:
+        case .native:
             return nil
-        case .hourly:
+        case .hourly, .hourly_1:
             return 3600
-        case .hourly3:
+        case .hourly_3:
             return 3*3600
-        case .hourly6:
+        case .hourly_6:
             return 6*3600
         }
     }
@@ -56,7 +58,7 @@ struct ApiQueryParameter: Content, ApiUnitsSelectable {
     let precipitation_unit: PrecipitationUnit?
     let length_unit: LengthUnit?
     let timeformat: Timeformat?
-    let timeinterval: ApiTimeIntervalEnum?
+    let time_interval: ApiTimeIntervalEnum?
     
     let bounding_box: [String]
     
@@ -431,6 +433,7 @@ enum ForecastapiError: Error {
     case coordinatesAndStartEndDatesCountMustBeTheSame
     case coordinatesAndElevationCountMustBeTheSame
     case generic(message: String)
+    case cannotReturnModelsWithDiffernetTimeIntervals
 }
 
 extension ForecastapiError: AbortError {
@@ -482,6 +485,8 @@ extension ForecastapiError: AbortError {
             return "Parameter 'elevation' must have the same number of elements as coordinates"
         case .generic(message: let message):
             return message
+        case .cannotReturnModelsWithDiffernetTimeIntervals:
+            return "Cannot return models with different time-intervals"
         }
     }
 }

--- a/Sources/App/Helper/Reader/GenericReader.swift
+++ b/Sources/App/Helper/Reader/GenericReader.swift
@@ -126,16 +126,15 @@ struct GenericReader<Domain: GenericDomain, Variable: GenericVariable>: GenericR
     func prefetchData(variable: Variable, time: TimerangeDtAndSettings) throws {
         if time.dtSeconds == domain.dtSeconds {
             try omFileSplitter.willNeed(variable: variable.omFileName.file, location: position..<position+1, level: time.ensembleMemberLevel, time: time)
-        }
-        if time.dtSeconds > domain.dtSeconds {
-            /// do not allow aggregations
-            fatalError()
+            return
         }
         
-        // Data is interpolated in dt
         let interpolationType = variable.interpolation
-        let timeLow = time.time.forInterpolationTo(modelDt: domain.dtSeconds).expandLeftRight(by: domain.dtSeconds*(interpolationType.padding-1))
-        try omFileSplitter.willNeed(variable: variable.omFileName.file, location: position..<position+1, level: time.ensembleMemberLevel, time: .init(time: timeLow, ensembleMember: time.ensembleMember, ensembleMemberLevel: time.ensembleMemberLevel, previousDay: time.previousDay))
+        let timeRead = time.dtSeconds > domain.dtSeconds ?
+            time.time.forAggregationTo(modelDt: domain.dtSeconds, interpolation: interpolationType) :
+            time.time.forInterpolationTo(modelDt: domain.dtSeconds, interpolation: interpolationType)
+        
+        try omFileSplitter.willNeed(variable: variable.omFileName.file, location: position..<position+1, level: time.ensembleMemberLevel, time: time.with(time: timeRead))
     }
     
     /// Read and scale if required
@@ -165,19 +164,17 @@ struct GenericReader<Domain: GenericDomain, Variable: GenericVariable>: GenericR
         
         if time.dtSeconds > domain.dtSeconds {
             // Aggregate data
-            // TODO backwards aggregation needs to read more timesteps to the left
-            let timeRead = time.time.with(dtSeconds: domain.dtSeconds)
+            let timeRead = time.time.forAggregationTo(modelDt: domain.dtSeconds, interpolation: interpolationType)
             let read = try readAndScale(variable: variable, time: time.with(time: timeRead))
-            let aggregated = read.data.aggregate(type: interpolationType, timeOld: time.time, timeNew: timeRead)
+            let aggregated = read.data.aggregate(type: interpolationType, timeOld: timeRead, timeNew: time.time)
             return DataAndUnit(aggregated, read.unit)
         }
         
-        let timeLow = time.time.forInterpolationTo(modelDt: domain.dtSeconds).expandLeftRight(by: domain.dtSeconds*(interpolationType.padding-1))
+        // Interpolate data
+        let timeLow = time.time.forInterpolationTo(modelDt: domain.dtSeconds, interpolation: interpolationType)
         let read = try readAndScale(variable: variable, time: time.with(time: timeLow))
-        let dataLow = read.data
-        
-        let data = dataLow.interpolate(type: interpolationType, timeOld: timeLow, timeNew: time.time, latitude: modelLat, longitude: modelLon, scalefactor: variable.scalefactor)
-        return DataAndUnit(data, read.unit)
+        let interpolated = read.data.interpolate(type: interpolationType, timeOld: timeLow, timeNew: time.time, latitude: modelLat, longitude: modelLon, scalefactor: variable.scalefactor)
+        return DataAndUnit(interpolated, read.unit)
     }
     
     func get(variable: Variable, time: TimerangeDtAndSettings) throws -> DataAndUnit {
@@ -193,13 +190,24 @@ struct GenericReader<Domain: GenericDomain, Variable: GenericVariable>: GenericR
 }
 
 extension TimerangeDt {
-    func forInterpolationTo(modelDt: Int) -> TimerangeDt {
-        let start = range.lowerBound.floor(toNearest: modelDt)
-        let end = range.upperBound.ceil(toNearest: modelDt)
+    /// Expand the time range for interpolation
+    func forAggregationTo(modelDt: Int, interpolation: ReaderInterpolation) -> TimerangeDt {
+        switch interpolation {
+        case .linear, .linearDegrees, .hermite(_), .backwards:
+            return self.with(dtSeconds: modelDt)
+        case .solar_backwards_averaged, .backwards_sum:
+            // Need to read previous timesteps to sum/average the correct value
+            let steps = dtSeconds / modelDt
+            let backSeconds = -1 * modelDt * (steps - 1)
+            return self.with(dtSeconds: modelDt).with(start: range.lowerBound.add(backSeconds))
+        }
+    }
+    
+    /// Adjust time for interpolation. E.g. Reads a bit more data for hermite interpolation
+    func forInterpolationTo(modelDt: Int, interpolation: ReaderInterpolation) -> TimerangeDt {
+        let expand = modelDt*(interpolation.padding-1)
+        let start = range.lowerBound.floor(toNearest: modelDt).add(-1*expand)
+        let end = range.upperBound.ceil(toNearest: modelDt).add(expand)
         return TimerangeDt(start: start, to: end, dtSeconds: modelDt)
     }
-    func expandLeftRight(by: Int) -> TimerangeDt {
-        return TimerangeDt(start: range.lowerBound.add(-1*by), to: range.upperBound.add(by), dtSeconds: dtSeconds)
-    }
 }
-

--- a/Sources/App/Helper/Reader/GenericReaderMixerRaw.swift
+++ b/Sources/App/Helper/Reader/GenericReaderMixerRaw.swift
@@ -70,10 +70,6 @@ extension GenericReaderMixerRaw {
     
     func prefetchData(variable: Reader.MixingVar, time: TimerangeDtAndSettings) throws {
         for reader in reader {
-            if time.dtSeconds > reader.modelDtSeconds {
-                /// 15 minutely domain while reading hourly data
-                continue
-            }
             try reader.prefetchData(variable: variable, time: time)
         }
     }
@@ -95,10 +91,6 @@ extension GenericReaderMixerRaw {
         var unit: SiUnit? = nil
         if variable.requiresOffsetCorrectionForMixing {
             for r in reader.reversed() {
-                if time.dtSeconds > r.modelDtSeconds {
-                    /// 15 minutely domain while reading hourly data
-                    continue
-                }
                 let d = try r.get(variable: variable, time: time)
                 if data == nil {
                     // first iteration
@@ -118,10 +110,6 @@ extension GenericReaderMixerRaw {
         } else {
             // default case, just place new data in 1:1
             for r in reader.reversed() {
-                if time.dtSeconds > r.modelDtSeconds {
-                    /// 15 minutely domain while reading hourly data
-                    continue
-                }
                 let d = try r.get(variable: variable, time: time)
                 if data == nil {
                     // first iteration

--- a/Sources/App/Helper/Reader/GenericReaderMulti.swift
+++ b/Sources/App/Helper/Reader/GenericReaderMulti.swift
@@ -55,10 +55,6 @@ struct GenericReaderMulti<Variable: GenericVariableMixable, Domain: MultiDomainM
     
     func prefetchData(variable: Variable, time: TimerangeDtAndSettings) throws {
         for reader in reader {
-            if time.dtSeconds > reader.modelDtSeconds {
-                /// 15 minutely domain while reading hourly data
-                continue
-            }
             if try reader.prefetchData(mixed: variable.rawValue, time: time) {
                 break
             }
@@ -78,10 +74,6 @@ struct GenericReaderMulti<Variable: GenericVariableMixable, Domain: MultiDomainM
         var unit: SiUnit? = nil
         if variable.requiresOffsetCorrectionForMixing {
             for r in reader.reversed() {
-                if time.dtSeconds > r.modelDtSeconds {
-                    /// 15 minutely domain while reading hourly data
-                    continue
-                }
                 guard let d = try r.get(mixed: variable.rawValue, time: time) else {
                     continue
                 }
@@ -103,10 +95,6 @@ struct GenericReaderMulti<Variable: GenericVariableMixable, Domain: MultiDomainM
         } else {
             // default case, just place new data in 1:1
             for r in reader.reversed() {
-                if time.dtSeconds > r.modelDtSeconds {
-                    /// 15 minutely domain while reading hourly data
-                    continue
-                }
                 guard let d = try r.get(mixed: variable.rawValue, time: time) else {
                     continue
                 }

--- a/Sources/App/Helper/Writer/ForecastapiResult.swift
+++ b/Sources/App/Helper/Writer/ForecastapiResult.swift
@@ -46,6 +46,9 @@ fileprivate struct ModelAndSection<Model: ModelFlatbufferSerialisable, Variable:
         guard let first = run.first else {
             throw ForecastapiError.noDataAvilableForThisLocation
         }
+        guard run.first(where: {$0.time.dtSeconds != first.time.dtSeconds }) == nil else {
+            throw ForecastapiError.cannotReturnModelsWithDiffernetTimeIntervals
+        }
         return ApiSectionString(name: first.name, time: first.time, columns: run.flatMap { $0.columns})
     }
 }

--- a/Sources/App/IconWave/IconWaveController.swift
+++ b/Sources/App/IconWave/IconWaveController.swift
@@ -124,7 +124,7 @@ struct IconWaveController {
                 guard let reader = try GenericReaderMulti<MarineVariable, IconWaveDomainApi>(domain: domain, lat: coordinates.latitude, lon: coordinates.longitude, elevation: .nan, mode: params.cell_selection ?? .sea, options: params.readerOptions) else {
                     return nil
                 }
-                let hourlyDt = (params.time_interval ?? .hourly).dtSeconds ?? reader.modelDtSeconds
+                let hourlyDt = (params.temporal_resolution ?? .hourly).dtSeconds ?? reader.modelDtSeconds
                 let timeHourlyRead = time.hourlyRead.with(dtSeconds: hourlyDt)
                 let timeHourlyDisplay = time.hourlyDisplay.with(dtSeconds: hourlyDt)
                 

--- a/Sources/App/IconWave/IconWaveController.swift
+++ b/Sources/App/IconWave/IconWaveController.swift
@@ -124,6 +124,9 @@ struct IconWaveController {
                 guard let reader = try GenericReaderMulti<MarineVariable, IconWaveDomainApi>(domain: domain, lat: coordinates.latitude, lon: coordinates.longitude, elevation: .nan, mode: params.cell_selection ?? .sea, options: params.readerOptions) else {
                     return nil
                 }
+                let hourlyDt = (params.time_interval ?? .hourly).dtSeconds ?? reader.modelDtSeconds
+                let timeHourlyRead = time.hourlyRead.with(dtSeconds: hourlyDt)
+                let timeHourlyDisplay = time.hourlyDisplay.with(dtSeconds: hourlyDt)
                 
                 return .init(
                     model: domain,
@@ -133,7 +136,7 @@ struct IconWaveController {
                     prefetch: {
                         if let paramsHourly {
                             for member in 0..<reader.domain.countEnsembleMember {
-                                try reader.prefetchData(variables: paramsHourly, time: time.hourlyRead.toSettings(ensembleMember: member))
+                                try reader.prefetchData(variables: paramsHourly, time: timeHourlyRead.toSettings(ensembleMember: member))
                             }
                         }
                         if let paramsCurrent {
@@ -157,18 +160,18 @@ struct IconWaveController {
                     },
                     hourly: paramsHourly.map { variables in
                         return {
-                            return .init(name: "hourly", time: time.hourlyDisplay, columns: try variables.map { variable in
+                            return .init(name: "hourly", time: timeHourlyDisplay, columns: try variables.map { variable in
                                 var unit: SiUnit? = nil
                                 let allMembers: [ApiArray] = try (0..<reader.domain.countEnsembleMember).compactMap { member in
-                                    guard let d = try reader.get(variable: variable, time: time.hourlyRead.toSettings(ensembleMemberLevel: member))?.convertAndRound(params: params) else {
+                                    guard let d = try reader.get(variable: variable, time: timeHourlyRead.toSettings(ensembleMemberLevel: member))?.convertAndRound(params: params) else {
                                         return nil
                                     }
                                     unit = d.unit
-                                    assert(time.hourlyRead.count == d.data.count)
+                                    assert(timeHourlyRead.count == d.data.count)
                                     return ApiArray.float(d.data)
                                 }
                                 guard allMembers.count > 0 else {
-                                    return ApiColumn(variable: .surface(variable), unit: .undefined, variables: .init(repeating: ApiArray.float([Float](repeating: .nan, count: time.hourlyRead.count)), count: reader.domain.countEnsembleMember))
+                                    return ApiColumn(variable: .surface(variable), unit: .undefined, variables: .init(repeating: ApiArray.float([Float](repeating: .nan, count: timeHourlyRead.count)), count: reader.domain.countEnsembleMember))
                                 }
                                 return .init(variable: .surface(variable), unit: unit ?? .undefined, variables: allMembers)
                             })


### PR DESCRIPTION
Expose a `&temporal_resolution=` parameter with options:
- `hourly` (default): Always interpolate to 1 hourly data
- `hourly_3`: Return 3-hourly data. If required aggregate data from 1-hourly to 6-hourly
- `hourly_6`: Aggregate to 6-hourly time steps
- `native`: Use the native temporal resolution of the selected weather model. If multiple models are selected with different resolutions, this will throw an error in most cases. Only the FlatBuffers format can return multiple models with different resolutions.

Closes: https://github.com/open-meteo/open-meteo/issues/556

This also closes https://github.com/open-meteo/open-meteo/issues/423, because 15-minutely data is now directly used and aggregated to 1-hourly data removing some unnecessary workarounds.

Aggregation depends in the specific variable. Precipitation will be the sum of previous time steps. Solar radiation will be averaged over the previous time-steps.

UI change in https://github.com/open-meteo/open-meteo-website/pull/300