### PR TITLE
fix: exponential backoff delay bug, and treat 401 Unauthorized as fatal

### DIFF
--- a/Sources/App/Helper/Download/Curl.swift
+++ b/Sources/App/Helper/Download/Curl.swift
@@ -12,6 +12,7 @@ enum CurlError: Error {
     case sizeTooSmall
     case didNotGetAllGribMessages(got: Int, expected: Int)
     case downloadFailed(code: HTTPStatus)
+    case unauthorized
     case fileNotFound
     case timeoutReached
     case timeoutPerChunkReached


### PR DESCRIPTION
This fixes the exponential backoff delay to apply the computed delay between retries and updates the attempt counter on each retry, re: https://github.com/open-meteo/open-meteo/issues/1019

This changes 401 HTTP credential failure errors into a fatal error, with no retries. And logs an error message suggesting the credentials may be outdated.

Example	log, since CDS-beta requires all CDS users to get a brand new API key (uuid4 format now, no colon). re: https://confluence.ecmwf.int/x/uINmFw
```
% openmeteo-api download-era5 era5_land --cdskey FAIL --only-variables temperature_2m,dew_point_2m --timeinterval 20240905-20240906
[ INFO ] Downloading timerange 2024-09-05 to 2024-09-06
[ INFO ] Downloading timestamp 20240905
[ INFO ] Download failed with 401 Unauthorized error, credentials rejected. Possibly outdated API key.
[ WARNING ] App.CurlError.unauthorized
Swift/ErrorType.swift:200: Fatal error: Error raised at top level: App.CurlError.unauthorized
Current stack trace:
<<< deleted >>>
```

Added debug-level logging before response is processed, example:
```
[ DEBUG ] Response for HTTP request #1 returned HTTP status code: 200 OK, from URL https://cds.climate.copernicus.eu/api/v2/resources/reanalysis-era5-land (App/HttpClient+Retry.swift:52)
```