### PR TITLE
fix: correct UKMO UKV UV index scaling factor (0.25 -> 0.025)

### DIFF
--- a/Sources/App/UKMO/UkmoVariable.swift
+++ b/Sources/App/UKMO/UkmoVariable.swift
@@ -370,7 +370,7 @@ enum UkmoSurfaceVariable: String, CaseIterable, UkmoVariableDownloadable, Generi
         case .uv_index:
             // 0.025 m2/W to get the uv index
             // compared to https://www.aemet.es/es/eltiempo/prediccion/radiacionuv
-            return (0, 1 / 0.25)
+            return (0, 1 / 0.025)
         case .pressure_msl:
             return (0, 1 / 100)
         default:


### PR DESCRIPTION
## Summary
- The UKMO UKV UV index values are wrong due to a typo in the conversion factor
- The field `radiation_flux_in_uv_downward_at_surface` is in W/m². The standard conversion to UV index is `value / 0.025` (i.e. `value * 40`), but the code uses `1 / 0.25` (i.e. `value * 4`) — off by 10x
- The comment on the line correctly references `0.025`, confirming this is a typo

## Note: possible secondary issue
UKMO shortwave and direct radiation are treated as instantaneous values and converted to backwards-averaged data via `backwardsAveragedToInstantFactor` in `UkmoDownloader.swift:288`. UV index does not receive this same treatment. If the UV field is also instantaneous (likely, as it's a radiation flux), this could be an additional source of error and might explain the "not always factor 4" observation from @patrick-zippenfenig's [comment](https://github.com/open-meteo/open-meteo/issues/1258#issuecomment-2691698966). Happy to investigate further if helpful.

## Test plan
- [x] Project builds successfully
- [x] All 97 existing tests pass
- [ ] Verify UKMO UKV UV index values now align with other models (e.g. best_match) at `latitude=51.5085&longitude=-0.1257`

Fixes #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)