### PR TITLE
feat: Store spatial data for each run

### DIFF
--- a/Sources/App/Bom/BomDownloader.swift
+++ b/Sources/App/Bom/BomDownloader.swift
@@ -64,7 +64,7 @@ struct DownloadBomCommand: AsyncCommand {
         
         if let uploadS3Bucket = signature.uploadS3Bucket {
             let timesteps = Array(handles.map { $0.time }.uniqued().sorted())
-            try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps)
+            try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps, run: run)
         }
     }
 

--- a/Sources/App/CMA/CmaDownloader.swift
+++ b/Sources/App/CMA/CmaDownloader.swift
@@ -328,7 +328,7 @@ struct DownloadCmaCommand: AsyncCommand {
                 }.collect().compactMap({ $0 })
             }
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp], run: run)
             }
             return handles
         }

--- a/Sources/App/Cams/CamsDownload.swift
+++ b/Sources/App/Cams/CamsDownload.swift
@@ -84,7 +84,7 @@ struct DownloadCamsCommand: AsyncCommand {
             try await GenericVariableHandle.convert(logger: logger, domain: domain, createNetcdf: signature.createNetcdf, run: run, handles: handles, concurrent: signature.concurrent ?? 1, writeUpdateJson: true, uploadS3Bucket: signature.uploadS3Bucket, uploadS3OnlyProbabilities: false)
             if let uploadS3Bucket = signature.uploadS3Bucket {
                 let timesteps = Array(handles.map { $0.time }.uniqued().sorted())
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps)
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps, run: run)
             }
             return
         case .cams_europe:
@@ -102,7 +102,7 @@ struct DownloadCamsCommand: AsyncCommand {
             try await GenericVariableHandle.convert(logger: logger, domain: domain, createNetcdf: signature.createNetcdf, run: run, handles: handles, concurrent: signature.concurrent ?? 1, writeUpdateJson: true, uploadS3Bucket: signature.uploadS3Bucket, uploadS3OnlyProbabilities: false)
             if let uploadS3Bucket = signature.uploadS3Bucket {
                 let timesteps = Array(handles.map { $0.time }.uniqued().sorted())
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps)
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps, run: run)
             }
             return
         case .cams_global_greenhouse_gases:
@@ -114,7 +114,7 @@ struct DownloadCamsCommand: AsyncCommand {
             try await GenericVariableHandle.convert(logger: logger, domain: domain, createNetcdf: signature.createNetcdf, run: run, handles: handles, concurrent: concurrent, writeUpdateJson: true, uploadS3Bucket: signature.uploadS3Bucket, uploadS3OnlyProbabilities: false)
             if let uploadS3Bucket = signature.uploadS3Bucket {
                 let timesteps = Array(handles.map { $0.time }.uniqued().sorted())
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps)
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps, run: run)
             }
             return
         }

--- a/Sources/App/Dmi/DmiDownloader.swift
+++ b/Sources/App/Dmi/DmiDownloader.swift
@@ -266,7 +266,7 @@ struct DmiDownload: AsyncCommand {
                 return h + windHandles
             }
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [t])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [t], run: run)
             }
             return handles
         }

--- a/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
+++ b/Sources/App/Ecmwf/DownloadEcmwfCommand.swift
@@ -454,7 +454,7 @@ struct DownloadEcmwfCommand: AsyncCommand {
             }
             
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp], run: run)
             }
             previousHour = hour
         }
@@ -525,7 +525,7 @@ struct DownloadEcmwfCommand: AsyncCommand {
             }.collect().compactMap({ $0 })
             handles.append(contentsOf: h)
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp], run: run)
             }
         }
         await curl.printStatistics()

--- a/Sources/App/Gem/GemDownloader.swift
+++ b/Sources/App/Gem/GemDownloader.swift
@@ -252,7 +252,7 @@ struct GemDownload: AsyncCommand {
                 }
             }
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp], run: run)
             }
             previousHour = hour
         }

--- a/Sources/App/Gfs/GfsDownload.swift
+++ b/Sources/App/Gfs/GfsDownload.swift
@@ -450,7 +450,7 @@ struct GfsDownload: AsyncCommand {
                 }
             }
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp], run: run)
             }
             previousHour = forecastHour
         }

--- a/Sources/App/GfsGraphCast/GfsGraphCastDownload.swift
+++ b/Sources/App/GfsGraphCast/GfsGraphCastDownload.swift
@@ -247,7 +247,7 @@ struct GfsGraphCastDownload: AsyncCommand {
                 try writer.write(time: timestamp, member: 0, variable: GfsGraphCastSurfaceVariable.cloud_cover, data: cloudcover)
             ]
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp], run: run)
             }
             return handles + handles2 + handles3 + handlesClouds
         }

--- a/Sources/App/Helper/DomainRegistry.swift
+++ b/Sources/App/Helper/DomainRegistry.swift
@@ -429,3 +429,44 @@ extension DomainRegistry {
         }
     }
 }
+
+
+struct DataSpatialJson: Encodable {
+    let reference_time: String
+    let last_modified_time: String
+    let completed: Bool
+    let valid_times: [String]
+    let variables: [VariableSpatialJson]
+    
+    /// Data temporal resolution in seconds. E.g. 3600 for 1-hourly data
+    let temporal_resolution_seconds: Int
+    
+    // grid attributes?
+    
+    public init(domain: GenericDomain, run: Timestamp, handles: [GenericVariableHandle], completed: Bool) {
+        let variables = handles.map(\.variable).uniqued(on: \.rawValue).map {
+            
+            return VariableSpatialJson(name: $0.rawValue, unit: $0.unit.abbreviation, skip_hour0: false, step_type: .instantaneous)
+        }
+        let valid_times = handles.map(\.time).uniqued()
+        
+        
+        fatalError()
+    }
+    
+    struct VariableSpatialJson: Encodable {
+        /// E.g. `temperature_2m`
+        let name: String
+        let unit: String
+        let skip_hour0: Bool
+        let step_type: StepType
+    }
+    
+    enum StepType: Encodable {
+        case instantaneous
+        case mean
+        case sum
+        case maximum
+        case minimum
+    }
+}

--- a/Sources/App/Helper/DomainRegistry.swift
+++ b/Sources/App/Helper/DomainRegistry.swift
@@ -397,15 +397,17 @@ extension DomainRegistry {
     
     /// Upload spatial files to S3 `/data_spatial/<domain>/<run>/<timestamp>/<variable>.om`
     /// Run timestamp is split into directories `YYYY/MM/DD/HH:MMZ`
-    func syncToS3Spatial(bucket: String, timesteps: [Timestamp]) throws {
+    func syncToS3Spatial(bucket: String, timesteps: [Timestamp], run: Timestamp) throws {
         let dir = rawValue
         guard let directorySpatial = OpenMeteo.dataSpatialDirectory else {
             return
         }
+        let runFormatted = run.format_directoriesYYYYMMddhhmm
         for timestep in timesteps {
+            let timeFormatted = timestep.iso8601_YYYYMMddTHHmm
             for bucket in bucket.split(separator: ",") {
-                let src = "\(directorySpatial)\(dir)/\(timestep.format_directoriesYYYYMMddhhmm)/"
-                let dest = "s3://\(bucket)/data_spatial/\(dir)/\(timestep.format_directoriesYYYYMMddhhmm)"
+                let src = "\(directorySpatial)\(dir)/\(runFormatted)/\(timeFormatted)/"
+                let dest = "s3://\(bucket)/data_spatial/\(dir)/\(runFormatted)/\(timeFormatted)/"
                 if !FileManager.default.fileExists(atPath: src) {
                     continue
                 }

--- a/Sources/App/Helper/ModelMetaJson.swift
+++ b/Sources/App/Helper/ModelMetaJson.swift
@@ -37,7 +37,7 @@ enum ModelTimeVariable: String, GenericVariable {
 /**
  TODO:
  - CAMS, IconWave, GloFas, seasonal forecast, CMIP, satellite
- - run end lenght might be too short for side-runs
+ - run end length might be too short for side-runs
  - license
  - name of provider
  - spatial resolution
@@ -48,7 +48,7 @@ enum ModelTimeVariable: String, GenericVariable {
  - model forecast steps with 1,3,6 hour switching?
  */
 struct ModelUpdateMetaJson: Codable {
-    /// Model initilsiation time as unix timestamp. E.g. 0z
+    /// Model initialisation time as unix timestamp. E.g. 0z
     let last_run_initialisation_time: Int
 
     /// Last modification time. The time the conversion finished on the download and processing server

--- a/Sources/App/Helper/OmFileWriterHelper.swift
+++ b/Sources/App/Helper/OmFileWriterHelper.swift
@@ -22,8 +22,8 @@ struct OmRunSpatialWriter: Sendable {
     func write(time: Timestamp, member: Int, variable: GenericVariable, data: [Float], compressionType: OmCompressionType = .pfor_delta2d_int16, overwrite: Bool = false) throws -> GenericVariableHandle {
         let fn: FileHandle
         if storeOnDisk, let directorySpatial = domain.domainRegistry.directorySpatial {
-            //let path = "\(directorySpatial)\(run.format_directoriesYYYYMMddhhmm)/\(time.iso8601_YYYYMMddTHHmm)/"
-            let path = "\(directorySpatial)/\(time.format_directoriesYYYYMMddhhmm)/"
+            let path = "\(directorySpatial)\(run.format_directoriesYYYYMMddhhmm)/\(time.iso8601_YYYYMMddTHHmm)/"
+            //let path = "\(directorySpatial)/\(time.format_directoriesYYYYMMddhhmm)/"
             let file = "\(path)\(variable.omFileName.file).om"
             try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
             let fileTemp = "\(file)~"

--- a/Sources/App/Icon/DownloadIconCommand.swift
+++ b/Sources/App/Icon/DownloadIconCommand.swift
@@ -402,7 +402,7 @@ struct DownloadIconCommand: AsyncCommand {
                 await handles15minIconD2.append(try writer.write(time: v.timestamp, member: v.member, variable: v.variable, data: data.data))
             }
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp], run: run)
             }
             previousHour = hour
         }

--- a/Sources/App/IconWave/IconWaveDownload.swift
+++ b/Sources/App/IconWave/IconWaveDownload.swift
@@ -109,7 +109,7 @@ struct DownloadIconWaveCommand: AsyncCommand {
                 return try writer.write(time: timestamp, member: 0, variable: variable, data: grib2d.array.data)
             }
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp], run: run)
             }
             return handles
         }

--- a/Sources/App/ItaliaMeteoArpae/ItaliaMeteoArpaeDownloader.swift
+++ b/Sources/App/ItaliaMeteoArpae/ItaliaMeteoArpaeDownloader.swift
@@ -61,7 +61,7 @@ struct ItaliaMeteoArpaeDownload: AsyncCommand {
         
         if let uploadS3Bucket = signature.uploadS3Bucket {
             let timesteps = Array(handles.map { $0.time }.uniqued().sorted())
-            try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps)
+            try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps, run: run)
         }
         logger.info("Finished in \(start.timeElapsedPretty())")
     }

--- a/Sources/App/JMA/JmaDownloader.swift
+++ b/Sources/App/JMA/JmaDownloader.swift
@@ -143,7 +143,7 @@ struct JmaDownload: AsyncCommand {
             }
             if let uploadS3Bucket = uploadS3Bucket {
                 let timesteps = Array(handles.map { $0.time }.uniqued().sorted())
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps)
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps, run: run)
             }
             return handles
         }

--- a/Sources/App/Kma/KmaDownloader.swift
+++ b/Sources/App/Kma/KmaDownloader.swift
@@ -173,7 +173,7 @@ struct KmaDownload: AsyncCommand {
                 precipCorrections = try await inMemory.sumUp(var1: .precipitation, var2: .snowfall_water_equivalent, outVariable: KmaSurfaceVariable.precipitation, writer: writer)
             }
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp], run: run)
             }
             return handles + wind10 + wind50 + precipCorrections
         }

--- a/Sources/App/Knmi/KnmiDownloader.swift
+++ b/Sources/App/Knmi/KnmiDownloader.swift
@@ -43,7 +43,7 @@ struct KnmiDownload: AsyncCommand {
         
         if let uploadS3Bucket = signature.uploadS3Bucket {
             let timesteps = Array(handles.map { $0.time }.uniqued().sorted())
-            try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps)
+            try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps, run: run)
         }
         logger.info("Finished in \(start.timeElapsedPretty())")
     }

--- a/Sources/App/MetNo/MetNoDownloader.swift
+++ b/Sources/App/MetNo/MetNoDownloader.swift
@@ -169,15 +169,15 @@ extension DomainRegistry {
         if let variables {
             let vDirectories = variables.map { $0.omFileName.file } + ["static"]
             for variable in vDirectories {
-                if variable.contains("_previous_day") {
-                    // do not upload data from past days yet
-                    continue
-                }
                 let src = "\(OpenMeteo.dataDirectory)\(dir)/\(variable)"
                 if !FileManager.default.fileExists(atPath: src) {
                     continue
                 }
                 for bucket in bucket.split(separator: ",") {
+                    if variable.contains("_previous_day") && bucket == "openmeteo" {
+                        // do not upload data from past days yet
+                        continue
+                    }
                     let dest = "s3://\(bucket)/data/\(dir)/\(variable)"
                     try Process.spawnRetried(
                         cmd: "aws",

--- a/Sources/App/MetNo/MetNoDownloader.swift
+++ b/Sources/App/MetNo/MetNoDownloader.swift
@@ -48,7 +48,7 @@ struct MetNoDownloader: AsyncCommand {
         
         if let uploadS3Bucket = signature.uploadS3Bucket {
             let timesteps = Array(handles.map { $0.time }.uniqued().sorted())
-            try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps)
+            try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps, run: run)
         }
 
         logger.info("Finished in \(start.timeElapsedPretty())")

--- a/Sources/App/MetNo/MetNoDownloader.swift
+++ b/Sources/App/MetNo/MetNoDownloader.swift
@@ -162,63 +162,6 @@ struct MetNoDownloader: AsyncCommand {
     }
 }
 
-extension DomainRegistry {
-    /// Upload all data to a specified S3 bucket
-    func syncToS3(bucket: String, variables: [GenericVariable]?) throws {
-        let dir = rawValue
-        if let variables {
-            let vDirectories = variables.map { $0.omFileName.file } + ["static"]
-            for variable in vDirectories {
-                let src = "\(OpenMeteo.dataDirectory)\(dir)/\(variable)"
-                if !FileManager.default.fileExists(atPath: src) {
-                    continue
-                }
-                for bucket in bucket.split(separator: ",") {
-                    if variable.contains("_previous_day") && bucket == "openmeteo" {
-                        // do not upload data from past days yet
-                        continue
-                    }
-                    let dest = "s3://\(bucket)/data/\(dir)/\(variable)"
-                    try Process.spawnRetried(
-                        cmd: "aws",
-                        args: ["s3", "sync", "--exclude", "*~", "--no-progress", src, dest]
-                    )
-                }
-            }
-        } else {
-            let src = "\(OpenMeteo.dataDirectory)\(dir)"
-            for bucket in bucket.split(separator: ",") {
-                let dest = "s3://\(bucket)/data/\(dir)"
-                try Process.spawnRetried(
-                    cmd: "aws",
-                    args: ["s3", "sync", "--exclude", "*~", "--no-progress", src, dest]
-                )
-            }
-        }
-    }
-    
-    /// Upload spatial files to S3 `/data_spatial/<domain>/YYYY/MM/DD/HHMMZ/<variable>.om`
-    func syncToS3Spatial(bucket: String, timesteps: [Timestamp]) throws {
-        let dir = rawValue
-        guard let directorySpatial = OpenMeteo.dataSpatialDirectory else {
-            return
-        }
-        for timestep in timesteps {
-            for bucket in bucket.split(separator: ",") {
-                let src = "\(directorySpatial)\(dir)/\(timestep.format_directoriesYYYYMMddhhmm)/"
-                let dest = "s3://\(bucket)/data_spatial/\(dir)/\(timestep.format_directoriesYYYYMMddhhmm)"
-                if !FileManager.default.fileExists(atPath: src) {
-                    continue
-                }
-                try Process.spawnRetried(
-                    cmd: "aws",
-                    args: ["s3", "sync", "--exclude", "*~", "--no-progress", src, dest]
-                )
-            }
-        }
-    }
-}
-
 extension NetCDF {
     /// Try to open a file. If it does not excist, wait 10 seconds and try again until deadline is reached
     /// Works with OpenDap urls

--- a/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
+++ b/Sources/App/MeteoFrance/MeteoFranceDownloader.swift
@@ -94,7 +94,7 @@ struct MeteoFranceDownload: AsyncCommand {
         
         if let uploadS3Bucket = signature.uploadS3Bucket {
             let timesteps = Array(handles.map { $0.time }.uniqued().sorted())
-            try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps)
+            try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps, run: run)
         }
         logger.info("Finished in \(start.timeElapsedPretty())")
     }

--- a/Sources/App/MeteoSwiss/MeteoSwissDownload.swift
+++ b/Sources/App/MeteoSwiss/MeteoSwissDownload.swift
@@ -155,7 +155,7 @@ struct MeteoSwissDownload: AsyncCommand {
                 return handles
             }.asyncFlatMap({$0})
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp], run: run)
             }
             return handles
         }

--- a/Sources/App/MfWave/MfWaveDownload.swift
+++ b/Sources/App/MfWave/MfWaveDownload.swift
@@ -70,7 +70,7 @@ struct MfWaveDownload: AsyncCommand {
         
         if let uploadS3Bucket = signature.uploadS3Bucket {
             let timesteps = Array(handles.map { $0.time }.uniqued().sorted())
-            try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps)
+            try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: timesteps, run: run)
         }
     }
 

--- a/Sources/App/Nbm/NbmDownload.swift
+++ b/Sources/App/Nbm/NbmDownload.swift
@@ -180,7 +180,7 @@ struct NbmDownload: AsyncCommand {
                 handles.append(try writer.write(time: timestamp, member: 0, variable: variable.variable, data: grib2d.array.data))
             }
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp], run: run)
             }
             previousForecastHour = forecastHour
         }

--- a/Sources/App/UKMO/UkmoDownloader.swift
+++ b/Sources/App/UKMO/UkmoDownloader.swift
@@ -304,7 +304,7 @@ struct UkmoDownload: AsyncCommand {
                 break
             }
             if let uploadS3Bucket {
-                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp])
+                try domain.domainRegistry.syncToS3Spatial(bucket: uploadS3Bucket, timesteps: [timestamp], run: run)
             }
         }
         await curl.printStatistics()


### PR DESCRIPTION
Store runs separately in `data_spatial`. Current idea is to store all runs and selectively delete data to keep it below ~300TB. Follow up of #1315.

This PR is work in progress!

Data will be stored on public AWS and private S3 instance. Retention criteria:
- AWS: 
  - Only retain 1 month of data
- Private S3:
  - Delete pressure level data older than 3 months. Keep certain levels like 850 hpA
  - Delete `runs % 3 != 0` like 1z and 2z from hourly models HRRR, DMI, etc

File paths:
- `data_spatial/<model>/<run>/<valid_time>/<variable>.om`
- E.g. `data_spatial/ecmwf_ifs025/2025/04/24/0000Z/20250424T0300/temperature_2m.om`

Metadata:
- `data_spatial/<model>/latest.json`: Point to the latest completed model run
- `data_spatial/<model>/in_progress.json`: Points to the run which is currently downloaded
- `data_spatial/<model>/<run>/meta.json`: Meta data for each run

All JSON files have the same content:
- Init time
- Domain meta like nx, ny, grid?
- Start/End download times
- Last modified timestamp
- Is completed flag (false for in-progress or canceled runs)
- List of variables with list of time steps (each variable has different timestamps. E.g. precipitation is missing for hour0)


## Note 2025-07-09
The total number of files is going to be a huge issue. 1 year GFS025 data => 96 million files!
One option would be to store a single `om` file per timestep which contains multiple variables

Pro:
- Clean data distribution in sync with model updates

Con:
- Huge amount of data / files
- Hard to clean-up to retain a long-term archive
- Any kind of time-series access is very inefficient -> No API possible on top