### PR TITLE
fix: om v3 file format to netcdf conversion

### DIFF
--- a/Sources/App/Commands/ConvertOmCommand.swift
+++ b/Sources/App/Commands/ConvertOmCommand.swift
@@ -4,91 +4,172 @@ import Vapor
 import SwiftNetCDF
 
 /**
- Small helper tool to convert a `om` file to NetCDF for debugging
- 
- e.g. openmeteo-api convert-om /Volumes/2TB_1GBs/data/master-MRI_AGCM3_2_S/windgusts_10m_mean_linear_bias_seasonal.om --nx 1920 --transpose -o temp.nc
- 
+ Small helper tool to convert between `om` versions and between om file format and NetCDF for debugging
+
+ Examples:
+  - Convert to NetCDF: openmeteo-api convert-om data.om --to netcdf -o output.nc --domain ecmwf_ifs025
+  - Convert between OM versions: openmeteo-api convert-om data.om --to om3 -o data.om3 --domain ecmwf_ifs025
  */
 struct ConvertOmCommand: Command {
     var help: String {
-        return "Convert an om file to to NetCDF"
+        return "Convert between om file format version or convert to NetCDF"
     }
-    
+
     struct Signature: CommandSignature {
         @Argument(name: "infile", help: "Input file")
         var infile: String
-        
-        @Option(name: "output", short: "o", help: "Output file name. Default: ./output.nc")
+
+        @Option(name: "to", help: "Conversion target format: 'netcdf' or 'om3'")
+        var convertTo: String?
+
+        @Option(name: "output", short: "o", help: "Output file name. Default: [infile].nc or [infile].om3")
         var outfile: String?
-        
+
         @Flag(name: "transpose", help: "Transpose data to fast space")
         var transpose: Bool
-        
-        @Option(name: "nx", help: "Use this nx value to convert to d3")
-        var nx: Int?
-        
-        @Option(name: "domain", help: "Domain used for grid definiton")
+
+        @Option(name: "domain", help: "Domain used for grid definition")
         var domain: String?
     }
-    
+
     func run(using context: CommandContext, signature: Signature) throws {
         let logger = context.application.logger
-        
-        if let domain = signature.domain {
-            let domain = try DomainRegistry.load(rawValue: domain)
-            let oufile = signature.outfile ?? "\(signature.infile).om3"
-            try convertOmv3(src: signature.infile, dest: oufile, grid: domain.getDomain().grid)
+        logger.info("Processing file: \(signature.infile)")
+
+        let convertTo = signature.convertTo?.lowercased() ?? "netcdf"
+
+        if convertTo == "om3" {
+            // Handle conversion to OM3
+            guard let domain = signature.domain else {
+                throw ConvertOmError("Domain parameter is required for OM3 conversion")
+            }
+            let domainObj = try DomainRegistry.load(rawValue: domain)
+            let outfile = signature.outfile ?? signature.infile.withoutOmSuffix + ".om3"
+            logger.info("Converting OM file to v3 with domain: \(domain). Outfile will be: \(outfile)")
+            try convertOmv3(src: signature.infile, dest: outfile, grid: domainObj.getDomain().grid)
             return
+        } else if convertTo == "netcdf" {
+            // Handle conversion to NetCDF
+            guard let om = try OmFileReader(file: signature.infile).asArray(of: Float.self) else {
+                throw ConvertOmError("Not a float array")
+            }
+            let dimensions = om.getDimensions().map { $0 }
+            let chunks = om.getChunkDimensions().map { $0 }
+            logger.info("File dimensions: \(dimensions), chunks: \(chunks)")
+
+            let data = try om.read()
+            let outfile = signature.outfile ?? signature.infile.withoutOmSuffix + ".nc"
+            logger.info("Converting to NetCDF: \(outfile)")
+            try convertToNetCDF(data: data, dimensions: dimensions, outfile: outfile, transpose: signature.transpose, domain: signature.domain, logger: logger)
+            return
+        } else {
+            throw ConvertOmError("Unsupported conversion target: \(convertTo)")
         }
-        
-        guard let om = try OmFileReader(file: signature.infile).asArray(of: Float.self) else {
-            fatalError("Not a float array")
+    }
+
+    /// Convert data to NetCDF format
+    private func convertToNetCDF(data: [Float], dimensions: [UInt64], outfile: String, transpose: Bool, domain: String?, logger: Logger) throws {
+        let ncFile = try NetCDF.create(path: outfile, overwriteExisting: true)
+        try ncFile.setAttribute("TITLE", "open-meteo data")
+
+        switch dimensions.count {
+        case 2:
+            try convertToNetCDF2D(data: data, dimensions: dimensions, ncFile: ncFile, transpose: transpose, domain: domain, logger: logger)
+        case 3:
+            try convertToNetCDF3D(data: data, dimensions: dimensions, ncFile: ncFile, transpose: transpose)
+        default:
+            logger.error("Unsupported number of dimensions for netcdf conversion: \(dimensions.count)")
+            throw ConvertOmError("Unsupported number of dimensions: \(dimensions.count)")
         }
-        let dimensions = om.getDimensions()
-        let chunks = om.getChunkDimensions()
-        guard dimensions.count == 2 else {
-            fatalError("Not a 2D array")
-        }
-        let dim0 = Int(dimensions[0])
-        let dim1 = Int(dimensions[1])
-        let chunk0 = chunks[0]
-        let chunk1 = chunks[1]
-        logger.info("dim0=\(dim0) dim1=\(dim1) chunk0=\(chunk0) chunk1=\(chunk1)")
-        
-        let data = try om.read()
-        
-        let oufile = signature.outfile ?? "\(signature.infile).nc"
-        let ncFile = try NetCDF.create(path: oufile, overwriteExisting: true)
-        try ncFile.setAttribute("TITLE", "open-meteo file convert")
-        
-        if let nx = signature.nx {
-            let ny = dim0 / nx
-            if signature.transpose {
-                logger.info("Transpose to nx=\(nx) ny=\(ny)")
-                // to fast space
+
+        logger.info("NetCDF conversion completed successfully")
+    }
+
+    /// Handle 2D data conversion to NetCDF
+    private func convertToNetCDF2D(data: [Float], dimensions: [UInt64], ncFile: Group, transpose: Bool, domain: String?, logger: Logger) throws {
+        if let domain = domain {
+            let grid = try DomainRegistry.load(rawValue: domain).getDomain().grid
+            let ny = grid.ny
+            let nx = grid.nx
+            let nt = Int(dimensions[1])
+
+            guard dimensions[0] == nx * ny, ny > 1, nx > 1 else {
+                throw ConvertOmError("Wrong grid! Expected \(nx * ny) locations, got \(dimensions[0])")
+            }
+
+            if transpose {
+                // Fast time dimension (locations, time) -> (time, locations)
                 var ncVariable = try ncFile.createVariable(name: "data", type: Float.self, dimensions: [
-                    try ncFile.createDimension(name: "time", length: dim1),
+                    try ncFile.createDimension(name: "time", length: nt),
                     try ncFile.createDimension(name: "LAT", length: ny),
                     try ncFile.createDimension(name: "LON", length: nx)
                 ])
-                let data2 = Array2DFastTime(data: data, nLocations: dim0, nTime: dim1).transpose()
-                try ncVariable.write(data2.data)
+                let transposedData = Array2DFastTime(data: data, nLocations: nx * ny, nTime: nt).transpose()
+                try ncVariable.write(transposedData.data)
             } else {
-                // fast time dimension
+                // Default layout
                 var ncVariable = try ncFile.createVariable(name: "data", type: Float.self, dimensions: [
                     try ncFile.createDimension(name: "LAT", length: ny),
                     try ncFile.createDimension(name: "LON", length: nx),
-                    try ncFile.createDimension(name: "time", length: dim1)
+                    try ncFile.createDimension(name: "time", length: nt)
                 ])
                 try ncVariable.write(data)
             }
         } else {
+            logger.warning("No domain provided, converting to LAT and LON dimensions, which might not be what you want for weather domains!")
+            logger.warning("If you want to convert to a proper 3-dimensional NetCDF file, please provide a domain (for grid dimensions).")
+
+            // Default layout
             var ncVariable = try ncFile.createVariable(name: "data", type: Float.self, dimensions: [
-                try ncFile.createDimension(name: "LAT", length: dim1),
-                try ncFile.createDimension(name: "LON", length: dim0),
+                try ncFile.createDimension(name: "LAT", length: Int(dimensions[0])),
+                try ncFile.createDimension(name: "LON", length: Int(dimensions[1]))
             ])
             try ncVariable.write(data)
         }
+    }
+
+    /// Handle 3D data conversion to NetCDF
+    private func convertToNetCDF3D(data: [Float], dimensions: [UInt64], ncFile: Group, transpose: Bool) throws {
+        let ny = Int(dimensions[0])
+        let nx = Int(dimensions[1])
+        let nt = Int(dimensions[2])
+
+        if transpose {
+            // Transpose to fast space (lat, lon, time) -> (time, lat, lon)
+            var ncVariable = try ncFile.createVariable(name: "data", type: Float.self, dimensions: [
+                try ncFile.createDimension(name: "time", length: nt),
+                try ncFile.createDimension(name: "LAT", length: ny),
+                try ncFile.createDimension(name: "LON", length: nx)
+            ])
+            // Need to implement appropriate 3D transpose logic
+            let transposed = transpose3D(data: data, ny: ny, nx: nx, nt: nt)
+            try ncVariable.write(transposed)
+        } else {
+            var ncVariable = try ncFile.createVariable(name: "data", type: Float.self, dimensions: [
+                try ncFile.createDimension(name: "LAT", length: ny),
+                try ncFile.createDimension(name: "LON", length: nx),
+                try ncFile.createDimension(name: "time", length: nt)
+            ])
+            try ncVariable.write(data)
+        }
+    }
+
+    /// Helper function to transpose 3D data from (lat, lon, time) to (time, lat, lon)
+    private func transpose3D(data: [Float], ny: Int, nx: Int, nt: Int) -> [Float] {
+        var result = [Float](repeating: 0, count: data.count)
+
+        for y in 0..<ny {
+            for x in 0..<nx {
+                for t in 0..<nt {
+                    // From (y, x, t) to (t, y, x)
+                    let srcIdx = y * (nx * nt) + x * nt + t
+                    let dstIdx = t * (ny * nx) + y * nx + x
+                    result[dstIdx] = data[srcIdx]
+                }
+            }
+        }
+
+        return result
     }
 
     /// Read om file and write it as version 3 and reshape data to proper 3d files
@@ -96,7 +177,7 @@ struct ConvertOmCommand: Command {
         // Read data from the input OM file
         guard let readfile = try? OmFileReader(fn: try MmapFile(fn: FileHandle.openFileReading(file: src))),
               let reader = readfile.asArray(of: Float.self) else {
-            fatalError("Failed to open file: \(src)")
+            throw ConvertOmError("Failed to open file: \(src)")
         }
 
         let dimensions = Array(reader.getDimensions())
@@ -106,20 +187,19 @@ struct ConvertOmCommand: Command {
         print("dimensions: \(dimensions)")
         print("chunks: \(chunks)")
         print("scaleFactor: \(reader.scaleFactor)")
-        
 
         let ny = UInt64(grid.ny)
         let nx = UInt64(grid.nx)
         let nt = dimensions[1]
-        
+
         guard dimensions.count == 2, nx * ny == dimensions[0], ny > 1, nx > 1 else {
-            fatalError("wrong grid")
+            throw ConvertOmError("Wrong grid! Expected \(nx * ny) locations, got \(dimensions[0])")
         }
-        
+
         let dimensionsOut = [ny, nx, nt]
         let chunksOut = [1,chunks[0],chunks[1]]
         // TODO somehow 5x5 is larger than 1x25....
-        
+
         /*let dataRaw = try reader.read(range: [0..<ny*nx, 0..<nt])
         print("data read")
         if false {
@@ -137,7 +217,7 @@ struct ConvertOmCommand: Command {
             print("nc wwrite done")
             return
         }*/
-        
+
         try FileManager.default.removeItemIfExists(at: dest)
         let fileHandle = try FileHandle.createNewFile(file: dest)
 
@@ -164,7 +244,7 @@ struct ConvertOmCommand: Command {
                     let xRange = xStart ..< min(xStart + chunksOut[1], nx)
                     let tRange = tStart ..< min(tStart + chunksOut[2], nt)
                     //print("chunk y=\(yRange) x=\(xRange) t=\(tRange)")
-                    
+
                     var chunk = [Float](repeating: .nan, count: yRange.count * xRange.count * tRange.count)
                     for (row, y) in yRange.enumerated() {
                         try reader.read(
@@ -183,7 +263,7 @@ struct ConvertOmCommand: Command {
                 }
             }
         }
-       
+
 
         let variableMeta = try writer.finalise()
         print("Finalized Array")
@@ -192,7 +272,7 @@ struct ConvertOmCommand: Command {
         try fileWriter.writeTrailer(rootVariable: variable)
 
         print("Finished writing")
-        
+
         /*// Verify the output
         guard let verificationFile = try? OmFileReader(fn: try MmapFile(fn: FileHandle.openFileReading(file: dest))),
             let verificationReader = verificationFile.asArray(of: Float.self) else {
@@ -200,8 +280,8 @@ struct ConvertOmCommand: Command {
         }
 
         let dataVerify = try verificationReader.read(range: [0..<ny, 0..<nx, 0..<nt])
-        
-        
+
+
         guard dataVerify == dataRaw else {
             for i in 0..<min(dataVerify.count, 1000) {
                 if dataVerify[i] != dataRaw[i] {//}&& !dataRaw[i].isNaN && !dataVerify[i].isNaN {
@@ -211,5 +291,22 @@ struct ConvertOmCommand: Command {
             print("verify failed")
             fatalError()
         }*/
+    }
+}
+
+struct ConvertOmError: Error {
+    let message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+}
+
+extension String {
+    var withoutOmSuffix: String {
+        if hasSuffix(".om") {
+            return String(dropLast(3))
+        }
+        return self
     }
 }

--- a/Sources/App/Helper/NumberExtensions.swift
+++ b/Sources/App/Helper/NumberExtensions.swift
@@ -3,7 +3,7 @@ import Foundation
 
 public extension Double {
     func round(digits: Int) -> Double {
-        let mut = pow(10, Double(digits))
+        let mut = Foundation.pow(10, Double(digits))
         return (self * mut).rounded() / mut
     }
 }


### PR DESCRIPTION
This fix addresses https://github.com/open-meteo/open-data/issues/24. There the conversion to netcdf with the new file format and particularly with more than 2 dimensions failed.  

This PR removes the `nx` option from the command and instead makes conversions more explicit using the `domain` option. I did it that way, because it seemed most consistent with how the om version 2 to om version 3 conversion was already implemented. 
Additionally, converting files from om2 to om3 will now need to set the additional option `format` to be `om3`, the default conversion is to `netcdf`.