### PR TITLE
fix: Auto detect spacing in interpolation

### DIFF
--- a/Sources/App/Arpae/ArpaeDownloader.swift
+++ b/Sources/App/Arpae/ArpaeDownloader.swift
@@ -97,7 +97,7 @@ struct DownloadArpaeCommand: AsyncCommand {
                 }
                 logger.info("Compressing and writing data to \(timestamp.format_YYYYMMddHH) \(variable)")
                 let fn = try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: variable.scalefactor, all: grib2d.array.data)
-                return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn, skipHour0: stepType == "accum")
+                return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn)
             }.collect().compactMap({$0})
         }
         await curl.printStatistics()

--- a/Sources/App/Bom/BomDownloader.swift
+++ b/Sources/App/Bom/BomDownloader.swift
@@ -174,8 +174,8 @@ struct DownloadBomCommand: AsyncCommand {
                 let fnSpeed = try writer.write(domain: domain, variable: map.speed, data: speed)
                 let fnDirection = try writer.write(domain: domain, variable: map.direction, data: direction)
                 return [
-                    GenericVariableHandle(variable: map.speed, time: timestamp, member: 0, fn: fnSpeed, skipHour0: false),
-                    GenericVariableHandle(variable: map.direction, time: timestamp, member: 0, fn: fnDirection, skipHour0: false)
+                    GenericVariableHandle(variable: map.speed, time: timestamp, member: 0, fn: fnSpeed),
+                    GenericVariableHandle(variable: map.direction, time: timestamp, member: 0, fn: fnDirection)
                     ]
             }
         }.flatMap({$0})
@@ -249,7 +249,7 @@ struct DownloadBomCommand: AsyncCommand {
                 logger.info("Compressing and writing data to member_\(member) \(omVariable.omFileName.file).om")
                 return try self.iterateForecast(domain: domain, member: member, variable: variable.name, run: run).map { (timestamp, data) in
                     let fn = try writer.write(domain: domain, variable: omVariable, data: data)
-                    return GenericVariableHandle(variable: omVariable, time: timestamp, member: member, fn: fn, skipHour0: false)
+                    return GenericVariableHandle(variable: omVariable, time: timestamp, member: member, fn: fn)
                 }
             }
             if domain == .access_global_ensemble && variable.om == .precipitation {
@@ -286,8 +286,8 @@ struct DownloadBomCommand: AsyncCommand {
                 let fnSnow = try writer.write(domain: domain, variable: .snowfall_water_equivalent, data: snow)
                 let fnWeatherCode = try writer.write(domain: domain, variable: .weather_code, data: weather_code)
                 return [
-                    GenericVariableHandle(variable: BomVariable.snowfall_water_equivalent, time: timestamp, member: member, fn: fnSnow, skipHour0: false),
-                    GenericVariableHandle(variable: BomVariable.weather_code, time: timestamp, member: member, fn: fnWeatherCode, skipHour0: false)
+                    GenericVariableHandle(variable: BomVariable.snowfall_water_equivalent, time: timestamp, member: member, fn: fnSnow),
+                    GenericVariableHandle(variable: BomVariable.weather_code, time: timestamp, member: member, fn: fnWeatherCode)
                 ]
             }.flatMap({$0})
         }
@@ -303,7 +303,7 @@ struct DownloadBomCommand: AsyncCommand {
                 let writer = OmFileWriter(dim0: 1, dim1: domain.grid.count, chunk0: 1, chunk1: nLocationsPerChunk)
                 let rh = zip(sfc_temp.1, dewpt_scrn.1).map({Meteorology.relativeHumidity(temperature: $0.0-273.15, dewpoint: $0.1-273.15)})
                 let fnRh = try writer.write(domain: domain, variable: .relative_humidity_2m, data: rh)
-                return GenericVariableHandle(variable: BomVariable.relative_humidity_2m, time: timestamp, member: member, fn: fnRh, skipHour0: false)
+                return GenericVariableHandle(variable: BomVariable.relative_humidity_2m, time: timestamp, member: member, fn: fnRh)
             }
         }
         
@@ -320,8 +320,8 @@ struct DownloadBomCommand: AsyncCommand {
                 let fnSpeed = try writer.write(domain: domain, variable: .wind_speed_10m, data: speed)
                 let fnDirection = try writer.write(domain: domain, variable: .wind_direction_10m, data: direction)
                 return [
-                    GenericVariableHandle(variable: BomVariable.wind_speed_10m, time: timestamp, member: member, fn: fnSpeed, skipHour0: false),
-                    GenericVariableHandle(variable: BomVariable.wind_direction_10m, time: timestamp, member: member, fn: fnDirection, skipHour0: false)
+                    GenericVariableHandle(variable: BomVariable.wind_speed_10m, time: timestamp, member: member, fn: fnSpeed),
+                    GenericVariableHandle(variable: BomVariable.wind_direction_10m, time: timestamp, member: member, fn: fnDirection)
                 ]
             }.flatMap({$0})
         }
@@ -398,7 +398,7 @@ struct DownloadBomCommand: AsyncCommand {
             logger.info("Compressing and writing data to \(omVariable.omFileName.file).om")
             return try self.combineAnalysisForecast(domain: domain, variable: variable.name, run: run).map { (timestamp, data) in
                 let fn = try writer.write(domain: domain, variable: omVariable, data: data)
-                return GenericVariableHandle(variable: omVariable, time: timestamp, member: 0, fn: fn, skipHour0: false)
+                return GenericVariableHandle(variable: omVariable, time: timestamp, member: 0, fn: fn)
             }
         }
         
@@ -426,8 +426,8 @@ struct DownloadBomCommand: AsyncCommand {
             let fnSnow = try writer.write(domain: domain, variable: .snowfall_water_equivalent, data: snow)
             let fnWeatherCode = try writer.write(domain: domain, variable: .weather_code, data: weather_code)
             return [
-                GenericVariableHandle(variable: BomVariable.snowfall_water_equivalent, time: timestamp, member: 0, fn: fnSnow, skipHour0: false),
-                GenericVariableHandle(variable: BomVariable.weather_code, time: timestamp, member: 0, fn: fnWeatherCode, skipHour0: false)
+                GenericVariableHandle(variable: BomVariable.snowfall_water_equivalent, time: timestamp, member: 0, fn: fnSnow),
+                GenericVariableHandle(variable: BomVariable.weather_code, time: timestamp, member: 0, fn: fnWeatherCode)
             ]
         }
         
@@ -443,8 +443,8 @@ struct DownloadBomCommand: AsyncCommand {
             let fnSpeed = try writer.write(domain: domain, variable: .wind_speed_10m, data: speed)
             let fnDirection = try writer.write(domain: domain, variable: .wind_direction_10m, data: direction)
             return [
-                GenericVariableHandle(variable: BomVariable.wind_speed_10m, time: timestamp, member: 0, fn: fnSpeed, skipHour0: false),
-                GenericVariableHandle(variable: BomVariable.wind_direction_10m, time: timestamp, member: 0, fn: fnDirection, skipHour0: false)
+                GenericVariableHandle(variable: BomVariable.wind_speed_10m, time: timestamp, member: 0, fn: fnSpeed),
+                GenericVariableHandle(variable: BomVariable.wind_direction_10m, time: timestamp, member: 0, fn: fnDirection)
                 ]
         }
         await curl.printStatistics()

--- a/Sources/App/CMA/CmaDownloader.swift
+++ b/Sources/App/CMA/CmaDownloader.swift
@@ -273,7 +273,7 @@ struct DownloadCmaCommand: AsyncCommand {
                     
                     logger.info("Compressing and writing data to \(variable.omFileName.file)_\(forecastHour).om")
                     let fn = try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: variable.scalefactor, all: grib2d.array.data)
-                    return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn, skipHour0: stepType == "accum")
+                    return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn)
                 }.collect().compactMap({$0})
             }
         }

--- a/Sources/App/Cams/CamsDownload.swift
+++ b/Sources/App/Cams/CamsDownload.swift
@@ -167,7 +167,7 @@ struct DownloadCamsCommand: AsyncCommand {
             let startOm = DispatchTime.now()
             let time = TimerangeDt(start: run, nTime: data2d.nTime, dtSeconds: domain.dtSeconds)
             //try data2d.transpose().writeNetcdf(filename: "\(domain.downloadDirectory)\(variable.rawValue).nc", nx: domain.grid.nx, ny: domain.grid.ny)
-            try om.updateFromTimeOriented(variable: variable.rawValue, array2d: data2d, time: time, skipFirst: 0, scalefactor: variable.scalefactor, storePreviousForecast: variable.storePreviousForecast)
+            try om.updateFromTimeOriented(variable: variable.rawValue, array2d: data2d, time: time, scalefactor: variable.scalefactor, storePreviousForecast: variable.storePreviousForecast)
             logger.info("Update om finished in \(startOm.timeElapsedPretty())")
         }
         
@@ -253,7 +253,7 @@ struct DownloadCamsCommand: AsyncCommand {
             logger.info("Create om file")
             let startOm = DispatchTime.now()
             let time = TimerangeDt(start: run, nTime: data2d.nTime, dtSeconds: domain.dtSeconds)
-            try om.updateFromTimeOriented(variable: variable.rawValue, array2d: data2d, time: time, skipFirst: 0,  scalefactor: variable.scalefactor, storePreviousForecast: variable.storePreviousForecast)
+            try om.updateFromTimeOriented(variable: variable.rawValue, array2d: data2d, time: time, scalefactor: variable.scalefactor, storePreviousForecast: variable.storePreviousForecast)
             logger.info("Update om finished in \(startOm.timeElapsedPretty())")
         }
     }

--- a/Sources/App/Dmi/DmiDownloader.swift
+++ b/Sources/App/Dmi/DmiDownloader.swift
@@ -247,7 +247,7 @@ struct DmiDownload: AsyncCommand {
                     }
                     
                     let fn = try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: variable.scalefactor, all: grib2d.array.data)
-                    return GenericVariableHandle(variable: variable, time: timestamp, member: member, fn: fn, skipHour0: stepType == "accum" || stepType == "avg")
+                    return GenericVariableHandle(variable: variable, time: timestamp, member: member, fn: fn)
                 }.collect().compactMap({$0})
                 
                 previous = previousScoped

--- a/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
+++ b/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
@@ -196,8 +196,7 @@ struct DownloadEcmwfCommand: AsyncCommand {
                     variable: rh,
                     time: timestamp,
                     member: member,
-                    fn: fn,
-                    skipHour0: false
+                    fn: fn
                 ))
             }
             
@@ -215,15 +214,13 @@ struct DownloadEcmwfCommand: AsyncCommand {
                     variable: u,
                     time: timestamp,
                     member: member,
-                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: u.scalefactor, all: uData),
-                    skipHour0: false
+                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: u.scalefactor, all: uData)
                 ))
                 handles.append(GenericVariableHandle(
                     variable: v,
                     time: timestamp,
                     member: member,
-                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: u.scalefactor, all: vData),
-                    skipHour0: false
+                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: u.scalefactor, all: vData)
                 ))
             }
             
@@ -343,8 +340,7 @@ struct DownloadEcmwfCommand: AsyncCommand {
                     variable: variable,
                     time: timestamp,
                     member: member,
-                    fn: fn,
-                    skipHour0: skipHour0
+                    fn: fn
                 )
             }.collect().compactMap({$0})
             handles.append(contentsOf: h)
@@ -361,8 +357,7 @@ struct DownloadEcmwfCommand: AsyncCommand {
                         variable: EcmwfVariable.relative_humidity_2m,
                         time: timestamp,
                         member: member,
-                        fn: fn,
-                        skipHour0: false
+                        fn: fn
                     ))
                 } else if let rh1000 = await inMemory.get(variable: .relative_humidity_1000hPa, timestamp: timestamp, member: member)?.data {
                     let fn = try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: 1, all: rh1000)
@@ -370,8 +365,7 @@ struct DownloadEcmwfCommand: AsyncCommand {
                         variable: EcmwfVariable.relative_humidity_2m,
                         time: timestamp,
                         member: member,
-                        fn: fn,
-                        skipHour0: false
+                        fn: fn
                     ))
                 }
                 
@@ -440,29 +434,25 @@ struct DownloadEcmwfCommand: AsyncCommand {
                     variable: EcmwfVariable.cloud_cover_low,
                     time: timestamp,
                     member: member,
-                    fn: fnCloudCoverLow,
-                    skipHour0: false
+                    fn: fnCloudCoverLow
                 ))
                 handles.append(GenericVariableHandle(
                     variable: EcmwfVariable.cloud_cover_mid,
                     time: timestamp,
                     member: member,
-                    fn: fnCloudCoverMid,
-                    skipHour0: false
+                    fn: fnCloudCoverMid
                 ))
                 handles.append(GenericVariableHandle(
                     variable: EcmwfVariable.cloud_cover_high,
                     time: timestamp,
                     member: member,
-                    fn: fnCloudCoverHigh,
-                    skipHour0: false
+                    fn: fnCloudCoverHigh
                 ))
                 handles.append(GenericVariableHandle(
                     variable: EcmwfVariable.cloud_cover,
                     time: timestamp,
                     member: member,
-                    fn: fnCloudCover,
-                    skipHour0: false
+                    fn: fnCloudCover
                 ))
             }
             
@@ -560,8 +550,7 @@ struct DownloadEcmwfCommand: AsyncCommand {
                     variable: variable,
                     time: timestamp,
                     member: member,
-                    fn: fn,
-                    skipHour0: false
+                    fn: fn
                 )
             }.collect().compactMap({$0})
             handles.append(contentsOf: h)

--- a/Sources/App/Era5/DownloadEra5Command.swift
+++ b/Sources/App/Era5/DownloadEra5Command.swift
@@ -444,8 +444,7 @@ struct DownloadEra5Command: AsyncCommand {
                                 variable: variable,
                                 time: t,
                                 member: 0,
-                                fn: fn,
-                                skipHour0: false
+                                fn: fn
                             ))
                         }
                     }
@@ -494,7 +493,7 @@ struct DownloadEra5Command: AsyncCommand {
                         let omFile = "\(domain.downloadDirectory)\(timestamp.format_YYYYMMdd)/\(variable.rawValue)_\(timestamp.format_YYYYMMddHH).om"
                         try FileManager.default.removeItemIfExists(at: omFile)
                         let fn = try writer.write(file: omFile, compressionType: .p4nzdec256, scalefactor: variable.scalefactor, all: grib2d.array.data)
-                        return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn, skipHour0: false)
+                        return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn)
                     }.collect().compactMap({$0})
                 }
                 handles.append(contentsOf: h)
@@ -562,8 +561,7 @@ struct DownloadEra5Command: AsyncCommand {
                                 variable: variable,
                                 time: t,
                                 member: 0,
-                                fn: fn,
-                                skipHour0: false
+                                fn: fn
                             ))
                         }
                     }
@@ -661,7 +659,7 @@ struct DownloadEra5Command: AsyncCommand {
                         let omFile = "\(domain.downloadDirectory)\(timestamp.format_YYYYMMdd)/\(variable.rawValue)_\(timestamp.format_YYYYMMddHH).om"
                         try FileManager.default.removeItemIfExists(at: omFile)
                         let fn = try writer.write(file: omFile, compressionType: .p4nzdec256, scalefactor: variable.scalefactor, all: grib2d.array.data)
-                        return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn, skipHour0: false)
+                        return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn)
                     }.collect().compactMap({$0})
                 }
                 handles.append(contentsOf: h)
@@ -768,7 +766,7 @@ struct DownloadEra5Command: AsyncCommand {
                         let omFile = "\(domain.downloadDirectory)\(date)/\(variable.rawValue)_\(date)\(hour.zeroPadded(len: 2)).om"
                         try FileManager.default.removeItemIfExists(at: omFile)
                         let fn = try writer.write(file: omFile, compressionType: .p4nzdec256, scalefactor: variable.scalefactor, all: grib2d.array.data)
-                        return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn, skipHour0: false)
+                        return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn)
                     }.collect().compactMap({$0})
                 }
                 handles.append(contentsOf: h)

--- a/Sources/App/Gem/GemDownloader.swift
+++ b/Sources/App/Gem/GemDownloader.swift
@@ -257,8 +257,7 @@ struct GemDownload: AsyncCommand {
                                     variable: windspeedVariable,
                                     time: run.add(hours: hour),
                                     member: member,
-                                    fn: fn,
-                                    skipHour0: variable.skipHour0
+                                    fn: fn
                                 ))
                                 grib2d.array.data = Meteorology.windirectionFast(u: u, v: grib2d.array.data)
                             }
@@ -269,8 +268,7 @@ struct GemDownload: AsyncCommand {
                             variable: variable,
                             time: run.add(hours: hour),
                             member: member,
-                            fn: fn,
-                            skipHour0: variable.skipHour0
+                            fn: fn
                         ))
                     }
                 } catch {

--- a/Sources/App/Gfs/GfsDownload.swift
+++ b/Sources/App/Gfs/GfsDownload.swift
@@ -273,8 +273,7 @@ struct GfsDownload: AsyncCommand {
                         variable: variable.variable,
                         time: timestamp,
                         member: 0,
-                        fn: fn,
-                        skipHour0: variable.variable.skipHour0(for: domain)
+                        fn: fn
                     ))
                 }
             }
@@ -424,9 +423,7 @@ struct GfsDownload: AsyncCommand {
                     handles.append(GenericVariableHandle(
                         variable: variable.variable,
                         time: timestamp,
-                        member: member, fn: fn,
-                        skipHour0: variable.variable.skipHour0(for: domain)
-                    ))
+                        member: member, fn: fn                    ))
                 }
             }
             if domain.ensembleMembers > 1 {
@@ -505,7 +502,7 @@ struct GfsDownload: AsyncCommand {
                 variable: GfsSurfaceVariable.precipitation_probability,
                 time: run.add(hours: forecastHour),
                 member: 0,
-                fn: fn, skipHour0: false
+                fn: fn
             ))
         }
         await curl.printStatistics()

--- a/Sources/App/Gfs/PrecipitationProbability.swift
+++ b/Sources/App/Gfs/PrecipitationProbability.swift
@@ -137,8 +137,7 @@ extension VariablePerMemberStorage {
             variable: variable,
             time: timestamp,
             member: 0,
-            fn: fn,
-            skipHour0: false
+            fn: fn
         )
     }
 }
@@ -181,8 +180,7 @@ extension Array where Element == GenericVariableHandle {
                     variable: variable,
                     time: timestamp,
                     member: 0,
-                    fn: fn,
-                    skipHour0: false
+                    fn: fn
                 )
             })
     }

--- a/Sources/App/GfsGraphCast/GfsGraphCastDownload.swift
+++ b/Sources/App/GfsGraphCast/GfsGraphCastDownload.swift
@@ -175,7 +175,7 @@ struct GfsGraphCastDownload: AsyncCommand {
                     
                     logger.info("Compressing and writing data to \(variable.omFileName.file)_\(forecastHour).om")
                     let fn = try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: variable.scalefactor, all: grib2d.array.data)
-                    return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn, skipHour0: false)
+                    return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn)
                 }.collect().compactMap({$0})
             }
             
@@ -202,8 +202,7 @@ struct GfsGraphCastDownload: AsyncCommand {
                     variable: rhVariable,
                     time: v.timestamp,
                     member: v.member,
-                    fn: fn,
-                    skipHour0: false
+                    fn: fn
                 )
             }.compactMap({$0})
             
@@ -224,8 +223,7 @@ struct GfsGraphCastDownload: AsyncCommand {
                     variable: v.variable,
                     time: v.timestamp,
                     member: v.member,
-                    fn: fn,
-                    skipHour0: false
+                    fn: fn
                 )
             }.compactMap({$0})
             
@@ -272,29 +270,25 @@ struct GfsGraphCastDownload: AsyncCommand {
                     variable: GfsGraphCastSurfaceVariable.cloud_cover_low,
                     time: timestamp,
                     member: 0,
-                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: 1, all: cloudcover_low),
-                    skipHour0: false
+                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: 1, all: cloudcover_low)
                 ),
                 GenericVariableHandle(
                     variable: GfsGraphCastSurfaceVariable.cloud_cover_mid,
                     time: timestamp,
                     member: 0,
-                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: 1, all: cloudcover_mid),
-                    skipHour0: false
+                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: 1, all: cloudcover_mid)
                 ),
                 GenericVariableHandle(
                     variable: GfsGraphCastSurfaceVariable.cloud_cover_high,
                     time: timestamp,
                     member: 0,
-                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: 1, all: cloudcover_high),
-                    skipHour0: false
+                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: 1, all: cloudcover_high)
                 ),
                 GenericVariableHandle(
                     variable: GfsGraphCastSurfaceVariable.cloud_cover,
                     time: timestamp,
                     member: 0,
-                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: 1, all: cloudcover),
-                    skipHour0: false
+                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: 1, all: cloudcover)
                 )
             ]
             return handles + handles2 + handles3 + handlesClouds

--- a/Sources/App/GloFas/GloFasDownloader.swift
+++ b/Sources/App/GloFas/GloFasDownloader.swift
@@ -209,7 +209,7 @@ struct GloFasDownloader: AsyncCommand {
                                 var data2d = Array2DFastTime(nLocations: nLocationsPerChunk, nTime: nTime)
                                 /// Reused read buffer
                                 var readTemp = [Float](repeating: .nan, count: nLocationsPerChunk)
-                                try om.updateFromTimeOrientedStreaming(variable: name, time: timerange, skipFirst: 0, scalefactor: 1000, compression: .p4nzdec256logarithmic, storePreviousForecast: false) { d0offset in
+                                try om.updateFromTimeOrientedStreaming(variable: name, time: timerange, scalefactor: 1000, compression: .p4nzdec256logarithmic, storePreviousForecast: false) { d0offset in
                                     
                                     try Task.checkCancellation()
                                     
@@ -327,7 +327,7 @@ struct GloFasDownloader: AsyncCommand {
             data2d[0..<nx*ny, i] = try dailyFile.readAll()
         }
         logger.info("Update om database")
-        try om.updateFromTimeOriented(variable: "river_discharge", array2d: data2d, time: timeinterval, skipFirst: 0, scalefactor: 1000, compression: .p4nzdec256logarithmic, storePreviousForecast: false)
+        try om.updateFromTimeOriented(variable: "river_discharge", array2d: data2d, time: timeinterval, scalefactor: 1000, compression: .p4nzdec256logarithmic, storePreviousForecast: false)
     }
     
     /// Convert a single file

--- a/Sources/App/Helper/Aggregation.swift
+++ b/Sources/App/Helper/Aggregation.swift
@@ -1,0 +1,42 @@
+extension Array where Element == Float {
+    /// Aggregate data
+    /// timeOld = 1h
+    /// timeNew = 3h
+    func aggregate(type: ReaderInterpolation, timeOld: TimerangeDt, timeNew: TimerangeDt) -> [Float] {
+        let steps = timeNew.dtSeconds / timeOld.dtSeconds
+        let backSeconds = -1 * timeOld.dtSeconds * (steps - 1)
+        precondition(timeNew.dtSeconds % timeOld.dtSeconds == 0)
+        switch type {
+        case .linear, .linearDegrees, .hermite(_), .backwards:
+            // take instantanous value
+            return timeNew.map({ t in
+                guard let i = timeOld.index(of: t) else {
+                    return .nan
+                }
+                return self[i]
+            })
+        case .solar_backwards_averaged:
+            /// Average past steps
+            return timeNew.map({ t in
+                guard let start = timeOld.index(of: t.add(backSeconds)) else {
+                    return .nan
+                }
+                guard let end = timeOld.index(of: t) else {
+                    return .nan
+                }
+                return self[start...end].mean()
+            })
+        case .backwards_sum:
+            /// Sum past steps
+            return timeNew.map({ t in
+                guard let start = timeOld.index(of: t.add(backSeconds)) else {
+                    return .nan
+                }
+                guard let end = timeOld.index(of: t) else {
+                    return .nan
+                }
+                return self[start...end].reduce(0, +)
+            })
+        }
+    }
+}

--- a/Sources/App/Helper/OmFile.swift
+++ b/Sources/App/Helper/OmFile.swift
@@ -244,12 +244,12 @@ struct OmFileSplitter {
      Write new data to the archived storage and combine it with existint data.
      Updates are done in chunks to keep memory size low. Otherwise ICON update would take 4+ GB memory for just this function.
      */
-    func updateFromTimeOriented(variable: String, array2d: Array2DFastTime, time: TimerangeDt, skipFirst: Int, scalefactor: Float, compression: CompressionType = .p4nzdec256, storePreviousForecast: Bool) throws {
+    func updateFromTimeOriented(variable: String, array2d: Array2DFastTime, time: TimerangeDt, scalefactor: Float, compression: CompressionType = .p4nzdec256, storePreviousForecast: Bool) throws {
         
         precondition(array2d.nTime == time.count)
         
         // Process at most 8 MB at once
-        try updateFromTimeOrientedStreaming(variable: variable, time: time, skipFirst: skipFirst, scalefactor: scalefactor, compression: compression, storePreviousForecast: storePreviousForecast) { d0offset in
+        try updateFromTimeOrientedStreaming(variable: variable, time: time, scalefactor: scalefactor, compression: compression, storePreviousForecast: storePreviousForecast) { d0offset in
             
             let locationRange = d0offset ..< min(d0offset+nLocationsPerChunk, nLocations)
             let dataRange = locationRange.multiply(array2d.nTime)
@@ -261,7 +261,7 @@ struct OmFileSplitter {
      Write new data to archived storage and combine it with existing data.
      `supplyChunk` should provide data for a couple of thousands locations at once. Upates are done streamlingly to low memory usage
      */
-    func updateFromTimeOrientedStreaming(variable: String, time: TimerangeDt, skipFirst: Int, scalefactor: Float, compression: CompressionType = .p4nzdec256, storePreviousForecast: Bool, supplyChunk: (_ dim0Offset: Int) throws -> ArraySlice<Float>) throws {
+    func updateFromTimeOrientedStreaming(variable: String, time: TimerangeDt, scalefactor: Float, compression: CompressionType = .p4nzdec256, storePreviousForecast: Bool, supplyChunk: (_ dim0Offset: Int) throws -> ArraySlice<Float>) throws {
         
         let indexTime = time.toIndexTime()
         let indextimeChunked  = indexTime.lowerBound / nTimePerFile ..< indexTime.upperBound.divideRoundedUp(divisor: nTimePerFile)
@@ -285,7 +285,7 @@ struct OmFileSplitter {
             }
             
             return try (0..<nPreviousDays).map { previousDay -> WriterPerStep in
-                let skip = previousDay > 0 ? previousDay * 86400 / time.dtSeconds : skipFirst
+                let skip = previousDay > 0 ? previousDay * 86400 / time.dtSeconds : 0
                 let readFile = OmFileManagerReadable.domainChunk(domain: domain, variable: variable, type: .chunk, chunk: timeChunk, ensembleMember: 0, previousDay: previousDay)
                 try readFile.createDirectory()
                 let tempFile = readFile.getFilePath() + "~"

--- a/Sources/App/Icon/DownloadIconCommand.swift
+++ b/Sources/App/Icon/DownloadIconCommand.swift
@@ -193,8 +193,7 @@ struct DownloadIconCommand: AsyncCommand {
                             variable: variable,
                             time: timestamp,
                             member: 0,
-                            fn: fn,
-                            skipHour0: variable.skipHour(hour: 0, domain: domain, forDownload: false, run: run)
+                            fn: fn
                         ))
                     }
                     messages = [messages[0]]
@@ -231,8 +230,7 @@ struct DownloadIconCommand: AsyncCommand {
                         variable: variable,
                         time: timestamp,
                         member: member,
-                        fn: fn,
-                        skipHour0: variable.skipHour(hour: 0, domain: domain, forDownload: false, run: run)
+                        fn: fn
                     ))
                 }
             }
@@ -354,8 +352,7 @@ struct DownloadIconCommand: AsyncCommand {
                     variable: v.variable,
                     time: v.timestamp,
                     member: v.member,
-                    fn: fn,
-                    skipHour0: v.variable.skipHour(hour: 0, domain: domain, forDownload: false, run: run)
+                    fn: fn
                 ))
             }
             
@@ -428,8 +425,7 @@ struct DownloadIconCommand: AsyncCommand {
                     variable: v.variable,
                     time: v.timestamp,
                     member: v.member,
-                    fn: fn,
-                    skipHour0: v.variable.skipHour(hour: 0, domain: domain, forDownload: false, run: run)
+                    fn: fn
                 ))
             }
             previousHour = hour

--- a/Sources/App/IconWave/IconWaveDownload.swift
+++ b/Sources/App/IconWave/IconWaveDownload.swift
@@ -131,7 +131,6 @@ struct DownloadIconWaveCommand: AsyncCommand {
         
         for variable in variables {
             let progress = ProgressTracker(logger: logger, total: nLocations, label: "Convert \(variable.rawValue)")
-            let skip = 0
 
             let readers: [(hour: Int, reader: OmFileReader<MmapFile>)] = try forecastHours.compactMap({ hour in
                 let reader = try OmFileReader(file: "\(domain.downloadDirectory)\(variable.rawValue)_\(hour).om")
@@ -139,7 +138,7 @@ struct DownloadIconWaveCommand: AsyncCommand {
                 return (hour, reader)
             })
             
-            try om.updateFromTimeOrientedStreaming(variable: variable.omFileName.file, time: time, skipFirst: skip, scalefactor: variable.scalefactor, storePreviousForecast: variable.storePreviousForecast) { d0offset in
+            try om.updateFromTimeOrientedStreaming(variable: variable.omFileName.file, time: time, scalefactor: variable.scalefactor, storePreviousForecast: variable.storePreviousForecast) { d0offset in
                 
                 let locationRange = d0offset ..< min(d0offset+nLocationsPerChunk, nLocations)
                 data2d.data.fillWithNaNs()

--- a/Sources/App/JMA/JmaDownloader.swift
+++ b/Sources/App/JMA/JmaDownloader.swift
@@ -145,7 +145,7 @@ struct JmaDownload: AsyncCommand {
                     //try data.writeNetcdf(filename: "\(domain.downloadDirectory)\(variable.variable.omFileName.file)_\(variable.hour).nc")
                     logger.info("Compressing and writing data to \(variable.omFileName.file)_\(hour).om")
                     let fn = try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: variable.scalefactor, all: grib2d.array.data)
-                    return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn, skipHour0: variable.skipHour0)
+                    return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn)
                 }.collect().compactMap({$0})
             }
         }

--- a/Sources/App/Knmi/KnmiDownloader.swift
+++ b/Sources/App/Knmi/KnmiDownloader.swift
@@ -269,7 +269,7 @@ struct KnmiDownload: AsyncCommand {
                 }
                 
                 let fn = try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: variable.scalefactor, all: grib2d.array.data)
-                return GenericVariableHandle(variable: variable, time: timestamp, member: member, fn: fn, skipHour0: stepType == "accum" || stepType == "avg")
+                return GenericVariableHandle(variable: variable, time: timestamp, member: member, fn: fn)
             }.collect().compactMap({$0})
             
             if generateElevationFile {

--- a/Sources/App/MetNo/MetNoDownloader.swift
+++ b/Sources/App/MetNo/MetNoDownloader.swift
@@ -126,7 +126,6 @@ struct MetNoDownloader: AsyncCommand {
         
         for variable in variables {
             logger.info("Converting \(variable)")
-            let skip = variable.skipHour0 ? 1 : 0
             
             guard let ncVar = ncFile.getVariable(name: variable.netCdfName) else {
                 fatalError("Could not open nc variable \(variable) \(variable.netCdfName)")
@@ -139,12 +138,12 @@ struct MetNoDownloader: AsyncCommand {
             
             /// Create chunked time-series arrays instead of transposing the entire array
             let progress = ProgressTracker(logger: logger, total: nLocations, label: "Convert \(variable.rawValue)")
-            try om.updateFromTimeOrientedStreaming(variable: variable.omFileName.file, time: time, skipFirst: skip, scalefactor: variable.scalefactor, storePreviousForecast: variable.storePreviousForecast) { d0offset in
+            try om.updateFromTimeOrientedStreaming(variable: variable.omFileName.file, time: time, scalefactor: variable.scalefactor, storePreviousForecast: variable.storePreviousForecast) { d0offset in
                 
                 let locationRange = d0offset ..< min(d0offset+nLocationsPerChunk, nLocations)
                 var data2d = Array2DFastTime(nLocations: locationRange.count, nTime: nTime)
                 for (i,l) in locationRange.enumerated() {
-                    for h in skip..<nTime {
+                    for h in 0..<nTime {
                         data2d[i, h] = spatial[h, l]
                     }
                 }

--- a/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
@@ -322,7 +322,7 @@ struct MeteoFranceDownload: AsyncCommand {
                         
                         logger.info("Compressing and writing data to \(timestamp.format_YYYYMMddHH) \(variable)")
                         let fn = try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: variable.scalefactor, all: grib2d.array.data)
-                        return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn, skipHour0: stepType == "accum" || stepType == "avg")
+                        return GenericVariableHandle(variable: variable, time: timestamp, member: 0, fn: fn)
                     }.collect()
                     
                     let writer = OmFileWriter(dim0: 1, dim1: grid.count, chunk0: 1, chunk1: nLocationsPerChunk)
@@ -504,8 +504,7 @@ struct MeteoFranceDownload: AsyncCommand {
                     variable: variable,
                     time: timestamp,
                     member: 0,
-                    fn: fn,
-                    skipHour0: variable.skipHour0(domain: domain)
+                    fn: fn
                 ))
                 
             }
@@ -533,8 +532,7 @@ extension VariablePerMemberStorage {
                     variable: outVariable,
                     time: t.timestamp,
                     member: t.member,
-                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: outVariable.scalefactor, all: precip),
-                    skipHour0: false
+                    fn: try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: outVariable.scalefactor, all: precip)
                 )
             }
         )

--- a/Sources/App/MfWave/MfWaveDownload.swift
+++ b/Sources/App/MfWave/MfWaveDownload.swift
@@ -190,8 +190,7 @@ struct MfWaveDownload: AsyncCommand {
                                 variable: variable,
                                 time: timestamp,
                                 member: 0,
-                                fn: fn,
-                                skipHour0: false
+                                fn: fn
                             )
                         }
                     }
@@ -228,8 +227,7 @@ struct MfWaveDownload: AsyncCommand {
                             variable: variable,
                             time: timestamp,
                             member: 0,
-                            fn: fn,
-                            skipHour0: false
+                            fn: fn
                         )
                     }
                 }.flatMap({$0})

--- a/Sources/App/SeasonalForecast/SeasonalForecastDownload.swift
+++ b/Sources/App/SeasonalForecast/SeasonalForecastDownload.swift
@@ -193,7 +193,7 @@ fileprivate extension Array2DFastTime {
         let startOm = DispatchTime.now()
         let time = TimerangeDt(start: run, nTime: nTime, dtSeconds: dtSeconds)
         
-        try om.updateFromTimeOriented(variable: "\(variable.rawValue)_member\(member.zeroPadded(len: 2))", array2d: self, time: time, skipFirst: 1, scalefactor: variable.scalefactor, storePreviousForecast: variable.storePreviousForecast)
+        try om.updateFromTimeOriented(variable: "\(variable.rawValue)_member\(member.zeroPadded(len: 2))", array2d: self, time: time, scalefactor: variable.scalefactor, storePreviousForecast: variable.storePreviousForecast)
         logger.info("Update om \(variable) finished in \(startOm.timeElapsedPretty())")
     }
 }

--- a/Sources/App/UKMO/UkmoDownloader.swift
+++ b/Sources/App/UKMO/UkmoDownloader.swift
@@ -239,8 +239,7 @@ struct UkmoDownload: AsyncCommand {
                             variable: variable,
                             time: timestamp,
                             member: 0,
-                            fn: fn,
-                            skipHour0: variable.skipHour0
+                            fn: fn
                         )
                     }
                 }.flatMap({$0})

--- a/Tests/AppTests/ArrayTests.swift
+++ b/Tests/AppTests/ArrayTests.swift
@@ -14,23 +14,28 @@ final class ArrayTests: XCTestCase {
     
     func testBackwardInterpolateInplace() {
         var a: [Float] = [0,1,.nan,.nan,.nan,5]
-        a.interpolateInplaceBackwards(nTime: 6, skipFirst: 0, isSummation: false)
+        a.interpolateInplaceBackwards(nTime: 6, isSummation: false)
         XCTAssertEqual(a, [0,1,5,5,5,5])
         
         // Make sure nTime is honored correctly
         a = [0,.nan,1,.nan,.nan,.nan, 0,.nan,1,.nan,.nan,.nan]
-        a.interpolateInplaceBackwards(nTime: 6, skipFirst: 0, isSummation: false)
+        a.interpolateInplaceBackwards(nTime: 6, isSummation: false)
         XCTAssertEqualArray(a, [0,1,1,.nan,.nan,.nan, 0,1,1,.nan,.nan,.nan], accuracy: 0.0001)
         
         // Make sure nTime is honored correctly
-        a = [.nan,.nan,1,.nan,.nan,.nan, .nan,.nan,1,.nan,.nan,.nan]
-        a.interpolateInplaceBackwards(nTime: 6, skipFirst: 1, isSummation: false)
-        XCTAssertEqualArray(a, [.nan,1,1,.nan,.nan,.nan, .nan,1,1,.nan,.nan,.nan], accuracy: 0.0001)
+        a = [1,.nan,2,.nan,1,.nan, 3,.nan,4,.nan,1,.nan]
+        a.interpolateInplaceBackwards(nTime: 6, isSummation: false)
+        XCTAssertEqualArray(a, [1,2,2,1,1,.nan, 3,4,4,1,1,.nan], accuracy: 0.0001)
         
         // Check sum
-        a = [.nan,.nan,1,.nan,.nan,.nan, .nan,.nan,1,.nan,.nan,.nan]
-        a.interpolateInplaceBackwards(nTime: 6, skipFirst: 1, isSummation: true)
-        XCTAssertEqualArray(a, [.nan,0.5,0.5,.nan,.nan,.nan, .nan,0.5,0.5,.nan,.nan,.nan], accuracy: 0.0001)
+        a = [.nan,.nan,1.5,.nan,.nan,1.5, .nan,.nan,3,.nan,.nan,3]
+        a.interpolateInplaceBackwards(nTime: 6, isSummation: true)
+        XCTAssertEqualArray(a, [0.5,0.5,0.5,0.5,0.5,0.5, 1,1,1,1,1,1], accuracy: 0.0001)
+        
+        // Check spacing detection
+        a = [.nan,.nan,.nan,1.5,.nan,.nan,1.5, .nan,.nan,.nan,3,.nan,.nan,3]
+        a.interpolateInplaceBackwards(nTime: 7, isSummation: true)
+        XCTAssertEqualArray(a, [.nan,0.5,0.5,0.5,0.5,0.5,0.5, .nan,1,1,1,1,1,1], accuracy: 0.0001)
     }
     
     func testInterpolateDegrees() {
@@ -84,20 +89,20 @@ final class ArrayTests: XCTestCase {
         let coords = IconDomains.icon.grid.getCoordinates(gridpoint: 1256 + 2879 * 1132)
         let grid = RegularGrid(nx: 1, ny: 1, latMin: coords.latitude, lonMin: coords.longitude, dx: 1, dy: 1)
         var time = TimerangeDt(start: Timestamp(2022,08,16), nTime: data.count, dtSeconds: 3600)
-        data.interpolateInplaceSolarBackwards(skipFirst: 1, time: time, grid: grid, locationRange: 0..<1)
+        data.interpolateInplaceSolarBackwards(time: time, grid: grid, locationRange: 0..<1)
         
         XCTAssertEqualArray(data[79..<181], [2.7751129, 12.565333, 29.92181, 68.30576, 131.8756, 208.47153, 294.43616, 375.1984, 409.64493, 379.91507, 308.65784, 221.19334, 128.86157, 52.262794, 9.649313, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.114281915, 0.58105505, 1.2083836, 2.049771, 3.058337, 3.6581643, 3.113253, 1.8148575, 0.87113553, 0.9296356, 1.2847356, 1.2012333, 0.62843615, 0.14723891, 0.0017813047, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.024401145, 0.0, 3.7263098, 48.388783, 136.54715, 215.34631, 230.58772, 197.1857, 151.3438, 107.45953, 63.816956, 32.818916, 16.335684, 7.1231337, 1.4328097, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.870412, 13.837922, 38.44829, 115.605644, 251.0613, 378.11237, 428.5317, 416.82214, 379.8396, 334.78162, 273.56696, 201.93892, 125.62505, 57.04836, 11.268686, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 6.6770487, 39.30699, 84.17851, 133.38658, 185.12206, 228.63828], accuracy: 0.001)
         // original: [0.5327332, 7.0458064, 30.065294, 68.640236, 125.21594, 208.47006, 287.15527, 362.1674, 409.62054, 381.09317, 313.93628, 221.14587, 134.36256, 58.54249, 9.156854, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.02641212, 0.35874152, 1.2143807, 2.1519227, 3.0996456, 3.658186, 3.2371387, 2.086485, 0.87108666, 0.88595426, 1.1891304, 1.2009717, 0.6598327, 0.18529162, 0.0016845806, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 3.7452843, 43.235752, 122.65912, 215.34958, 233.18326, 206.56552, 151.33687, 110.88687, 69.342674, 32.812675, 17.16428, 7.791204, 1.3503972, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.45440406, 7.076116, 38.64731, 112.47823, 234.80026, 378.12024, 429.4058, 423.3296, 379.82858, 336.3908, 276.80637, 201.91202, 130.41829, 62.39851, 10.584465, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.5342923, 24.450073, 84.617775, 142.16772, 190.57127, 228.64375]
         
         /// Mix 3 and 6 hourly missing values
         data = [.nan, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.3125, 11.9375, 57.484375, 75.203125, 81.625, 56.3125, 69.359375, 100.671875, 320.9375, 400.78125, 373.76562, 246.95312, 53.632812, 29.242188, 2.578125, -0.109375, 0.0, 0.0625, 0.0859375, -0.0859375, 0.0234375, -0.0859375, 0.140625, -0.03125, 0.2421875, 4.2109375, 3.515625, 8.65625, 14.0, 4.015625, 18.257812, 0.3359375, 4.0, 1.90625, 0.796875, 1.09375, 3.59375, 0.578125, -0.046875, 0.140625, 0.1015625, -0.1953125, -0.015625, -0.109375, 0.2890625, -0.0078125, -0.234375, 0.03125, 2.96875, 27.578125, 98.99219, 126.14844, 183.63281, 261.22656, 319.10156, 409.4922, 386.6797, 374.72656, 353.08594, 311.9453, 132.4375, 70.46875, 8.3828125, -0.0703125, 0.0703125, -0.2578125, 0.0546875, -0.1171875, 0.3671875, -0.2421875, -0.203125, 0.515625, .nan, .nan, 15.9765625, .nan, .nan, 175.58594, .nan, .nan, 411.35938, .nan, .nan, 272.71875, .nan, .nan, 40.820312, .nan, .nan, -0.0234375, .nan, .nan, -0.0859375, .nan, .nan, 0.0546875, .nan, .nan, 0.640625, .nan, .nan, 3.078125, .nan, .nan, 0.875, .nan, .nan, 1.484375, .nan, .nan, 0.0078125, .nan, .nan, -0.0546875, .nan, .nan, 0.140625, .nan, .nan, -0.0625, .nan, .nan, 1.9609375, .nan, .nan, 181.02344, .nan, .nan, 152.05469, .nan, .nan, 40.648438, .nan, .nan, 6.5390625, .nan, .nan, -0.0546875, .nan, .nan, .nan, .nan, .nan, (0.1875-0.015625)/2, .nan, .nan, .nan, .nan, .nan, (317.53125+20.078125)/2, .nan, .nan, .nan, .nan, .nan, (250.71094+381.72656)/2, .nan, .nan, .nan, .nan, .nan, (-0.3359375+53.742188)/2, .nan, .nan, .nan, .nan, .nan, (-0.0625+0.171875)/2, .nan, .nan, .nan, .nan, .nan, (191.8125+43.609375)/2]
-        data.interpolateInplaceSolarBackwards(skipFirst: 1, time: time, grid: grid, locationRange: 0..<1)
+        data.interpolateInplaceSolarBackwards(time: time, grid: grid, locationRange: 0..<1)
         XCTAssertEqualArray(data[79..<181], [2.7751129, 12.565333, 29.92181, 68.30576, 131.8756, 208.47153, 294.43616, 375.1984, 409.64493, 379.91507, 308.65784, 221.19334, 128.86157, 52.262794, 9.649313, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.114281915, 0.58105505, 1.2083836, 2.049771, 3.058337, 3.6581643, 3.113253, 1.8148575, 0.87113553, 0.9296356, 1.2847356, 1.2012333, 0.62843615, 0.14723891, 0.0017813047, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.024401145, 0.0, 3.7263098, 48.388783, 136.54715, 215.34631, 230.58772, 197.1857, 151.3438, 107.45953, 63.816956, 32.818916, 16.335684, 7.1231337, 1.4328097, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.024332, 67.70339, 140.62544, 208.97667, 268.2166, 314.4697, 346.27148, 361.9829, 358.3321, 333.28455, 287.1204, 223.18909, 147.80145, 71.60986, 14.433392, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 7.8246827, 46.422653, 97.88847, 146.12347, 187.83421, 220.17207], accuracy: 0.001)
         
         /// Immediately 3 hourly data. Note: the left-most values only rely on the clearness index of the first point
         data = [.nan, .nan, .nan, 320.9375, .nan, .nan, 246.95312, .nan, .nan, 2.578125, .nan, .nan, 0.0, .nan, .nan, 0.0]
         time = TimerangeDt(start: Timestamp(2022,08,16,12), nTime: data.count, dtSeconds: 3600)
-        data.interpolateInplaceSolarBackwards(skipFirst: 1, time: time, grid: grid, locationRange: 0..<1)
+        data.interpolateInplaceSolarBackwards(time: time, grid: grid, locationRange: 0..<1)
         XCTAssertEqualArray(data, [.nan, 316.6924, 327.28204, 319.8192, 304.3659, 271.0651, 201.56267, 101.99449, 25.591284, 0.6671406, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], accuracy: 0.001)
     }
     
@@ -185,7 +190,7 @@ func XCTAssertEqualArray<T: Collection>(_ a: T, _ b: T, accuracy: Float) where T
         if a1.isNaN && b1.isNaN {
             continue
         }
-        if abs(a1 - b1) > accuracy {
+        if a1.isNaN || b1.isNaN || abs(a1 - b1) > accuracy {
             failed = true
             break
         }
@@ -195,7 +200,7 @@ func XCTAssertEqualArray<T: Collection>(_ a: T, _ b: T, accuracy: Float) where T
             if a1.isNaN && b1.isNaN {
                 continue
             }
-            if abs(a1 - b1) > accuracy {
+            if a1.isNaN || b1.isNaN || abs(a1 - b1) > accuracy {
                 print("\(a1)\t\(b1)\t\(a1-b1)")
             }
         }

--- a/Tests/AppTests/ZensunTests.swift
+++ b/Tests/AppTests/ZensunTests.swift
@@ -180,7 +180,7 @@ final class ZensunTests: XCTestCase {
             averagedWithNaNs[7+i*2+1] = averagedWithNaNs[7+i*2..<9+i*2].mean()
             averagedWithNaNs[7+i*2] = .nan
         }
-        averagedWithNaNs.interpolateInplaceSolarBackwards(skipFirst: 0, time: time, grid: position, locationRange: 0..<1)
+        averagedWithNaNs.interpolateInplaceSolarBackwards(time: time, grid: position, locationRange: 0..<1)
         XCTAssertEqualArray(reference, averagedWithNaNs, accuracy: 0.001)
         
         averagedWithNaNs = reference
@@ -190,7 +190,7 @@ final class ZensunTests: XCTestCase {
             averagedWithNaNs[7+i*3] = .nan
         }
         print(averagedWithNaNs)
-        averagedWithNaNs.interpolateInplaceSolarBackwards(skipFirst: 0, time: time, grid: position, locationRange: 0..<1)
+        averagedWithNaNs.interpolateInplaceSolarBackwards(time: time, grid: position, locationRange: 0..<1)
         XCTAssertEqualArray(reference, averagedWithNaNs, accuracy: 0.01)
     }
     


### PR DESCRIPTION
Automatically detects initial missing data in interpolation like `--DDDDD--D--D--D` and interpolates correctly to `--DDDDDddDddDddD` ( `-` = missing, `D` = data, `d` = interpolated)

Also detect data spacing like `--D--D--D` and interpolates to `ddDDddDDddD`

Removes all skipHour0 attributes, which are not required anymore for data conversion