### PR TITLE
Remove old GFS precipitation probability calculation

### DIFF
--- a/Sources/App/Commands/MigrationCommand.swift
+++ b/Sources/App/Commands/MigrationCommand.swift
@@ -190,8 +190,6 @@ struct MigrationCommand: Command {
             return .ncep_gfs025
         case "gfs025_ens":
             return .ncep_gefs025
-        case "gfs025_ensemble":
-            return .ncep_gefs025_probability
         case "gfs05_ens":
             return .ncep_gefs05
         case "hrrr_conus":

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -366,7 +366,7 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
             let gfsProbabilites = try ProbabilityReader.makeGfsReader(lat: lat, lon: lon, elevation: elevation, mode: mode)
             let iconProbabilities = try ProbabilityReader.makeIconReader(lat: lat, lon: lon, elevation: elevation, mode: mode)
             
-            guard let gfs: any GenericReaderProtocol = try GfsReader(domains: [.gfs025_ensemble, .gfs025, .gfs013], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options) else {
+            guard let gfs: any GenericReaderProtocol = try GfsReader(domains: [.gfs025, .gfs013], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options) else {
                 throw ModelError.domainInitFailed(domain: IconDomains.icon.rawValue)
             }
             // For Netherlands and Belgium use KNMI
@@ -435,7 +435,7 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
             return [gfsProbabilites] + (try GfsReader(domains: [.gfs025, .gfs013, .hrrr_conus, .hrrr_conus_15min], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? [])
         case .gfs_global:
             let gfsProbabilites = try ProbabilityReader.makeGfsReader(lat: lat, lon: lon, elevation: elevation, mode: mode)
-            return [gfsProbabilites] + (try GfsReader(domains: [.gfs025_ensemble, .gfs025, .gfs013], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? [])
+            return [gfsProbabilites] + (try GfsReader(domains: [.gfs025, .gfs013], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? [])
         case .gfs025:
             return try GfsReader(domains: [.gfs025], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
         case .gfs013:

--- a/Sources/App/Gfs/GfsDomain.swift
+++ b/Sources/App/Gfs/GfsDomain.swift
@@ -20,9 +20,6 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
     
     case hrrr_conus_15min
     
-    /// Only used for precipitation probability on the fly
-    case gfs025_ensemble
-    
     /// Actually contains raw member data.
     /// Contains up to 35 days of forecast, BUT the first 16 days are calculated at first, followed by day 16-25 18 hours later and only for 0z run.
     case gfs025_ens
@@ -44,8 +41,6 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
             return .ncep_hrrr_conus
         case .hrrr_conus_15min:
             return .ncep_hrrr_conus_15min
-        case .gfs025_ensemble:
-            return .ncep_gefs025_probability
         case .gfs025_ens:
             return .ncep_gefs025
         case .gfs05_ens:
@@ -61,7 +56,7 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
         switch self {
         case .hrrr_conus_15min:
             return .ncep_hrrr_conus
-        case .gfs025_ensemble, .gfswave025, .gfswave025_ens:
+        case .gfswave025, .gfswave025_ens:
             return .ncep_gefs025
         default:
             return domainRegistry
@@ -86,8 +81,6 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
             return 24
         case .hrrr_conus_15min:
             return 24
-        case .gfs025_ensemble:
-            return 4
         case .gfs025_ens:
             return 4
         case .gfs05_ens:
@@ -107,8 +100,6 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
             return 3600
         case .hrrr_conus:
             return 3600
-        case .gfs025_ensemble:
-            return 3*3600
         case .gfs025_ens, .gfswave025_ens:
             return 3*3600
         case .gfs05_ens:
@@ -128,8 +119,6 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
             return true
         case .hrrr_conus:
             return false
-        case .gfs025_ensemble:
-            return true
         case .gfs025_ens, .gfswave025_ens:
             return true
         case .gfs05_ens:
@@ -148,8 +137,6 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
         case .gfs05_ens:
             fallthrough
         case .gfs025_ens, .gfswave025_ens:
-            fallthrough
-        case .gfs025_ensemble:
             fallthrough
         case .gfs013:
             fallthrough
@@ -189,8 +176,6 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
             return Array(stride(from: 0, to: 240, by: 3)) + Array(stride(from: 240, through: 384, by: 6))
         case .gfs025_ens:
             fallthrough
-        case .gfs025_ensemble:
-            return Array(stride(from: 0, through: 240, by: 3))
         case .gfswave025_ens:
             return Array(stride(from: 0, through: 384, by: 3))
         case .gfs013:
@@ -218,8 +203,6 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
             /// Smaler selection, same as ECMWF IFS04
             return [50, 200, 250, 300, 500, 700, 850, 925, 1000]
         case .gfs025_ens:
-            fallthrough
-        case .gfs025_ensemble:
             return []
         case .gfs013:
             return []
@@ -250,8 +233,6 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
             return (840 + 4*24)/3 + 1 // 313
         case .gfs025_ens:
             fallthrough
-        case .gfs025_ensemble:
-            return (240 + 4*24)/3 + 1 // 113
         //case .nam_conus:
             //return 60 + 4*24
         case .gfs013:
@@ -277,8 +258,6 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
             // Coordinates confirmed with eccodes coordinate output
             return RegularGrid(nx: 3072, ny: 1536, latMin: -0.11714935 * (1536-1) / 2, lonMin: -180, dx: 360/3072, dy: 0.11714935)
         case .gfs025_ens:
-            fallthrough
-        case .gfs025_ensemble:
             fallthrough
         case .gfs025, .gfswave025, .gfswave025_ens:
             return RegularGrid(nx: 1440, ny: 721, latMin: -90, lonMin: -180, dx: 0.25, dy: 0.25)
@@ -333,8 +312,6 @@ enum GfsDomain: String, GenericDomain, CaseIterable {
             let memberString = member == 0 ? "gec00" : "gep\(member.zeroPadded(len: 2))"
             return ["\(gefsServer)gefs.\(yyyymmdd)/\(hh)/atmos/pgrb2ap5/\(memberString).t\(hh)z.pgrb2a.0p50.f\(fHHH)",
                     "\(gefsServer)gefs.\(yyyymmdd)/\(hh)/atmos/pgrb2bp5/\(memberString).t\(hh)z.pgrb2b.0p50.f\(fHHH)"]
-        case .gfs025_ensemble:
-            fallthrough
         case .gfs025_ens:
             let memberString = member == 0 ? "gec00" : "gep\(member.zeroPadded(len: 2))"
             return ["\(gefsServer)gefs.\(yyyymmdd)/\(hh)/atmos/pgrb2sp25/\(memberString).t\(hh)z.pgrb2s.0p25.f\(fHHH)"]

--- a/Sources/App/Gfs/GfsVariable.swift
+++ b/Sources/App/Gfs/GfsVariable.swift
@@ -75,8 +75,6 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
     
     case visibility
     
-    case precipitation_probability
-    
     
     var storePreviousForecast: Bool {
         switch self {
@@ -152,7 +150,6 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .diffuse_radiation: return 1
         case .uv_index: return 20
         case .uv_index_clear_sky: return 20
-        case .precipitation_probability: return 1
         case .categorical_freezing_rain: return 1
         case .convective_inhibition: return 1
         }
@@ -240,8 +237,6 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
             return .hermite(bounds: nil)
         case .visibility:
             return .linear
-        case .precipitation_probability:
-            return .linear
         case .convective_inhibition:
             return .hermite(bounds: nil)
         }
@@ -288,7 +283,6 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .diffuse_radiation: return .wattPerSquareMetre
         case .uv_index: return .dimensionless
         case .uv_index_clear_sky: return .dimensionless
-        case .precipitation_probability: return .percentage
         case .categorical_freezing_rain: return .dimensionless
         case .convective_inhibition: return .joulePerKilogram
         }

--- a/Sources/App/Gfs/GfsVariableDownloadable.swift
+++ b/Sources/App/Gfs/GfsVariableDownloadable.swift
@@ -171,8 +171,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
                 return ":CAPE:surface:"
             case .visibility:
                 return ":VIS:surface:"
-            case .precipitation_probability:
-                return nil
             default:
                 return nil
             }
@@ -209,13 +207,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
                 return ":VDDSF:surface:\(fcst):"
             case .visibility:
                 return ":VIS:surface:\(fcst):"
-            default:
-                return nil
-            }
-        case .gfs025_ensemble:
-            switch self {
-            case .precipitation_probability:
-                return ":APCP:surface:"
             default:
                 return nil
             }
@@ -356,7 +347,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
             }
         }
         switch self {
-        case .precipitation_probability: return true
         case .precipitation: return true
         case .categorical_freezing_rain: return true
         case .sensible_heat_flux: return true
@@ -409,8 +399,6 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
             case .hrrr_conus:
                 // precipitation rate per second to hourly precipitation
                 return (Float(domain.dtSeconds), 0)
-            case .gfs025_ensemble:
-                fallthrough
             case .gfs025_ens:
                 fallthrough
             case .gfs05_ens:
@@ -469,8 +457,6 @@ extension GfsPressureVariable: GfsVariableDownloadable {
                 // Converted later while downlading
                 return ":VVEL:\(level) mb:"
             case .gfs025_ens:
-                return nil
-            case .gfs025_ensemble:
                 return nil
             }
         }

--- a/Sources/App/Gfs/PrecipitationProbability.swift
+++ b/Sources/App/Gfs/PrecipitationProbability.swift
@@ -43,7 +43,6 @@ struct ProbabilityReader {
     /// Read probabilities from GFS ensemble models 0.25° and 0.5°
     static func makeGfsReader(lat: Float, lon: Float, elevation: Float, mode: GridSelectionMode) throws -> GenericReaderMixerSameDomain<GenericReader<GfsDomain, ProbabilityVariable>> {
         return GenericReaderMixerSameDomain(reader: [
-            try GenericReader<GfsDomain, ProbabilityVariable>(domain: .gfs025_ensemble, lat: lat, lon: lon, elevation: elevation, mode: mode),
             try GenericReader<GfsDomain, ProbabilityVariable>(domain: .gfs05_ens, lat: lat, lon: lon, elevation: elevation, mode: mode),
             try GenericReader<GfsDomain, ProbabilityVariable>(domain: .gfs025_ens, lat: lat, lon: lon, elevation: elevation, mode: mode)
         ].compactMap({$0}))

--- a/Sources/App/Helper/DomainRegistry.swift
+++ b/Sources/App/Helper/DomainRegistry.swift
@@ -35,7 +35,6 @@ enum DomainRegistry: String, CaseIterable {
     case ncep_gfswave025
     case ncep_gefswave025
     case ncep_gefs025
-    case ncep_gefs025_probability
     case ncep_gefs05
     case ncep_hrrr_conus
     case ncep_hrrr_conus_15min
@@ -162,8 +161,6 @@ enum DomainRegistry: String, CaseIterable {
             return GfsDomain.gfs025
         case .ncep_gefs025:
             return GfsDomain.gfs025_ens
-        case .ncep_gefs025_probability:
-            return GfsDomain.gfs025_ensemble
         case .ncep_gefs05:
             return GfsDomain.gfs05_ens
         case .glofas_consolidated_v4:

--- a/docs/cronjobs.md
+++ b/docs/cronjobs.md
@@ -20,7 +20,6 @@ This document lists all required cronjobs to download data. However, downloading
 # GFS
 40 3,9,15,21 * * * /usr/local/bin/openmeteo-api download-gfs gfs025 > ~/log/gfs025.log 2>&1 || cat ~/log/gfs025.log
 40 3,9,15,21 * * * /usr/local/bin/openmeteo-api download-gfs gfs013 > ~/log/gfs013.log 2>&1 || cat ~/log/gfs013.log
-40 3,9,15,21 * * * /usr/local/bin/openmeteo-api download-gfs gfs025_ensemble > ~/log/gfs025_ensemble.log 2>&1 || cat ~/log/gfs025_ensemble.log
 
 # HRRR
 55 * * * * /usr/local/bin/openmeteo-api download-gfs hrrr_conus > ~/log/hrrr_conus.log 2>&1 || cat ~/log/hrrr_conus.log


### PR DESCRIPTION
Precipitation probabilities are now calculated while downloading ensemble models. The old work around to calculate precipitation probabilities is not required anymore

With this change the model [`ncep_gefs025_probability`](https://openmeteo.s3.amazonaws.com/index.html#data/ncep_gefs025_probability/) is not updated anymore. Instead the models [`bom_access_global_ensemble`](https://openmeteo.s3.amazonaws.com/index.html#data/bom_access_global_ensemble/), [`cmc_gem_geps`](https://openmeteo.s3.amazonaws.com/index.html#data/), [`ecmwf_ifs025_ensemble`](https://openmeteo.s3.amazonaws.com/index.html#data/ecmwf_ifs025_ensemble/), [`dwd_icon_d2_eps`](https://openmeteo.s3.amazonaws.com/index.html#data/ecmwf_ifs025_ensemble/), [`dwd_icon_eu_eps`](https://openmeteo.s3.amazonaws.com/index.html#data/dwd_icon_d2_eps/), [`dwd_icon_eps`](https://openmeteo.s3.amazonaws.com/index.html#data/dwd_icon_eu_eps/), [`ncep_gefs025`](https://openmeteo.s3.amazonaws.com/index.html#data/dwd_icon_eps/) and [`ncep_gefs05`](https://openmeteo.s3.amazonaws.com/index.html#data/ncep_gefs025/) are used to provide more accurate precipitation probabilities