### PR TITLE
Add weather-cli-dualprovider to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Repositories:
 - [Weather-Cli](https://github.com/Rayrsn/Weather-Cli) A CLI program written in golang that allows you to get weather information from the terminal
 - [WeatherReport.jl](https://github.com/vnegi10/WeatherReport.jl) A simple weather app for the Julia REPL
 - [wthrr-the-weathercrab](https://github.com/tobealive/wthrr-the-weathercrab) Weather companion for the terminal
+- [weather-cli-dualprovider](https://github.com/jimishol/weather-cli-dualprovider) Minimal Bash CLI (single-file core; requires weather.en) fetching Open‑Meteo forecasts with a fallback provider; localized WMO descriptions. License: GPL‑3.0.
 
 Other:
 


### PR DESCRIPTION
**Summary**  
Add **weather-cli-dualprovider** to the “Who is using Open‑Meteo?” list.

**What the project is**  
**weather-cli-dualprovider** is a minimal Bash CLI with a single‑file core and required `weather.*` provider files (at least `weather.en`). It fetches forecasts from Open‑Meteo and automatically falls back to an alternate provider when needed. The project includes localized WMO code descriptions.

**Why add it**  
- Demonstrates a **portable, end‑user CLI** use of Open‑Meteo (POSIX shell, no heavy runtime).  
- Shows a **dual‑provider fallback** pattern useful for reliability examples.  
- Adds diversity to the list by representing tiny, scriptable terminal tools alongside SDKs and web apps.

**Files changed**  
- `README.md` — single line added under the “Who is using Open‑Meteo?” section.

**License**  
**GPL‑3.0** (see LICENSE in repository).

**Notes for maintainers**  
Entry is factual and non‑promotional; happy to adjust wording to match list style if desired.