### PR TITLE
feat: add mass_density_8m variable, on ncep_hrrr model for smoke concentration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.89.0"),
         .package(url: "https://github.com/google/flatbuffers.git", from: "24.3.25"),
-        .package(url: "https://github.com/open-meteo/sdk.git", from: "1.14.1"),
+        .package(url: "https://github.com/open-meteo/sdk.git", from: "1.15.0"),
+        // .package(path: "../openmeteo-sdk-fork"),  // local forked version
         //.package(url: "https://github.com/open-meteo/sdk.git", branch: "add_ecmwf_long_window"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftNetCDF.git", from: "1.1.2"),
         .package(url: "https://github.com/patrick-zippenfenig/SwiftTimeZoneLookup.git", from: "1.0.7"),

--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -742,6 +742,7 @@ enum ForecastSurfaceVariable: String, GenericVariableMixable {
     case convective_inhibition
     case leaf_wetness_probability
     case lightning_potential
+    case mass_density_8m
     case precipitation
     case precipitation_probability
     case pressure_msl

--- a/Sources/App/Gfs/GfsController.swift
+++ b/Sources/App/Gfs/GfsController.swift
@@ -54,6 +54,7 @@ enum GfsVariableDerivedSurface: String, CaseIterable, GenericVariableMixable {
     case latent_heatflux
     case windgusts_10m
     case freezinglevel_height
+    case mass_density_8m
     
     case sunshine_duration
     
@@ -362,6 +363,8 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 try prefetchData(raw: .surface(.freezing_level_height), time: time)
             case .sunshine_duration:
                 try prefetchData(derived: .surface(.direct_radiation), time: time)
+            case .mass_density_8m:
+                try prefetchData(derived: .surface(.mass_density_8m), time: time)
             }
         case .pressure(let v):
             switch v.variable {
@@ -583,6 +586,8 @@ struct GfsReader: GenericReaderDerived, GenericReaderProtocol {
                 return try get(raw: .surface(.wind_gusts_10m), time: time)
             case .freezinglevel_height:
                 return try get(raw: .surface(.freezing_level_height), time: time)
+            case .mass_density_8m:
+                return try get(raw: .surface(.mass_density_8m), time: time)
             case .sunshine_duration:
                 let directRadiation = try get(derived: .surface(.direct_radiation), time: time)
                 let duration = Zensun.calculateBackwardsSunshineDuration(directRadiation: directRadiation.data, latitude: reader.modelLat, longitude: reader.modelLon, timerange: time.time)

--- a/Sources/App/Gfs/GfsVariable.swift
+++ b/Sources/App/Gfs/GfsVariable.swift
@@ -78,7 +78,8 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
     case boundary_layer_height
     
     case total_column_integrated_water_vapour
-    
+
+    case mass_density_8m
     
     var storePreviousForecast: Bool {
         switch self {
@@ -158,6 +159,7 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .categorical_freezing_rain: return 1
         case .convective_inhibition: return 1
         case .total_column_integrated_water_vapour: return 10
+        case .mass_density_8m: return 1
         }
     }
     
@@ -249,6 +251,8 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
             return .hermite(bounds: 0...10e9)
         case .total_column_integrated_water_vapour:
             return .hermite(bounds: nil)
+        case .mass_density_8m:
+            return .linear
         }
     }
     
@@ -296,6 +300,7 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .categorical_freezing_rain: return .dimensionless
         case .convective_inhibition: return .joulePerKilogram
         case .total_column_integrated_water_vapour: return .kilogramPerSquareMetre
+        case .mass_density_8m: return .microgramsPerCubicMetre
         }
     }
     

--- a/Sources/App/Gfs/GfsVariable.swift
+++ b/Sources/App/Gfs/GfsVariable.swift
@@ -159,7 +159,7 @@ enum GfsSurfaceVariable: String, CaseIterable, GenericVariable, GenericVariableM
         case .categorical_freezing_rain: return 1
         case .convective_inhibition: return 1
         case .total_column_integrated_water_vapour: return 10
-        case .mass_density_8m: return 1
+        case .mass_density_8m: return 0.1
         }
     }
     

--- a/Sources/App/Gfs/GfsVariableDownloadable.swift
+++ b/Sources/App/Gfs/GfsVariableDownloadable.swift
@@ -179,6 +179,8 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
                 return ":HPBL:surface:"
             case .total_column_integrated_water_vapour:
                 return ":PWAT:entire atmosphere (considered as a single layer):"
+            case .mass_density_8m:
+                return ":MASSDEN:8 m above ground:"
             default:
                 return nil
             }
@@ -419,6 +421,8 @@ extension GfsSurfaceVariable: GfsVariableDownloadable {
             // 0.025 m2/W to get the uv index
             // compared to https://www.aemet.es/es/eltiempo/prediccion/radiacionuv
             return (18.9 * 0.025, 0)
+        case .mass_density_8m:
+            return (1e9, 0)  // convert kg/m³ to µg/m³
         default:
             return nil
         }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
@@ -311,6 +311,8 @@ extension VariableAndPreviousDay: FlatBuffersVariable {
             return .init(variable: .cloudBase, previousDay: previousDay)
         case .cloud_top:
             return .init(variable: .cloudTop, previousDay: previousDay)
+        case .mass_density_8m:
+            return .init(variable: .massDensity, altitude: 8, previousDay: previousDay)
         case .wind_speed_10m_spread:
             return .init(variable: .windSpeed, aggregation: .spread, altitude: 10, previousDay: previousDay)
         case .wind_speed_100m_spread:


### PR DESCRIPTION
mass_density_8m is smoke concentration, native grib units of kg/m³ but converted to µg/m³ here for compatibility with existing Unit of microgramsPerCubicMetre

anticipating Sdk version 1.15.0 to include mass_density -> massDensity mapping for api

re proposed: https://github.com/open-meteo/open-meteo/issues/1013
