### PR TITLE
Add Calima Canarias to apps showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Apps:
 - [Alpine Conditions](https://www.alpineconditions.com) Allows a user to compare multiple models at once & create ensemble forecasts for any location
 - [BusyRunner](https://busyrunner.com/) Allows users to plan their weekly runs based on the weather.
 - [Breezy Weather](https://github.com/breezy-weather/breezy-weather) A feature-rich, free and open source Material 3 Expressive Android weather app.
+- [Calima Canarias](https://calimacanarias.com) Real-time Saharan dust (calima) forecast and air quality monitoring for the Canary Islands and the rest of Spain.
 - [Cirrus](https://github.com/woheller69/omweather) Android Weather App
 - [Clima](https://f-droid.org/packages/co.prestosole.clima/) Beautiful, minimal, and fast weather app
 - [DroneWeather](https://play.google.com/store/apps/details?id=xyz.droneweather.app) Weather forecasts, satellite count, and KP index for drone pilots.


### PR DESCRIPTION
Hi! I've built Calima Canarias, a free real-time Saharan dust (calima) forecast and air quality monitoring tool for the Canary Islands and the rest of Spain. It uses Open-Meteo's forecast API to track PM10 concentrations across all 8 Canary Islands and mainland Spanish cities, with 5-day forecasts and hourly updates.

Would love to be included in your apps list. Thanks for the amazing API!

https://calimacanarias.com