### PR TITLE
fix: Correct ERA5-Land landmask

### DIFF
--- a/Sources/App/Era5/DownloadEra5Command.swift
+++ b/Sources/App/Era5/DownloadEra5Command.swift
@@ -307,7 +307,7 @@ struct DownloadEra5Command: AsyncCommand {
                     landmask = data.map { $0.isNaN ? 1 : 0 }
                 case "2t":
                     // Used in ERA5-Land to mask out exactly which grid-cells provide data
-                    landmask = data.map { $0.isNaN ? 1 : 0 }
+                    landmask = data.map { $0.isNaN ? 0 : 1 }
                 default:
                     fatalError("Found \(shortName) in grib")
                 }


### PR DESCRIPTION
Remove certain points that do not have data although land fraction >50%. Just a temperature file as reference to exactly mask out which datapoints have data

Cannot test right now, because CDS is down