### PR TITLE
fix log10 copying

### DIFF
--- a/Sources/OmFileFormatC/src/om_common.c
+++ b/Sources/OmFileFormatC/src/om_common.c
@@ -6,7 +6,6 @@
 //
 
 #include "om_common.h"
-#include <stdlib.h>
 #include <math.h>
 #include "vp4.h"
 #include "fp.h"
@@ -48,10 +47,10 @@ void om_common_copy_float_to_int16_log10(uint64_t length, float scale_factor, fl
     for (uint64_t i = 0; i < length; ++i) {
         float val = ((float *)src)[i];
         if (isnan(val)) {
-            ((float *)dst)[i] = INT16_MAX;
+            ((int16_t *)dst)[i] = INT16_MAX;
         } else {
             float scaled = log10f(1 + val) * scale_factor;
-            ((float *)dst)[i] = (int16_t)fmaxf(INT16_MIN, fminf(INT16_MAX, roundf(scaled)));
+            ((int16_t *)dst)[i] = (int16_t)fmaxf(INT16_MIN, fminf(INT16_MAX, roundf(scaled)));
         }
     }
 }
@@ -109,4 +108,3 @@ uint64_t om_common_decompress_fpxdec32(const void* src, uint64_t length, void* d
 uint64_t om_common_decompress_fpxdec64(const void* src, uint64_t length, void* dst) {
     return fpxdec64((unsigned char *)src, length, (uint64_t *)dst, 0);
 }
-

--- a/Tests/OmFileFormatTests/OmFileFormatTests.swift
+++ b/Tests/OmFileFormatTests/OmFileFormatTests.swift
@@ -177,7 +177,7 @@ final class OmFileFormatTests: XCTestCase {
         
         XCTAssertEqual(readFn.count, 144)
         let bytes = Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: readFn.getData(offset: 0, count: readFn.count)), count: readFn.count, deallocator: .none).map{UInt8($0)}
-        // difference on x86 and ARM cause by the underlaying compression
+        // difference on x86 and ARM cause by the underlying compression
         //XCTAssertTrue(bytes == [79, 77, 3, 0, 4, 130, 0, 2, 3, 34, 0, 4, 194, 2, 10, 4, 178, 0, 12, 4, 242, 0, 14, 197, 17, 20, 194, 2, 22, 194, 2, 24, 3, 3, 228, 200, 109, 1, 0, 0, 20, 0, 4, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 100, 97, 116, 97, 0, 0, 0, 0, 79, 77, 3, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 76, 0, 0, 0, 0, 0, 0, 0] || bytes == [79, 77, 3, 0, 4, 130, 64, 2, 3, 34, 16, 4, 194, 2, 10, 4, 178, 64, 12, 4, 242, 64, 14, 197, 17, 20, 194, 2, 22, 194, 2, 24, 3, 3, 228, 200, 109, 1, 0, 0, 20, 0, 4, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 100, 97, 116, 97, 0, 0, 0, 0, 79, 77, 3, 0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 76, 0, 0, 0, 0, 0, 0, 0])
     }
     
@@ -263,7 +263,7 @@ final class OmFileFormatTests: XCTestCase {
         let bytes = Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: readFn.getData(offset: 0, count: readFn.count)), count: readFn.count, deallocator: .none).map{UInt8($0)}
         XCTAssertEqual(bytes[0..<3], [79, 77, 3])
         XCTAssertEqual(bytes[3..<8], [0, 3, 34, 140, 2]) // chunk
-        XCTAssertTrue(bytes[8..<12] == [2, 3, 114, 1] || bytes[8..<12] == [2, 3, 114, 141]) // difference on x86 and ARM cause by the underlaying compression
+        XCTAssertTrue(bytes[8..<12] == [2, 3, 114, 1] || bytes[8..<12] == [2, 3, 114, 141]) // difference on x86 and ARM cause by the underlying compression
         XCTAssertTrue(bytes[12..<16] == [6, 3, 34, 0] || bytes[12..<16] == [6, 3, 34, 140]) // chunk
         XCTAssertEqual(bytes[16..<19], [8, 194, 2]) // chunk
         XCTAssertEqual(bytes[19..<23], [18, 5, 226, 3]) // chunk
@@ -709,6 +709,26 @@ final class OmFileFormatTests: XCTestCase {
         print(data2)
         XCTAssertTrue(try read.read(dim0Slow: 1..<2, dim1: 1..<2)[0].isNaN)
         try FileManager.default.removeItem(atPath: file)
+    }
+    
+    func testCopyLog10Roundtrip() {
+        let ints: [Int16] = [100, 200, 300, 400, 500]
+        var floats = [Float](repeating: 0, count: ints.count)
+        var intsRoundtrip = [Int16](repeating: 0, count: ints.count)
+
+        ints.withUnsafeBufferPointer { srcPtr in
+            floats.withUnsafeMutableBufferPointer { dstPtr in
+                om_common_copy_int16_to_float_log10(UInt64(ints.count), 1000.0, 0.0, srcPtr.baseAddress, dstPtr.baseAddress)
+            }
+        }
+
+        floats.withUnsafeBufferPointer { srcPtr in
+            intsRoundtrip.withUnsafeMutableBufferPointer { dstPtr in
+                om_common_copy_float_to_int16_log10(UInt64(floats.count), 1000.0, 0.0, srcPtr.baseAddress, dstPtr.baseAddress)
+            }
+        }
+
+        XCTAssertEqual(ints, intsRoundtrip)
     }
 }
 


### PR DESCRIPTION
Small fix for `p4nzdec256logarithmic` compression and minor spelling fixes.

Not sure whether the test is really useful like this or if it is better to remove it and test the different compression methods in a consistent way using the om-reader-writer. 

If only the copy-round-triping should be tested (as in the current test) it might be useful to extended the test to also verify any other round-trips work as expected.