### PR TITLE
Remove ICON D2 EPS from ICON seamless domain

### DIFF
--- a/Sources/App/Controllers/EnsembleController.swift
+++ b/Sources/App/Controllers/EnsembleController.swift
@@ -126,7 +126,9 @@ enum EnsembleMultiDomains: String, RawRepresentableString, CaseIterable, MultiDo
     func getReader(lat: Float, lon: Float, elevation: Float, mode: GridSelectionMode, options: GenericReaderOptions) throws -> [any GenericReaderProtocol] {
         switch self {
         case .icon_seamless:
-            return try IconMixer(domains: [.iconEps, .iconEuEps, .iconD2Eps], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)?.reader ?? []
+            /// Note: ICON D2 EPS has been excluded, because it only provides 20 members and noticable different results compared to ICON EU EPS
+            /// See: https://github.com/open-meteo/open-meteo/issues/876
+            return try IconMixer(domains: [.iconEps, .iconEuEps], lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)?.reader ?? []
         case .icon_global:
             return try IconReader(domain: .iconEps, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options).flatMap({[$0]}) ?? []
         case .icon_eu:


### PR DESCRIPTION
ICON D2 EPS has been excluded, because it only provides 20 members and noticeable different results compared to ICON EU EPS.
 See: https://github.com/open-meteo/open-meteo/issues/876