### PR TITLE
fix: add missing parameters to historical OpenAPI specification

### DIFF
--- a/openapi_historical_weather_api.yml
+++ b/openapi_historical_weather_api.yml
@@ -85,6 +85,7 @@ paths:
             enum:
             - temperature_2m_max
             - temperature_2m_min
+            - temperature_2m_mean
             - apparent_temperature_max
             - apparent_temperature_min
             - precipitation_sum


### PR DESCRIPTION
I believe the following parameters are missing from the historical OpenAPI specification (they are in the documentation):

- daily
            - daylight_duration
            - sunshine_duration
            - rain_sum
            - snowfall_sum
            - temperature_2m_mean
- hourly
            - snow_depth

You can verify that the API returns data for these parameters by running:

```
curl https://archive-api.open-meteo.com/v1/archive\?latitude\=52.52\&longitude\=13.41\&start_date\=2025-12-28\&end_date\=2026-01-11\&hourly\=snow_depth\&daily\=daylight_duration,sunshine_duration,rain_sum,snowfall_sum,temperature_2m_mean
```

PS: I don't know if the specification file should be changed directly or if modifying it requires some other update somewhere else. If that's the case I'd be happy to include it in this PR!