### PR TITLE
Add UVI Today and Pollen Today to apps showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Apps:
 - [OSS Weather](https://github.com/Akylas/oss-weather) - Multi-model/multi-provider Open Source Android/iOS Weather app
 - [Overmorrow](https://github.com/bmaroti9/Overmorrow) A modern material design Android weather app.
 - [PointWx](https://hh.guidocioni.it/pointwx/) Dash application with interactive plots (from beginner-friendly to weather-enthusiast level) easily deployable
+- [Pollen Today](https://pollen.today) Real-time pollen and allergen forecasts across Europe.
 - [Precip](https://precip.ai) Hyperlocal weather history and forecast app for Android, iOS, and Web.
 - [QuickWeather](https://github.com/TylerWilliamson/QuickWeather) Fast, free, and open source Android app
 - [Rain](https://github.com/DarkMooNight/Rain) Free, open source, beautiful, minimal and fast weather app
@@ -74,6 +75,7 @@ Apps:
 - [The Weather](https://weather.jamesdinovo.com) A detailed, installable, progressive web application
 - [truthclimate](https://www.truthclimate.com) Discover how weather and climate changed all around the world.
 - [Typhoon](https://archisman-panigrahi.github.io/typhoon) A stylish weather app for GNU/Linux that acts as a desktop widget
+- [UVI Today](https://uvi.today) UV index forecasts with WHO sun protection guidelines, using CAMS air quality data via Open-Meteo.
 - [Weather Please](https://github.com/ggaidelevicius/weather-please/) Clean and minimal new tab replacement for browsers
 - [Weather](https://github.com/GustavLindberg99/AndroidWeather) Free, open source, simple and complete weather app for Android
 - [Weather.io](https://weather.roessner.tech) A simple Progressive Web App (PWA) for checking the weather.


### PR DESCRIPTION
Hi! Adding two weather apps that use Open-Meteo APIs:

- **[UVI Today](https://uvi.today)** — UV index forecast site using the CAMS Air Quality API for UV data and the Geocoding API. Shows hourly UV forecasts, 5-day trends, and WHO-based sun protection recommendations. Available in 10 languages.

- **[Pollen Today](https://pollen.today)** — Pollen forecast app for allergy sufferers using the Air Quality API for pollen data across Europe.

Both are free, privacy-first web apps with no tracking or cookies. Built with Next.js.

Thanks for the amazing API! 