### PR TITLE
docs: clarify repository structure and link to API source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ The API is available for non-commercial use at no cost. Despite being free of ch
 - Larger changes are announced in the [Open-Meteo Blog](https://openmeteo.substack.com)
 - The [Open-Meteo weather database](https://github.com/open-meteo/open-data) is redistributed as part of an AWS Open-Data Sponsorship
 
+## Repository Structure
+
+Open-Meteo consists of multiple repositories serving different purposes:
+
+- **This repository** ([open-meteo/open-meteo](https://github.com/open-meteo/open-meteo)) - Documentation, setup guides, and usage instructions
+- **API Server** ([open-meteo/open-meteo-api](https://github.com/open-meteo/open-meteo-api)) - Swift source code for the weather API server and download commands referenced in the [cronjobs documentation](/docs/cronjobs.md)
+- **Website** ([open-meteo/open-meteo-website](https://github.com/open-meteo/open-meteo-website)) - Source code for https://open-meteo.com
+- **Geocoding API** ([open-meteo/geocoding-api](https://github.com/open-meteo/geocoding-api)) - Geocoding service implementation
+- **Open Data** ([open-meteo/open-data](https://github.com/open-meteo/open-data)) - Weather database files and AWS distribution
+
+To run your own weather API server, refer to the [getting started guide](/docs/getting-started.md) in this repository and the [API server source code](https://github.com/open-meteo/open-meteo-api) for implementation details.
+
 ## Who is using Open-Meteo?
 
 Apps:


### PR DESCRIPTION
## Summary
This PR adds a new "Repository Structure" section to the README to help new users understand the relationship between the different Open-Meteo repositories.

## Motivation
As a newcomer to the project, I found it confusing that:
- The cronjobs documentation references commands like `openmeteo-api download-gfs` without clear links to where this source code lives
- The README states "The API source code is in this current repository" (under Resources section), but this repository only contains documentation
- It's not immediately obvious that the API implementation is in a separate repository (`open-meteo-api`)
- The connection between multiple repositories isn't explained upfront

## Changes
- Added "Repository Structure" section after "Resources"
- Lists all major repositories with brief descriptions
- Clarifies that THIS repo is for documentation and guides
- Points developers to the API source code repository where the download commands are implemented
- Links to the cronjobs documentation which references these commands

## Benefits
- Reduces confusion for new contributors
- Makes it easier to find the right repository for different types of contributions
- Provides a clear roadmap of the project structure

## Related Issues
N/A - Documentation improvement based on user experience