### PR TITLE
feat: Sea temperature and sea level height considering Ocean tides

### DIFF
--- a/Sources/App/Cams/CamsController.swift
+++ b/Sources/App/Cams/CamsController.swift
@@ -41,7 +41,7 @@ extension CamsMixer: GenericReaderProvider {
  */
 struct CamsController {
     func query(_ req: Request) async throws -> Response {
-        let host = try await req.ensureSubdomain("air-quality-api")
+        _ = try await req.ensureSubdomain("air-quality-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         let numberOfLocationsMaximum = try await req.ensureApiKey("air-quality-api", apikey: params.apikey)
         

--- a/Sources/App/Cmip6/CmipController.swift
+++ b/Sources/App/Cmip6/CmipController.swift
@@ -5,7 +5,7 @@ import Vapor
 
 struct CmipController {
     func query(_ req: Request) async throws -> Response {
-        let host = try await req.ensureSubdomain("climate-api")
+        _ = try await req.ensureSubdomain("climate-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         let numberOfLocationsMaximum = try await req.ensureApiKey("climate-api", apikey: params.apikey)
         

--- a/Sources/App/Controllers/EnsembleController.swift
+++ b/Sources/App/Controllers/EnsembleController.swift
@@ -8,7 +8,7 @@ import Vapor
  */
 public struct EnsembleApiController {
     func query(_ req: Request) async throws -> Response {
-        let host = try await req.ensureSubdomain("ensemble-api")
+        _ = try await req.ensureSubdomain("ensemble-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         let numberOfLocationsMaximum = try await req.ensureApiKey("ensemble-api", apikey: params.apikey)
         let currentTime = Timestamp.now()

--- a/Sources/App/GloFas/GloFasController.swift
+++ b/Sources/App/GloFas/GloFasController.swift
@@ -87,7 +87,7 @@ struct GloFasReader: GenericReaderDerivedSimple, GenericReaderProtocol {
 
 struct GloFasController {
     func query(_ req: Request) async throws -> Response {
-        let host = try await req.ensureSubdomain("flood-api")
+        _ = try await req.ensureSubdomain("flood-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         let numberOfLocationsMaximum = try await req.ensureApiKey("flood-api", apikey: params.apikey)
         let currentTime = Timestamp.now()

--- a/Sources/App/Helper/DomainRegistry.swift
+++ b/Sources/App/Helper/DomainRegistry.swift
@@ -14,6 +14,7 @@ enum DomainRegistry: String, CaseIterable {
     case meteofrance_arpege_world025_probabilities
     case meteofrance_wave
     case meteofrance_currents
+    case meteofrance_sea_surface_temperature
     
     case cams_europe
     case cams_global
@@ -319,6 +320,8 @@ enum DomainRegistry: String, CaseIterable {
             return EumetsatLsaSafDomain.msg
         case .eumetsat_lsa_saf_iodc_15min:
             return EumetsatLsaSafDomain.iodc
+        case .meteofrance_sea_surface_temperature:
+            return MfWaveDomain.mfsst
         }
     }
 }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+MarineApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+MarineApi.swift
@@ -32,7 +32,7 @@ extension MarineVariable: FlatBuffersVariable {
             return .init(variable: .oceanCurrentVelocity)
         case .ocean_current_direction:
             return .init(variable: .oceanCurrentDirection)
-        case .wave_peak_period, .sea_level_height_msl, .invert_barometer_height:
+        case .wave_peak_period, .sea_level_height_msl, .invert_barometer_height, .sea_surface_temperature:
             // TODO register in SDK
             return .init(variable: .wavePeriod)
         }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+MarineApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+MarineApi.swift
@@ -32,7 +32,7 @@ extension MarineVariable: FlatBuffersVariable {
             return .init(variable: .oceanCurrentVelocity)
         case .ocean_current_direction:
             return .init(variable: .oceanCurrentDirection)
-        case .wave_peak_period:
+        case .wave_peak_period, .sea_level_height_msl, .invert_barometer_height:
             // TODO register in SDK
             return .init(variable: .wavePeriod)
         }

--- a/Sources/App/Helper/ForecastapiQuery.swift
+++ b/Sources/App/Helper/ForecastapiQuery.swift
@@ -301,7 +301,7 @@ struct ApiQueryParameter: Content, ApiUnitsSelectable {
         })
     }
     
-    func getTimerange2(timezone: TimezoneWithOffset, current: Timestamp, forecastDaysDefault: Int, forecastDaysMax: Int, startEndDate: ApiQueryStartEndRanges?, allowedRange: Range<Timestamp>, pastDaysMax: Int) throws -> ForecastApiTimeRange {
+    func getTimerange2(timezone: TimezoneWithOffset, current: Timestamp, forecastDaysDefault: Int, forecastDaysMax: Int, startEndDate: ApiQueryStartEndRanges?, allowedRange: Range<Timestamp>, pastDaysMax: Int, forecastDaysMinutely15Default: Int = 3) throws -> ForecastApiTimeRange {
         
         let actualUtcOffset = timezone.utcOffsetSeconds
         /// Align data to nearest hour -> E.g. timezones in india may have 15 minutes offsets
@@ -348,7 +348,7 @@ struct ApiQueryParameter: Content, ApiUnitsSelectable {
         let hourly = try Self.forecastTimeRange2(currentTime: current, utcOffset: utcOffset, pastSteps: past_hours, forecastSteps: forecast_hours, pastStepsMax: pastDaysMax * 24, forecastStepsMax: forecastDaysMax * 24, forecastStepsDefault: forecastDaysMax*24, initialStep: initial_hours, dtSeconds: 3600) ?? daily.with(dtSeconds: 3600)
         
         // May default back to 3 day forecast
-        let minutely_15 = try Self.forecastTimeRange2(currentTime: current, utcOffset: utcOffset, pastSteps: past_minutely_15, forecastSteps: forecast_minutely_15, pastStepsMax: pastDaysMax * 24 * 4, forecastStepsMax: forecastDaysMax * 24 * 4, forecastStepsDefault: 3 * 24 * 4, initialStep: initial_minutely_15, dtSeconds: 900) ?? Self.forecastTimeRange2(currentTime: current, utcOffset: utcOffset, pastSteps: past_days ?? 0, forecastSteps: forecast_days ?? 3, initialStep: nil, dtSeconds: 86400).with(dtSeconds: 900)
+        let minutely_15 = try Self.forecastTimeRange2(currentTime: current, utcOffset: utcOffset, pastSteps: past_minutely_15, forecastSteps: forecast_minutely_15, pastStepsMax: pastDaysMax * 24 * 4, forecastStepsMax: forecastDaysMax * 24 * 4, forecastStepsDefault: forecastDaysMinutely15Default * 24 * 4, initialStep: initial_minutely_15, dtSeconds: 900) ?? Self.forecastTimeRange2(currentTime: current, utcOffset: utcOffset, pastSteps: past_days ?? 0, forecastSteps: forecast_days ?? 3, initialStep: nil, dtSeconds: 86400).with(dtSeconds: 900)
         
         return ForecastApiTimeRange(
             dailyDisplay: daily.add(-1 * actualUtcOffset),

--- a/Sources/App/Helper/ForecastapiQuery.swift
+++ b/Sources/App/Helper/ForecastapiQuery.swift
@@ -348,7 +348,7 @@ struct ApiQueryParameter: Content, ApiUnitsSelectable {
         let hourly = try Self.forecastTimeRange2(currentTime: current, utcOffset: utcOffset, pastSteps: past_hours, forecastSteps: forecast_hours, pastStepsMax: pastDaysMax * 24, forecastStepsMax: forecastDaysMax * 24, forecastStepsDefault: forecastDaysMax*24, initialStep: initial_hours, dtSeconds: 3600) ?? daily.with(dtSeconds: 3600)
         
         // May default back to 3 day forecast
-        let minutely_15 = try Self.forecastTimeRange2(currentTime: current, utcOffset: utcOffset, pastSteps: past_minutely_15, forecastSteps: forecast_minutely_15, pastStepsMax: pastDaysMax * 24 * 4, forecastStepsMax: forecastDaysMax * 24 * 4, forecastStepsDefault: forecastDaysMinutely15Default * 24 * 4, initialStep: initial_minutely_15, dtSeconds: 900) ?? Self.forecastTimeRange2(currentTime: current, utcOffset: utcOffset, pastSteps: past_days ?? 0, forecastSteps: forecast_days ?? 3, initialStep: nil, dtSeconds: 86400).with(dtSeconds: 900)
+        let minutely_15 = try Self.forecastTimeRange2(currentTime: current, utcOffset: utcOffset, pastSteps: past_minutely_15, forecastSteps: forecast_minutely_15, pastStepsMax: pastDaysMax * 24 * 4, forecastStepsMax: forecastDaysMax * 24 * 4, forecastStepsDefault: forecastDaysMinutely15Default * 24 * 4, initialStep: initial_minutely_15, dtSeconds: 900) ?? Self.forecastTimeRange2(currentTime: current, utcOffset: utcOffset, pastSteps: past_days ?? 0, forecastSteps: forecast_days ?? forecastDaysMinutely15Default, initialStep: nil, dtSeconds: 86400).with(dtSeconds: 900)
         
         return ForecastApiTimeRange(
             dailyDisplay: daily.add(-1 * actualUtcOffset),

--- a/Sources/App/IconWave/IconWaveController.swift
+++ b/Sources/App/IconWave/IconWaveController.swift
@@ -114,7 +114,7 @@ enum MarineVariable: String, GenericVariableMixable {
 
 struct IconWaveController {
     func query(_ req: Request) async throws -> Response {
-        let host = try await req.ensureSubdomain("marine-api")
+        _ = try await req.ensureSubdomain("marine-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         let numberOfLocationsMaximum = try await req.ensureApiKey("marine-api", apikey: params.apikey)
         let currentTime = Timestamp.now()
@@ -226,7 +226,7 @@ struct IconWaveController {
                                         return nil
                                     }
                                     unit = d.unit
-                                    assert(timeHourlyRead.count == d.data.count)
+                                    assert(time.minutely15.count == d.data.count)
                                     return ApiArray.float(d.data)
                                 }
                                 guard allMembers.count > 0 else {

--- a/Sources/App/IconWave/IconWaveController.swift
+++ b/Sources/App/IconWave/IconWaveController.swift
@@ -100,6 +100,8 @@ enum MarineVariable: String, GenericVariableMixable {
     case swell_wave_direction
     case ocean_current_velocity
     case ocean_current_direction
+    case sea_level_height_msl
+    case invert_barometer_height
     
     var requiresOffsetCorrectionForMixing: Bool {
         return false

--- a/Sources/App/MfWave/MfWaveDomain.swift
+++ b/Sources/App/MfWave/MfWaveDomain.swift
@@ -51,7 +51,8 @@ enum MfWaveDomain: String, CaseIterable, GenericDomain {
     var grid: Gridable {
         switch self {
         case .mfwave, .mfsst, .mfcurrents:
-            return RegularGrid(nx: 4320, ny: 2041, latMin: -80, lonMin: -180, dx: 1/12, dy: 1/12, searchRadius: 2)
+            // Important: GRID needs to be aligned to center points by dx/2 and dy/2
+            return RegularGrid(nx: 4320, ny: 2041, latMin: -80 + 1/24, lonMin: -180 + 1/24, dx: 1/12, dy: 1/12, searchRadius: 2)
         }
     }
     

--- a/Sources/App/MfWave/MfWaveDomain.swift
+++ b/Sources/App/MfWave/MfWaveDomain.swift
@@ -6,6 +6,7 @@ import Foundation
 enum MfWaveDomain: String, CaseIterable, GenericDomain {
     case mfwave
     case mfcurrents
+    case mfsst
     
     var hasYearlyFiles: Bool {
         return false
@@ -21,11 +22,18 @@ enum MfWaveDomain: String, CaseIterable, GenericDomain {
             return .meteofrance_wave
         case .mfcurrents:
             return .meteofrance_currents
+        case .mfsst:
+            return .meteofrance_sea_surface_temperature
         }
     }
     
     var domainRegistryStatic: DomainRegistry? {
-        return domainRegistry
+        switch self {
+        case .mfsst:
+            return .meteofrance_currents
+        default:
+            return domainRegistry
+        }
     }
     
     /// Number of time steps in each time series optimised file. 5 days more than each run.
@@ -39,12 +47,14 @@ enum MfWaveDomain: String, CaseIterable, GenericDomain {
             return 3*3600
         case .mfcurrents:
             return 3600
+        case .mfsst:
+            return 6*3600
         }
     }
     
     var grid: Gridable {
         switch self {
-        case .mfwave:
+        case .mfwave, .mfsst:
             return RegularGrid(nx: 4320, ny: 2041, latMin: -80, lonMin: -180, dx: 1/12, dy: 1/12, searchRadius: 2)
         case .mfcurrents:
             return RegularGrid(nx: 4320, ny: 2041, latMin: -80, lonMin: -180, dx: 1/12, dy: 1/12)
@@ -55,7 +65,7 @@ enum MfWaveDomain: String, CaseIterable, GenericDomain {
         switch self {
         case .mfwave:
             return 12*3600
-        case .mfcurrents:
+        case .mfcurrents, .mfsst:
             return 24*3600
         }
     }
@@ -66,7 +76,7 @@ enum MfWaveDomain: String, CaseIterable, GenericDomain {
         case .mfwave:
             // Delay of 11 hours after initialisation
             return t.add(hours: -11).floor(toNearestHour: 12)
-        case .mfcurrents:
+        case .mfcurrents, .mfsst:
             // Delay of 11 hours after initialisation
             return t.add(hours: -11).floor(toNearestHour: 24)
         }
@@ -78,6 +88,8 @@ enum MfWaveDomain: String, CaseIterable, GenericDomain {
             return 12 // 2 files per day
         case .mfcurrents:
             return 24 // 1 file per day
+        case .mfsst:
+            return 6 // 1 file per 6 hours
         }
     }
 }

--- a/Sources/App/MfWave/MfWaveDomain.swift
+++ b/Sources/App/MfWave/MfWaveDomain.swift
@@ -29,10 +29,8 @@ enum MfWaveDomain: String, CaseIterable, GenericDomain {
     
     var domainRegistryStatic: DomainRegistry? {
         switch self {
-        case .mfsst:
-            return .meteofrance_currents
-        default:
-            return domainRegistry
+        case .mfwave, .mfsst, .mfcurrents:
+            return .meteofrance_wave
         }
     }
     
@@ -54,10 +52,8 @@ enum MfWaveDomain: String, CaseIterable, GenericDomain {
     
     var grid: Gridable {
         switch self {
-        case .mfwave, .mfsst:
+        case .mfwave, .mfsst, .mfcurrents:
             return RegularGrid(nx: 4320, ny: 2041, latMin: -80, lonMin: -180, dx: 1/12, dy: 1/12, searchRadius: 2)
-        case .mfcurrents:
-            return RegularGrid(nx: 4320, ny: 2041, latMin: -80, lonMin: -180, dx: 1/12, dy: 1/12)
         }
     }
     

--- a/Sources/App/MfWave/MfWaveDomain.swift
+++ b/Sources/App/MfWave/MfWaveDomain.swift
@@ -28,10 +28,8 @@ enum MfWaveDomain: String, CaseIterable, GenericDomain {
     }
     
     var domainRegistryStatic: DomainRegistry? {
-        switch self {
-        case .mfwave, .mfsst, .mfcurrents:
-            return .meteofrance_wave
-        }
+        /// Note: sea land mask is slighly differnet for each model
+        return domainRegistry
     }
     
     /// Number of time steps in each time series optimised file. 5 days more than each run.

--- a/Sources/App/MfWave/MfWaveDownload.swift
+++ b/Sources/App/MfWave/MfWaveDownload.swift
@@ -271,7 +271,7 @@ extension MfWaveDomain {
         case .mfsst:
             /// Only hindcast available after 7 days
             let isHindcast = run.add(days: 7) < Timestamp.now()
-            let type = isHindcast ? "hcast" : "fcst"
+            let type = isHindcast ? "hcst" : "fcst"
             // glo12_rg_6h-i_20250206-18h_3D-thetao_fcst_R20250207.nc
             return [
                 "\(server)GLOBAL_ANALYSISFORECAST_PHY_001_024/cmems_mod_glo_phy-thetao_anfc_0.083deg_PT6H-i_202406/\(r.year)/\(rMM)/glo12_rg_6h-i_\(step.format_YYYYMMdd)-\(step.hh)h_3D-thetao_\(type)_R\(run.format_YYYYMMdd).nc",

--- a/Sources/App/MfWave/MfWaveDownload.swift
+++ b/Sources/App/MfWave/MfWaveDownload.swift
@@ -82,7 +82,8 @@ struct MfWaveDownload: AsyncCommand {
         let ny = domain.grid.ny
         let writer = OmFileSplitter.makeSpatialWriter(domain: domain)
         
-        if domain == .mfwave && !FileManager.default.fileExists(atPath: domain.surfaceElevationFileOm.getFilePath()) {
+        // Note: The actual domain data area is slightly different
+        /*if domain == .mfwave && !FileManager.default.fileExists(atPath: domain.surfaceElevationFileOm.getFilePath()) {
             let url = domain.getBathymetryUrl()
             let memory = try await curl.downloadInMemoryAsync(url: url, minSize: 1024*1024)
             let bathy = try memory.withUnsafeReadableBytes({ memory in
@@ -108,7 +109,7 @@ struct MfWaveDownload: AsyncCommand {
             }
             try domain.surfaceElevationFileOm.createDirectory()
             try elevation.writeOmFile2D(file: domain.surfaceElevationFileOm.getFilePath(), grid: domain.grid, createNetCdf: false)
-        }
+        }*/
         
         let phyModel = domain == .mfsst || domain == .mfcurrents
         
@@ -218,7 +219,7 @@ struct MfWaveDownload: AsyncCommand {
                                         }
                                     }
                                 }
-                                if domain == .mfwave && !FileManager.default.fileExists(atPath: domain.surfaceElevationFileOm.getFilePath()) {
+                                if !FileManager.default.fileExists(atPath: domain.surfaceElevationFileOm.getFilePath()) {
                                     // create land elevation file. 0=land, -999=sea
                                     let elevation = data.map {
                                         return $0.isNaN ? Float(0) : -999

--- a/Sources/App/MfWave/MfWaveDownload.swift
+++ b/Sources/App/MfWave/MfWaveDownload.swift
@@ -57,7 +57,7 @@ struct MfWaveDownload: AsyncCommand {
                     logger.info("Downloading domain '\(domain.rawValue)' run '\(run.iso8601_YYYY_MM_dd_HH_mm)'")
                     return try await download(application: context.application, domain: domain, run: run, onlyTides: signature.onlyTides)
                 }
-                try await GenericVariableHandle.convert(logger: logger, domain: domain, createNetcdf: signature.createNetcdf, run: runs.range.lowerBound, handles: handles, concurrent: nConcurrent, writeUpdateJson: false, uploadS3Bucket: nil, uploadS3OnlyProbabilities: false)
+                try await GenericVariableHandle.convert(logger: logger, domain: domain, createNetcdf: signature.createNetcdf, run: nil, handles: handles, concurrent: nConcurrent, writeUpdateJson: false, uploadS3Bucket: nil, uploadS3OnlyProbabilities: false)
             }
             return
         }

--- a/Sources/App/MfWave/MfWaveDownload.swift
+++ b/Sources/App/MfWave/MfWaveDownload.swift
@@ -190,7 +190,7 @@ struct MfWaveDownload: AsyncCommand {
                                         }
                                     }
                                 }
-                                if !FileManager.default.fileExists(atPath: domain.surfaceElevationFileOm.getFilePath()) {
+                                if domain == .mfwave && !FileManager.default.fileExists(atPath: domain.surfaceElevationFileOm.getFilePath()) {
                                     // create land elevation file. 0=land, -999=sea
                                     let elevation = data.map {
                                         return $0.isNaN ? Float(0) : -999

--- a/Sources/App/MfWave/MfWaveDownload.swift
+++ b/Sources/App/MfWave/MfWaveDownload.swift
@@ -90,7 +90,7 @@ struct MfWaveDownload: AsyncCommand {
             logger.warning("Not data for \(run.format_YYYYMMddHH)")
             return []
         }
-        if domain == .mfcurrents && [Timestamp(2022,11,30)].contains(run) {
+        if domain == .mfcurrents && [Timestamp(2022,11,30), Timestamp(2024,6,26)].contains(run) {
             logger.warning("Skipping due to NRT change \(run.format_YYYYMMddHH)")
             return []
         }

--- a/Sources/App/MfWave/MfWaveVariable.swift
+++ b/Sources/App/MfWave/MfWaveVariable.swift
@@ -104,6 +104,8 @@ enum MfWaveVariable: String, CaseIterable, GenericVariable, GenericVariableMixab
 enum MfCurrentVariable: String, CaseIterable, GenericVariable, GenericVariableMixable {
     case ocean_u_current
     case ocean_v_current
+    case sea_level_height_msl
+    case invert_barometer_height
     
     var storePreviousForecast: Bool {
         return false
@@ -126,6 +128,8 @@ enum MfCurrentVariable: String, CaseIterable, GenericVariable, GenericVariableMi
         switch self {
         case .ocean_u_current, .ocean_v_current:
             return .metrePerSecond
+        case .sea_level_height_msl, .invert_barometer_height:
+            return .metre
         }
     }
     
@@ -133,12 +137,16 @@ enum MfCurrentVariable: String, CaseIterable, GenericVariable, GenericVariableMi
         switch self {
         case .ocean_u_current, .ocean_v_current:
             return 20 // 0.05 ms (~0.1 knots)
+        case .sea_level_height_msl, .invert_barometer_height:
+            return 100 // 1cm res
         }
     }
     
     var interpolation: ReaderInterpolation {
         switch self {
         case .ocean_u_current, .ocean_v_current:
+            return .hermite(bounds: nil)
+        case .sea_level_height_msl, .invert_barometer_height:
             return .hermite(bounds: nil)
         }
     }

--- a/Sources/App/MfWave/MfWaveVariable.swift
+++ b/Sources/App/MfWave/MfWaveVariable.swift
@@ -254,3 +254,46 @@ struct MfWaveReader: GenericReaderProtocol {
 }
 
 
+
+
+enum MfSSTVariable: String, CaseIterable, GenericVariable, GenericVariableMixable {
+    case sea_surface_temperature
+    
+    var storePreviousForecast: Bool {
+        return false
+    }
+    
+    var isElevationCorrectable: Bool {
+        return false
+    }
+    
+    var requiresOffsetCorrectionForMixing: Bool {
+        return false
+    }
+    
+    var omFileName: (file: String, level: Int) {
+        return (rawValue, 0)
+    }
+    
+    /// Si unit
+    var unit: SiUnit {
+        switch self {
+        case .sea_surface_temperature:
+            return .celsius
+        }
+    }
+    
+    var scalefactor: Float {
+        switch self {
+        case .sea_surface_temperature:
+            return 20
+        }
+    }
+    
+    var interpolation: ReaderInterpolation {
+        switch self {
+        case .sea_surface_temperature:
+            return .hermite(bounds: nil)
+        }
+    }
+}

--- a/Sources/App/SeasonalForecast/SeasonalForecastController.swift
+++ b/Sources/App/SeasonalForecast/SeasonalForecastController.swift
@@ -148,7 +148,7 @@ extension SeasonalForecastReader {
  */
 struct SeasonalForecastController {
     func query(_ req: Request) async throws -> Response {
-        let host = try await req.ensureSubdomain("seasonal-api")
+        _ = try await req.ensureSubdomain("seasonal-api")
         let params = req.method == .POST ? try req.content.decode(ApiQueryParameter.self) : try req.query.decode(ApiQueryParameter.self)
         let numberOfLocationsMaximum = try await req.ensureApiKey("seasonal-api", apikey: params.apikey)
         let currentTime = Timestamp.now()

--- a/Tests/AppTests/DataTests.swift
+++ b/Tests/AppTests/DataTests.swift
@@ -525,33 +525,34 @@ final class DataTests: XCTestCase {
     }
     
     func testMfWaveGrid() {
+        // Note: Grid is moved by dx/2 dy/2
         let grid = MfWaveDomain.mfwave.grid
         var coord = grid.findPoint(lat: 36.16667, lon: -0.83333333)!
         var pos = grid.getCoordinates(gridpoint: coord)
         // i=x (i=2150, j=1394) 0.0292969 (x=-0.8333333, y=36.16667)
         XCTAssertEqual(coord, 1394*grid.nx + 2150)
-        XCTAssertEqual(pos.latitude, 36.16667, accuracy: 0.0005)
-        XCTAssertEqual(pos.longitude, -0.83333333, accuracy: 0.0005)
+        XCTAssertEqual(pos.latitude, 36.208336, accuracy: 0.0005)
+        XCTAssertEqual(pos.longitude, -0.7916565, accuracy: 0.0005)
         
         // (i-3486, j-778) -0.0556641 (x=110.5, y=-15.16667)
         coord = grid.findPoint(lat: -15.16667, lon: 110.5)!
         pos = grid.getCoordinates(gridpoint: coord)
-        XCTAssertEqual(coord, 778*grid.nx + 3486)
-        XCTAssertEqual(pos.latitude, -15.16667, accuracy: 0.0005)
-        XCTAssertEqual(pos.longitude, 110.5)
+        XCTAssertEqual(coord, 777*grid.nx + 3485)
+        XCTAssertEqual(pos.latitude, -15.208336, accuracy: 0.0005)
+        XCTAssertEqual(pos.longitude, 110.45836)
         
         //(i-714, j-1230) 0.0146484 (x=-120.5, y=22.5)
         coord = grid.findPoint(lat: 22.5, lon: -120.5)!
         pos = grid.getCoordinates(gridpoint: coord)
-        XCTAssertEqual(coord, 1230*grid.nx + 714)
-        XCTAssertEqual(pos.latitude, 22.5, accuracy: 0.0005)
-        XCTAssertEqual(pos.longitude, -120.5)
+        XCTAssertEqual(coord, 1230*grid.nx + 713)
+        XCTAssertEqual(pos.latitude, 22.541664, accuracy: 0.0005)
+        XCTAssertEqual(pos.longitude, -120.54166)
         
         // (i=4278, j=1170) -0.321289 (x=176.5, y=17.5)
         coord = grid.findPoint(lat: 17.5, lon: 176.5)!
         pos = grid.getCoordinates(gridpoint: coord)
-        XCTAssertEqual(coord, 1170*grid.nx + 4278)
-        XCTAssertEqual(pos.latitude, 17.5, accuracy: 0.0005)
-        XCTAssertEqual(pos.longitude, 176.5)
+        XCTAssertEqual(coord, 1170*grid.nx + 4277)
+        XCTAssertEqual(pos.latitude, 17.541664, accuracy: 0.0005)
+        XCTAssertEqual(pos.longitude, 176.45836)
     }
 }


### PR DESCRIPTION
Integrate sea level height considering ocean tides.

Important: Ocean tides use the field "total_sea_level" which is the height above the global mean sea level.
This is not the height above lowest atmospherical tide LAT which is usually used in navigation.
To estimate the LAT, we can compute the minimum of "total_sea_level - invert_barometer" over 2.5 years. Ideal would be 18 years.

Preview: https://open-meteo.com/en/docs/marine-weather-api#latitude=49.356361&longitude=-1.810854&current=&hourly=sea_level_height_msl,invert_barometer_height&daily=&models=

TODO:
- [ ] Find solution for chart datum LAT
- [x] allow 10/15 min interpolations

![Screenshot 2025-02-10 at 17 42 43](https://github.com/user-attachments/assets/0013127e-8d87-457b-9e46-cade8d228bf7)


Docs PR: https://github.com/open-meteo/open-meteo-website/pull/397

Closes #104