### PR TITLE
fix: icon global nearest neighbour mapping

### DIFF
--- a/Sources/App/Icon/Cdo.swift
+++ b/Sources/App/Icon/Cdo.swift
@@ -89,9 +89,10 @@ struct CdoIconGlobal {
         guard let dst_address = try NetCDF.open(path: weightsFile, allowUpdate: false)?.getVariable(name: "dst_address")?.asType(Int32.self)?.read() else {
             fatalError("could not open weights file")
         }
+
         var mapping = [Int32](repeating: -1, count: domain.grid.count)
         for (i, src) in src_address.enumerated() {
-            mapping[Int(dst_address[i])] = src - 1
+            mapping[Int(dst_address[i]) - 1] = src - 1
         }
         self.mapping = mapping
     }


### PR DESCRIPTION
The index into the `mapping` array was not correct, which also lead to invalid indexing. 
This fix shifts the nearest neighbour mapping to be correctly zero-indexed. This is also appears to be visually more correct:
### Left before vs. right after 
<img width="2307" height="1314" alt="2026-05-18T12:07:25,659033953+02:00" src="https://github.com/user-attachments/assets/05f0bc20-333e-4c65-a4fd-d5dc58bc41de" />
<img width="2302" height="1315" alt="2026-05-18T12:07:03,582882465+02:00" src="https://github.com/user-attachments/assets/91bdfc1e-e5e9-4560-adb1-956e4370ffda" />
