### PR TITLE
Add Usage of OpenKNX OFM-InternetWeatherModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Repositories:
 Other:
 - [Menubar Weather](https://www.raycast.com/koinzhang/menubar-weather) A Raycast extension that displays live weather information in your menu bar
 - [MiniPavi](https://www.minipavi.fr/emulminitel/) Vintage French Minitel (a kind of BBS) weather forecast service (type "METEO" keyword on welcome Minitel screen)
+- [OFM-InternetWeatherModule](https://github.com/OpenKNX/OFM-InternetWeatherModule) An OpenKNX module to provide data of weather services on KNX-bus (configurable via ETS)  
 - Contributions welcome!
 
 Do you use Open-Meteo? Please open a pull request and add your repository or app to the list!


### PR DESCRIPTION
Thank you very much for this service.

We are happy to announce the integration as an addtional weather service into the OpenKNX (a project for building open and compatible knx applications and devices) Internet-Weather-Module and are planning to use it as the default source in the future, as we like the free access for typical non-commercial users.

It's important for us to comply with your terms of service, so please confirm our implementation match your expectations.
The number of API-calls of each knx-device (installed at the user) using this module and open-meteo as service is expected be far below 10K per day, so the typical smart-home-enthusiast usage (in the meaning of "Utilizing our service for personal home automation purposes.") should be within the requirements for Free-API.
* Users are required to select the type of usage:
![Screenshot 2025-05-31 154518](https://github.com/user-attachments/assets/e7deb499-c1af-4342-afe8-2a08b74badf8)
* We show an additional note for the Free-API:
![Screenshot 2025-05-31 154330](https://github.com/user-attachments/assets/9b09842c-032e-4b82-8cb1-09a2cad945f7)
* We show a special note for data source and licence when selecting open-meteo as service:
![Screenshot 2025-05-31 154621](https://github.com/user-attachments/assets/343f8a50-15d4-4507-9de9-ea0540168e5c)

Support for API-Subscription and own hosting is prepared, but we could not test this without api-key or own server:
 * API-Subscription:
![Screenshot 2025-05-31 154401](https://github.com/user-attachments/assets/c0e7d988-a69d-4493-aa89-02a9262fd40c)
* self hosting:
![Screenshot 2025-05-31 154450](https://github.com/user-attachments/assets/35f37bff-4f14-4559-ada1-eb01ce9aee89)
Configuration allows 40 chars for API-key, and 80 chars for Server-URL

