### PR TITLE
feat: Add ICON convective cloud base and cloud top variables

### DIFF
--- a/Sources/App/Icon/Cdo.swift
+++ b/Sources/App/Icon/Cdo.swift
@@ -45,7 +45,7 @@ struct CdoHelper {
         guard let cdo else {
             return try await curl.downloadGrib(url: url, bzip2Decode: true)
         }
-        // Multiple messages might be present in each grib fle
+        // Multiple messages might be present in each grib file
         // DWD produces non-standard GRIB2 files for 15 minutes ensemble data
         // GRIB messages need to be reordered by timestep
         // Otherwise CDO does not work

--- a/Sources/App/Icon/DownloadIconCommand.swift
+++ b/Sources/App/Icon/DownloadIconCommand.swift
@@ -341,7 +341,8 @@ struct DownloadIconCommand: AsyncCommand {
                 
                 if v.variable == .convective_cloud_top || v.variable == .convective_cloud_base {
                     // Icon sets points where no convective clouds are present to -500
-                    data.data = data.data.map { $0 < -450 ? .nan : $0 }
+                    // We set them to 0 to be consistent with cloud_top and cloud_base in DMI Harmonie model
+                    data.data = data.data.map { $0 < -499 ? 0 : $0 }
                 }
                 
                 let writer = OmFileWriter(dim0: 1, dim1: domain.grid.count, chunk0: 1, chunk1: nLocationsPerChunk)

--- a/Sources/App/Icon/DownloadIconCommand.swift
+++ b/Sources/App/Icon/DownloadIconCommand.swift
@@ -24,7 +24,7 @@ struct DownloadIconCommand: AsyncCommand {
         @Option(name: "run")
         var run: String?
 
-        @Option(name: "concurrent", short: "c", help: "Numer of concurrent download/conversion jobs")
+        @Option(name: "concurrent", short: "c", help: "Number of concurrent download/conversion jobs")
         var concurrent: Int?
         
         @Flag(name: "create-netcdf")
@@ -258,7 +258,7 @@ struct DownloadIconCommand: AsyncCommand {
                 if [.iconEps, .iconEuEps].contains(domain) && v.variable == .pressure_msl, 
                     let t2m = await storage.get(v.with(variable: .temperature_2m)) {
                     // ICON EPC is actually downloading surface level pressure
-                    // calculate sea level presure using temperature and elevation
+                    // calculate sea level pressure using temperature and elevation
                     data.data = Meteorology.sealevelPressureSpatial(temperature: t2m.data, pressure: data.data, elevation: domainElevation)
                 }
                 if domain == .iconEps && v.variable == .relative_humidity_2m,
@@ -287,7 +287,7 @@ struct DownloadIconCommand: AsyncCommand {
                 }
                 
                 /// Lower freezing level height below grid-cell elevation to adjust data to mixed terrain
-                /// Use temperature to esimate freezing level height below ground. This is consistent with GFS
+                /// Use temperature to estimate freezing level height below ground. This is consistent with GFS
                 /// https://github.com/open-meteo/open-meteo/issues/518#issuecomment-1827381843
                 /// Note: snowfall height is NaN if snowfall height is at ground level
                 if v.variable == .freezing_level_height || v.variable == .snowfall_height,
@@ -390,7 +390,7 @@ struct DownloadIconCommand: AsyncCommand {
                 }
                 
                 /// Lower freezing level height below grid-cell elevation to adjust data to mixed terrain
-                /// Use temperature to esimate freezing level height below ground. This is consistent with GFS
+                /// Use temperature to estimate freezing level height below ground. This is consistent with GFS
                 /// https://github.com/open-meteo/open-meteo/issues/518#issuecomment-1827381843
                 if v.variable == .freezing_level_height || v.variable == .snowfall_height {
                     /// Take temperature from 1-hourly data

--- a/Sources/App/Icon/DownloadIconCommand.swift
+++ b/Sources/App/Icon/DownloadIconCommand.swift
@@ -339,6 +339,11 @@ struct DownloadIconCommand: AsyncCommand {
                     return
                 }
                 
+                if v.variable == .convective_cloud_top || v.variable == .convective_cloud_base {
+                    // Icon sets points where no convective clouds are present to -500
+                    data.data = data.data.map { $0 < -450 ? .nan : $0 }
+                }
+                
                 let writer = OmFileWriter(dim0: 1, dim1: domain.grid.count, chunk0: 1, chunk1: nLocationsPerChunk)
                 let fn = try writer.writeTemporary(compressionType: .p4nzdec256, scalefactor: v.variable.scalefactor, all: data.data)
                 await handles.append(GenericVariableHandle(

--- a/Sources/App/Icon/Icon.swift
+++ b/Sources/App/Icon/Icon.swift
@@ -107,7 +107,7 @@ enum IconDomains: String, CaseIterable, GenericDomain {
         }
     }
     
-    /// Numer of avaialble forecast steps differs from run
+    /// Number of available forecast steps differs from run
     /// E.g. icon global 0z has 180 as a last value, but 6z only 120
     func getDownloadForecastSteps(run: Int) -> [Int] {
         switch self {
@@ -204,4 +204,3 @@ enum IconDomains: String, CaseIterable, GenericDomain {
     /// ICON uses 1.5°C melting point temperature: https://gitlab.dkrz.de/icon/icon-model/-/blob/release-2024.01-public/src/atm_phy_nwp/mo_nh_interface_nwp.f90?ref_type=heads#L2232
     static let tMelt = Float(1.5)
 }
-

--- a/Sources/App/Icon/IconVariable.swift
+++ b/Sources/App/Icon/IconVariable.swift
@@ -366,9 +366,9 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
         case .cloud_cover_high:
             return .linear
         case .convective_cloud_top:
-            return .linear
+            return .hermite(bounds: 0...10e9)
         case .convective_cloud_base:
-            return .linear
+            return .hermite(bounds: 0...10e9)
         case .pressure_msl:
             return .hermite(bounds: nil)
         case .precipitation:

--- a/Sources/App/Icon/IconVariable.swift
+++ b/Sources/App/Icon/IconVariable.swift
@@ -97,6 +97,8 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
     case cloud_cover_low
     case cloud_cover_mid
     case cloud_cover_high
+    case convective_cloud_top
+    case convective_cloud_base
     
     /// pressure reduced to sea level
     case pressure_msl
@@ -220,6 +222,8 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
         case .cloud_cover_low: return 1
         case .cloud_cover_mid: return 1
         case .cloud_cover_high: return 1
+        case .convective_cloud_top: return 1
+        case .convective_cloud_base: return 1
         case .precipitation: return 10
         case .weather_code: return 1
         case .wind_v_component_10m: return 10
@@ -278,6 +282,8 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
         case .cloud_cover_low: return .percentage
         case .cloud_cover_mid: return .percentage
         case .cloud_cover_high: return .percentage
+        case .convective_cloud_top: return .metre
+        case .convective_cloud_base: return .metre
         case .precipitation: return .millimetre
         case .weather_code: return .wmoCode
         case .wind_v_component_10m: return .metrePerSecond
@@ -329,7 +335,7 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
         }
     }
     
-    /// Soil moisture or snow depth are cumulative processes and have offests if mutliple models are mixed
+    /// Soil moisture or snow depth are cumulative processes and have offsets if multiple models are mixed
     var requiresOffsetCorrectionForMixing: Bool {
         switch self {
         case .soil_moisture_0_to_1cm: return true
@@ -358,6 +364,10 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
         case .cloud_cover_mid:
             return .linear
         case .cloud_cover_high:
+            return .linear
+        case .convective_cloud_top:
+            return .linear
+        case .convective_cloud_base:
             return .linear
         case .pressure_msl:
             return .hermite(bounds: nil)

--- a/Sources/App/Icon/IconVariable.swift
+++ b/Sources/App/Icon/IconVariable.swift
@@ -222,8 +222,8 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable {
         case .cloud_cover_low: return 1
         case .cloud_cover_mid: return 1
         case .cloud_cover_high: return 1
-        case .convective_cloud_top: return 1
-        case .convective_cloud_base: return 1
+        case .convective_cloud_top: return 0.1
+        case .convective_cloud_base: return 0.1
         case .precipitation: return 10
         case .weather_code: return 1
         case .wind_v_component_10m: return 10

--- a/Sources/App/Icon/IconVariableDownloadable.swift
+++ b/Sources/App/Icon/IconVariableDownloadable.swift
@@ -192,8 +192,12 @@ extension IconSurfaceVariable: IconVariableDownloadable {
         case .cloud_cover_low: return ("clcl", "single-level", nil)
         case .cloud_cover_mid: return ("clcm", "single-level", nil)
         case .cloud_cover_high: return ("clch", "single-level", nil)
-        case .convective_cloud_top: return ("htop_con", "single-level", nil)
-        case .convective_cloud_base: return ("hbas_con", "single-level", nil)
+        case .convective_cloud_top: 
+            let shallowOrDeepConvectionTop = domain == .iconD2 ? "htop_sc" : "htop_con"
+            return (shallowOrDeepConvectionTop, "single-level", nil)
+        case .convective_cloud_base: 
+            let shallowOrDeepConvectionBase = domain == .iconD2 ? "hbas_sc" : "hbas_con"
+            return (shallowOrDeepConvectionBase, "single-level", nil)
         case .precipitation: return ("tot_prec", "single-level", nil)
         case .weather_code: return ("ww", "single-level", nil)
         case .wind_v_component_10m: return ("v_10m", "single-level", nil)

--- a/Sources/App/Icon/IconVariableDownloadable.swift
+++ b/Sources/App/Icon/IconVariableDownloadable.swift
@@ -192,6 +192,8 @@ extension IconSurfaceVariable: IconVariableDownloadable {
         case .cloud_cover_low: return ("clcl", "single-level", nil)
         case .cloud_cover_mid: return ("clcm", "single-level", nil)
         case .cloud_cover_high: return ("clch", "single-level", nil)
+        case .convective_cloud_top: return ("htop_con", "single-level", nil)
+        case .convective_cloud_base: return ("hbas_con", "single-level", nil)
         case .precipitation: return ("tot_prec", "single-level", nil)
         case .weather_code: return ("ww", "single-level", nil)
         case .wind_v_component_10m: return ("v_10m", "single-level", nil)


### PR DESCRIPTION
I was recently building a small meteogram targeted at hobby pilots mostly paragliders and hangliders: https://terraputix.github.io/meteo-fly/?lat=36.89363&lon=-5.41386&day=1&model=icon_seamless, and would like to add estimates of convective cloud base height. This variable is directly available from icon models, so I took the freedom to open this PR to add it. 

This PR adds convective cloud base and cloud top variables for ICON models. They are available for `icon`, `icon-eu` and `icon-d2`, however `icon-d2` has shallow convection while `icon-eu` and `icon` have "deep" convection. I am honestly not sure if we can just unify them like done in this PR (most likely it matches in some cases, but in other cases the results might be rather different). What's your take on that?

Unfortunately, I was only able to test the download locally for icon-d2 and icon-eu, because I currently don't have `cdo` with grib2 support at hand for my distro and I was too lazy to build it from source. 
