### PR TITLE
fix: Asia/Qostanay timezone

### DIFF
--- a/Sources/App/Helper/ForecastapiQuery.swift
+++ b/Sources/App/Helper/ForecastapiQuery.swift
@@ -614,6 +614,13 @@ extension TimeZone {
         if identifier == "America/Nuuk", let tz = TimeZone(identifier: "America/Godthab") {
             return tz
         }
+
+        // Asia/Qostanay and Asia/Almaty are outdated in Swift.
+        // https://github.com/open-meteo/open-meteo/issues/1236
+        if identifier == "Asia/Qostanay" || identifier == "Asia/Almaty", let tz = TimeZone(identifier: "Asia/Qyzylorda") {
+            return tz
+        }
+
         guard let tz = TimeZone(identifier: identifier) else {
             if identifier == "America/Ciudad_Juarez", let tz = TimeZone(identifier: "America/Mexico_City") {
                 return tz


### PR DESCRIPTION
Closes https://github.com/open-meteo/open-meteo/issues/1236.

According to [Wikipedia](https://en.wikipedia.org/wiki/Time_in_Kazakhstan#IANA_time_zone_database):

> According to an email on the tz mailing list, Qostanay Region could be part of Asia/Qyzylorda.

And according to [release notes of tzdata 2024a](https://mm.icann.org/pipermail/tz-announce/2024-February/000081.html) the unification of kazakhstans timezone are relevant for the two modified timezones.