### PR TITLE
fix: ERA5 wind spread calculation

### DIFF
--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -894,6 +894,8 @@ enum ForecastSurfaceVariable: String, GenericVariableMixable {
     
     case wind_speed_10m_spread
     case wind_speed_100m_spread
+    case wind_direction_10m_spread
+    case wind_direction_100m_spread
     case snowfall_spread
     case temperature_2m_spread
     case wind_gusts_10m_spread

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -500,7 +500,8 @@ enum MultiDomains: String, RawRepresentableString, CaseIterable, MultiDomainMixe
         case .era5_seamless:
             return [try Era5Factory.makeEra5CombinedLand(lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)]
         case .era5:
-            return [try Era5Factory.makeReader(domain: .era5, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)]
+            // If explicitly selected ERA5, combine with ensemble to read spread variables
+            return [try Era5Factory.makeEra5WithEnsemble(lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)]
         case .era5_land:
             return [try Era5Factory.makeReader(domain: .era5_land, lat: lat, lon: lon, elevation: elevation, mode: mode, options: options)]
         case .cerra:

--- a/Sources/App/Era5/Era5Controller.swift
+++ b/Sources/App/Era5/Era5Controller.swift
@@ -271,9 +271,13 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
         case .wind_speed_10m_spread, .wind_direction_10m_spread:
             try prefetchData(raw: .wind_u_component_10m_spread, time: time)
             try prefetchData(raw: .wind_v_component_10m_spread, time: time)
+            try prefetchData(raw: .wind_u_component_10m, time: time)
+            try prefetchData(raw: .wind_v_component_10m, time: time)
         case .wind_speed_100m_spread, .wind_direction_100m_spread:
             try prefetchData(raw: .wind_u_component_100m_spread, time: time)
             try prefetchData(raw: .wind_v_component_100m_spread, time: time)
+            try prefetchData(raw: .wind_u_component_100m, time: time)
+            try prefetchData(raw: .wind_v_component_100m, time: time)
         case .snowfall_spread:
             try prefetchData(raw: .snowfall_water_equivalent, time: time)
         }
@@ -532,25 +536,53 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let gti = Zensun.calculateTiltedIrradiance(directRadiation: directRadiation, diffuseRadiation: diffuseRadiation, tilt: try options.getTilt(), azimuth: try options.getAzimuth(), latitude: reader.modelLat, longitude: reader.modelLon, timerange: time.time, convertBackwardsToInstant: true)
             return DataAndUnit(gti, .wattPerSquareMetre)
         case .wind_speed_10m_spread:
-            let u = try get(raw: .wind_u_component_10m_spread, time: time)
-            let v = try get(raw: .wind_v_component_10m_spread, time: time)
-            let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .metrePerSecond)
+            let σu = try get(raw: .wind_u_component_10m_spread, time: time)
+            let σv = try get(raw: .wind_v_component_10m_spread, time: time)
+            let u = try get(raw: .wind_u_component_10m, time: time)
+            let v = try get(raw: .wind_v_component_10m, time: time)
+            /// Calculate propagation of uncertainty. See https://en.wikipedia.org/wiki/Propagation_of_uncertainty
+            /// https://www.wolframalpha.com/input?i=Simplify%5BSqrt%5BFold%5B%231%2B%232+%26%2CD%5B%5B%2F%2Fmath%3Asqrt%28U*U%2BV*V%29%2F%2F%5D%2C%7B%7B%5B%2F%2Fmath%3AU%2CV%2F%2F%5D%7D%7D%5D%5E2*%7B%5B%2F%2Fmath%3Au%2Cv%2F%2F%5D%7D%5E2%5D%5D%5D
+            /// Simplify[Sqrt[Fold[#1+#2 &,D[[//math:sqrt(U*U+V*V)//],{{[//math:U,V//]}}]^2*{[//math:u,v//]}^2]]]
+            /// sqrt((u^2 U^2 + v^2 V^2)/(U^2 + V^2))
+            let σr = zip(zip(u.data,v.data), zip(σu.data, σv.data)).map { arg -> Float in
+                let ((u,v),(σu,σv)) = arg
+                return sqrt((u*u * σu*σu + v*v * σv*σv) / (u*u / v*v))
+            }
+            return DataAndUnit(σr, .metrePerSecond)
         case .wind_speed_100m_spread:
-            let u = try get(raw: .wind_u_component_100m_spread, time: time)
-            let v = try get(raw: .wind_v_component_100m_spread, time: time)
-            let speed = zip(u.data,v.data).map(Meteorology.windspeed)
-            return DataAndUnit(speed, .metrePerSecond)
+            let σu = try get(raw: .wind_u_component_100m_spread, time: time)
+            let σv = try get(raw: .wind_v_component_100m_spread, time: time)
+            let u = try get(raw: .wind_u_component_100m, time: time)
+            let v = try get(raw: .wind_v_component_100m, time: time)
+            let σr = zip(zip(u.data,v.data), zip(σu.data, σv.data)).map { arg -> Float in
+                let ((u,v),(σu,σv)) = arg
+                let r = sqrt(u*u + v*v)
+                return sqrt((u/r)*(u/r) * σu*σu + (v/r)*(v/r) * σv*σv)
+            }
+            return DataAndUnit(σr, .metrePerSecond)
         case .wind_direction_10m_spread:
-            let u = try get(raw: .wind_u_component_10m_spread, time: time).data
-            let v = try get(raw: .wind_v_component_10m_spread, time: time).data
-            let direction = Meteorology.windirectionFast(u: u, v: v)
-            return DataAndUnit(direction, .degreeDirection)
+            let σu = try get(raw: .wind_u_component_10m_spread, time: time)
+            let σv = try get(raw: .wind_v_component_10m_spread, time: time)
+            let u = try get(raw: .wind_u_component_10m, time: time)
+            let v = try get(raw: .wind_v_component_10m, time: time)
+            /// https://www.wolframalpha.com/input?i=Simplify%5BSqrt%5BFold%5B%231%2B%232+%26%2CD%5B%5B%2F%2Fmath%3Aatan2%28U%2CV%29*180%2FPI+%2B+180%2F%2F%5D%2C%7B%7B%5B%2F%2Fmath%3AU%2CV%2F%2F%5D%7D%7D%5D%5E2*%7B%5B%2F%2Fmath%3Au%2Cv%2F%2F%5D%7D%5E2%5D%5D%5D
+            /// Simplify[Sqrt[Fold[#1+#2 &,D[[//math:atan2(U,V)*180/PI + 180//],{{[//math:U,V//]}}]^2*{[//math:u,v//]}^2]]]
+            /// (180 sqrt((u^2 V^2 + U^2 v^2)/(U^2 + V^2)^2))/π
+            let σ = zip(zip(u.data,v.data), zip(σu.data, σv.data)).map { arg -> Float in
+                let ((u,v),(σu,σv)) = arg
+                return sqrt((u*u * σv*σv + v*v * σu*σu) / ((u*u + v*v)*(u*u + v*v))) * 180 / .pi
+            }
+            return DataAndUnit(σ, .degreeDirection)
         case .wind_direction_100m_spread:
-            let u = try get(raw: .wind_u_component_100m_spread, time: time).data
-            let v = try get(raw: .wind_v_component_100m_spread, time: time).data
-            let direction = Meteorology.windirectionFast(u: u, v: v)
-            return DataAndUnit(direction, .degreeDirection)
+            let σu = try get(raw: .wind_u_component_100m_spread, time: time)
+            let σv = try get(raw: .wind_v_component_100m_spread, time: time)
+            let u = try get(raw: .wind_u_component_100m, time: time)
+            let v = try get(raw: .wind_v_component_100m, time: time)
+            let σ = zip(zip(u.data,v.data), zip(σu.data, σv.data)).map { arg -> Float in
+                let ((u,v),(σu,σv)) = arg
+                return sqrt((u*u * σv*σv + v*v * σu*σu) / ((u*u + v*v)*(u*u + v*v))) * 180 / .pi
+            }
+            return DataAndUnit(σ, .degreeDirection)
         case .snowfall_spread:
             let snowwater = try get(raw: .snowfall_water_equivalent_spread, time: time).data
             let snowfall = snowwater.map { $0 * 0.7 }

--- a/Sources/App/Era5/Era5Controller.swift
+++ b/Sources/App/Era5/Era5Controller.swift
@@ -542,8 +542,8 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let uSpread = try get(raw: .wind_u_component_10m_spread, time: time)
             let vSpread = try get(raw: .wind_v_component_10m_spread, time: time)
             let speed = zip(zip(u.data, uSpread.data), zip(v.data, vSpread.data)).map({
-                return Meteorology.windspeed(u: $0.0 + $0.1, v: $1.0 + $1.1)
-                    - Meteorology.windspeed(u: $0.0, v: $1.0)
+                return Meteorology.windspeed(u: abs($0.0) + $0.1, v: abs($1.0) + $1.1)
+                    - Meteorology.windspeed(u: abs($0.0), v: abs($1.0))
             })
             return DataAndUnit(speed, .metrePerSecond)
         case .wind_speed_100m_spread:
@@ -553,8 +553,8 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let uSpread = try get(raw: .wind_u_component_100m_spread, time: time)
             let vSpread = try get(raw: .wind_v_component_100m_spread, time: time)
             let speed = zip(zip(u.data, uSpread.data), zip(v.data, vSpread.data)).map({
-                return Meteorology.windspeed(u: $0.0 + $0.1, v: $1.0 + $1.1)
-                    - Meteorology.windspeed(u: $0.0, v: $1.0)
+                return Meteorology.windspeed(u: abs($0.0) + $0.1, v: abs($1.0) + $1.1)
+                    - Meteorology.windspeed(u: abs($0.0), v: abs($1.0))
             })
             return DataAndUnit(speed, .metrePerSecond)
         case .wind_direction_10m_spread:
@@ -563,10 +563,10 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let uSpread = try get(raw: .wind_u_component_10m_spread, time: time)
             let vSpread = try get(raw: .wind_v_component_10m_spread, time: time)
             let winddirectionWithSpread = Meteorology.windirectionFast(
-                u: zip(u.data, uSpread.data).map(+),
-                v: zip(v.data, vSpread.data).map(+)
+                u: zip(u.data, uSpread.data).map({abs($0)+$1}),
+                v: zip(v.data, vSpread.data).map({abs($0)+$1})
             )
-            let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
+            let direction = Meteorology.windirectionFast(u: u.data.map(abs), v: v.data.map(abs))
             let spread = zip(winddirectionWithSpread, direction).map{(abs($0-$1))}
             return DataAndUnit(spread, .degreeDirection)
         case .wind_direction_100m_spread:
@@ -575,10 +575,10 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let uSpread = try get(raw: .wind_u_component_100m_spread, time: time)
             let vSpread = try get(raw: .wind_v_component_100m_spread, time: time)
             let winddirectionWithSpread = Meteorology.windirectionFast(
-                u: zip(u.data, uSpread.data).map(+),
-                v: zip(v.data, vSpread.data).map(+)
+                u: zip(u.data, uSpread.data).map({abs($0)+$1}),
+                v: zip(v.data, vSpread.data).map({abs($0)+$1})
             )
-            let direction = Meteorology.windirectionFast(u: u.data, v: v.data)
+            let direction = Meteorology.windirectionFast(u: u.data.map(abs), v: v.data.map(abs))
             let spread = zip(winddirectionWithSpread, direction).map{(abs($0-$1))}
             return DataAndUnit(spread, .degreeDirection)
         case .snowfall_spread:

--- a/Sources/App/Era5/Era5Controller.swift
+++ b/Sources/App/Era5/Era5Controller.swift
@@ -542,13 +542,13 @@ struct Era5Reader<Reader: GenericReaderProtocol>: GenericReaderDerivedSimple, Ge
             let speed = zip(u.data,v.data).map(Meteorology.windspeed)
             return DataAndUnit(speed, .metrePerSecond)
         case .wind_direction_10m_spread:
-            let u = try get(raw: .wind_u_component_10m, time: time).data
-            let v = try get(raw: .wind_v_component_10m, time: time).data
+            let u = try get(raw: .wind_u_component_10m_spread, time: time).data
+            let v = try get(raw: .wind_v_component_10m_spread, time: time).data
             let direction = Meteorology.windirectionFast(u: u, v: v)
             return DataAndUnit(direction, .degreeDirection)
         case .wind_direction_100m_spread:
-            let u = try get(raw: .wind_u_component_100m, time: time).data
-            let v = try get(raw: .wind_v_component_100m, time: time).data
+            let u = try get(raw: .wind_u_component_100m_spread, time: time).data
+            let v = try get(raw: .wind_v_component_100m_spread, time: time).data
             let direction = Meteorology.windirectionFast(u: u, v: v)
             return DataAndUnit(direction, .degreeDirection)
         case .snowfall_spread:

--- a/Sources/App/Era5/Era5Variables.swift
+++ b/Sources/App/Era5/Era5Variables.swift
@@ -126,10 +126,10 @@ enum Era5Variable: String, CaseIterable, GenericVariable, GribMessageAssociated 
     /// Scalefactor to compress data
     var scalefactor: Float {
         switch self {
-        case .wind_u_component_100m, .wind_u_component_100m_spread: return 10
-        case .wind_v_component_100m, .wind_v_component_100m_spread: return 10
-        case .wind_u_component_10m, .wind_u_component_10m_spread: return 10
-        case .wind_v_component_10m, .wind_v_component_10m_spread: return 10
+        case .wind_u_component_100m, .wind_v_component_100m,
+                .wind_u_component_10m, .wind_v_component_10m: return 20 // 0.05 m/s resolution. Typically 10, but want to have sligthly higher resolution
+        case .wind_u_component_100m_spread, .wind_v_component_100m_spread,
+                .wind_u_component_10m_spread, .wind_v_component_10m_spread: return 50 // 0.02 m/s resolution
         case .cloud_cover_low, .cloud_cover_low_spread: return 1
         case .cloud_cover_mid, .cloud_cover_mid_spread: return 1
         case .cloud_cover_high, .cloud_cover_high_spread: return 1

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
@@ -315,6 +315,10 @@ extension VariableAndPreviousDay: FlatBuffersVariable {
             return .init(variable: .windSpeed, aggregation: .spread, altitude: 10, previousDay: previousDay)
         case .wind_speed_100m_spread:
             return .init(variable: .windSpeed, aggregation: .spread, altitude: 100, previousDay: previousDay)
+        case .wind_direction_10m_spread:
+            return .init(variable: .windDirection, aggregation: .spread, altitude: 10, previousDay: previousDay)
+        case .wind_direction_100m_spread:
+            return .init(variable: .windDirection, aggregation: .spread, altitude: 100, previousDay: previousDay)
         case .snowfall_spread:
             return .init(variable: .snowfall, aggregation: .spread, previousDay: previousDay)
         case .temperature_2m_spread:


### PR DESCRIPTION
Properly consider error propagation for spread calculation for wind speed and direction

See:
- https://en.wikipedia.org/wiki/Propagation_of_uncertainty
- speed: [WolframAlpha](https://www.wolframalpha.com/input?i=Simplify%5BSqrt%5BFold%5B%231%2B%232+%26%2CD%5B%5B%2F%2Fmath%3Aatan2%28U%2CV%29*180%2FPI+%2B+180%2F%2F%5D%2C%7B%7B%5B%2F%2Fmath%3AU%2CV%2F%2F%5D%7D%7D%5D%5E2*%7B%5B%2F%2Fmath%3Au%2Cv%2F%2F%5D%7D%5E2%5D%5D%5D)
- direction: [WolframAlpha](https://www.wolframalpha.com/input?i=Simplify%5BSqrt%5BFold%5B%231%2B%232+%26%2CD%5B%5B%2F%2Fmath%3Asqrt%28U*U%2BV*V%29%2F%2F%5D%2C%7B%7B%5B%2F%2Fmath%3AU%2CV%2F%2F%5D%7D%7D%5D%5E2*%7B%5B%2F%2Fmath%3Au%2Cv%2F%2F%5D%7D%5E2%5D%5D%5D)