### PR TITLE
Cleanup: Fix two bugs, fix spelling, remove AI artifacts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Apps:
 - [FlyDecision](https://flydecision.com/) Automated weather forecast analysis and flight condition scoring for paragliding pilots, with interactive takeoff mapping.
 - [Home Assistant](https://www.home-assistant.io/integrations/open_meteo/) A popular open source smart home platform.
 - [Lively Weather](https://www.rocksdanister.com/weather) Windows native weather app powered by DirectX12 animations.
-- [LunaLink](https://www.lunalink.de) A site for hunters, fishermen and nature observers: It provides sun and moon values ​​(including moon brightness) as well as the weather for individual locations in Central Europe.
+- [LunaLink](https://www.lunalink.de) A site for hunters, fishermen and nature observers: It provides sun and moon values (including moon brightness) as well as the weather for individual locations in Central Europe.
 - [Meteo-Fly](https://meteo-fly.com) Free flight-weather charts for paraglider & hang-glider pilots.
 - [MeteoHist](https://yotka.org/meteo-hist) A web app to create interactive temperature and precipitation graphs for places around the world
 - [monkeysnow](https://github.com/kcluit/monkeysnow) The most customizable resort/snow forecast website for ski and board!
@@ -97,7 +97,7 @@ Repositories:
 - [Weather-Cli](https://github.com/Rayrsn/Weather-Cli) A CLI program written in golang that allows you to get weather information from the terminal
 - [WeatherReport.jl](https://github.com/vnegi10/WeatherReport.jl) A simple weather app for the Julia REPL
 - [wthrr-the-weathercrab](https://github.com/tobealive/wthrr-the-weathercrab) Weather companion for the terminal
-- [weather-cli-dualprovider](https://github.com/jimishol/weather-cli-dualprovider) Minimal Bash CLI (single-file core; requires weather.en) fetching Open‑Meteo forecasts with a fallback provider; localized WMO descriptions. License: GPL‑3.0.
+- [weather-cli-dualprovider](https://github.com/jimishol/weather-cli-dualprovider) Minimal Bash CLI (single-file core; requires weather.en) fetching Open-Meteo forecasts with a fallback provider; localized WMO descriptions. License: GPL-3.0.
 
 Other:
 

--- a/Sources/App/CMA/CmaDownloader.swift
+++ b/Sources/App/CMA/CmaDownloader.swift
@@ -52,7 +52,7 @@ struct DownloadCmaCommand: AsyncCommand {
 
         /*if let timeinterval = signature.timeinterval {
             if signature.fixSolar {
-                // timeinterval devided by chunk time range
+                // timeinterval divided by chunk time range
                 let time = try Timestamp.parseRange(yyyymmdd: timeinterval)
                 try self.fixSolarFiles(application: context.application, domain: domain, timerange: time)
                 return

--- a/Sources/App/Cmip6/CmipDownloader.swift
+++ b/Sources/App/Cmip6/CmipDownloader.swift
@@ -48,7 +48,7 @@ import SwiftNetCDF
  MEDIUM:
  
  NICAM16-9S https://gmd.copernicus.org/articles/14/795/2021/
- 0.14°, but only 2040-2050 and 1950–1960, 2000–2010 (high computational cost hindered us from running NICAM16-9S for 100 years)
+ 0.14°, but only 2040-2050 and 1950-1960, 2000-2010 (high computational cost hindered us from running NICAM16-9S for 100 years)
  1h: precip
  3h: precip, clc, snow, swrad (+cs), temp, wind, pres, hum
  day: temp, clc, wind, precip, snow, hum, swrad,

--- a/Sources/App/Commands/MergeYearlyCommand.swift
+++ b/Sources/App/Commands/MergeYearlyCommand.swift
@@ -24,7 +24,7 @@ struct MergeYearlyCommand: AsyncCommand {
         @Flag(name: "force", help: "Generate yearly file, even if it already exists")
         var force: Bool
 
-        @Flag(name: "delete", help: "Delete the underlaying chunks")
+        @Flag(name: "delete", help: "Delete the underlying chunks")
         var delete: Bool
         
         @Flag(name: "allow-missing", help: "Allow partial years (missing chunks)")

--- a/Sources/App/DwdSis/DwdSisDownloader.swift
+++ b/Sources/App/DwdSis/DwdSisDownloader.swift
@@ -74,7 +74,7 @@ struct DwdSisDownloader: AsyncCommand {
         /// The southernmost line is acquired 15 seconds plus (90-38)*1/0.025 = 2080 lines by 9.5 minutes => total 3 minutes after sweep start
         /// The scan-time for the limited latitude range is ~5:26 minutes
         /// This is not 100% correct, but a reasonable approximation
-        let sweepTimeOfLimitedLatitudeRangeSeconds = (4121/7201*9.5*60)
+        let sweepTimeOfLimitedLatitudeRangeSeconds = (Double(4121)/7201*9.5*60)
         let timeDifference: [Double] = (0..<3201 * 4121).map {
             let line = $0 / 3201
             let lineFraction = Double(line) / (4121-1)

--- a/Sources/App/EcmwfEcpds/EcmwfEcpdsVariable.swift
+++ b/Sources/App/EcmwfEcpds/EcmwfEcpdsVariable.swift
@@ -65,7 +65,7 @@ enum EcmwfEcdpsIfsVariable: String, CaseIterable, GenericVariable {
     /// Scale-factor to compress data
     var scalefactor: Float {
         switch self {
-        case .wind_u_component_100m, .wind_v_component_100m, .wind_u_component_10m, .wind_v_component_10m, .wind_u_component_200m, .wind_v_component_200m: return 20 // 0.05 m/s resolution. Typically 10, but want to have sligthly higher resolution
+        case .wind_u_component_100m, .wind_v_component_100m, .wind_u_component_10m, .wind_v_component_10m, .wind_u_component_200m, .wind_v_component_200m: return 20 // 0.05 m/s resolution. Typically 10, but want to have slightly higher resolution
         case .cloud_cover: return 1
         case .cloud_cover_low: return 1
         case .cloud_cover_mid: return 1

--- a/Sources/App/Era5/DownloadEra5Command.swift
+++ b/Sources/App/Era5/DownloadEra5Command.swift
@@ -139,7 +139,7 @@ struct DownloadEra5Command: AsyncCommand {
                 let locationRange = dim0..<min(dim0+nLocationChunks, writer.dim0)
                 var bias = Array2DFastTime(nLocations: locationRange.count, nTime: binsPerYear)
                 
-                // Read location one-by-one... Multi location support does not work with derived varibales
+                // Read location one-by-one... Multi location support does not work with derived variables
                 for (l, gridpoint) in locationRange.enumerated() {
                     let gridpointNext = min(gridpoint+1, writer.dim0-1)
                     let readerNext = GenericReaderMulti<ForecastVariable, MultiDomains>(domain: MultiDomains.era5, reader: [Era5Reader(reader: GenericReaderCached<CdsDomain, Era5Variable>(reader: try GenericReader<CdsDomain, Era5Variable>(domain: domain, position: gridpointNext)), options: options)])

--- a/Sources/App/Era5/Era5Variables.swift
+++ b/Sources/App/Era5/Era5Variables.swift
@@ -136,7 +136,7 @@ enum Era5Variable: String, CaseIterable, GenericVariable, GribMessageAssociated 
     var scalefactor: Float {
         switch self {
         case .wind_u_component_100m, .wind_v_component_100m,
-                .wind_u_component_10m, .wind_v_component_10m: return 20 // 0.05 m/s resolution. Typically 10, but want to have sligthly higher resolution
+                .wind_u_component_10m, .wind_v_component_10m: return 20 // 0.05 m/s resolution. Typically 10, but want to have slightly higher resolution
         case .wind_u_component_100m_spread, .wind_v_component_100m_spread,
                 .wind_u_component_10m_spread, .wind_v_component_10m_spread: return 50 // 0.02 m/s resolution
         case .cloud_cover, .cloud_cover_spread: return 1

--- a/Sources/App/Gfs/PrecipitationProbability.swift
+++ b/Sources/App/Gfs/PrecipitationProbability.swift
@@ -121,7 +121,7 @@ extension VariablePerMemberStorage {
     /// `domain` must be set to generate a temporary file handle afterwards
     /// `dtHoursOfCurrentStep` should be set to the correct delta time in hours for this timestep if the step width changes. E.g. 3 to 6 hours after 120h. If no dt switching takes place, just use `domain.dtHours`.
     func calculatePrecipitationProbability(precipitationVariable: V, dtHoursOfCurrentStep: Int, writer: OmSpatialTimestepWriter) async throws {
-        // Usefull probs, precip >0.1, >1, clouds <20%, clouds 20-50, 50-80, >80, snowfall eq >0.1, >1.0, wind >20kt, temp <0, temp >25
+        // Useful probs, precip >0.1, >1, clouds <20%, clouds 20-50, 50-80, >80, snowfall eq >0.1, >1.0, wind >20kt, temp <0, temp >25
         // However, more and more probabilities takes up more resources than analysing raw member data
         let handles = self.data.filter({ $0.key.variable == precipitationVariable })
         let nMember = handles.count

--- a/Sources/App/Helper/Download/Curl.swift
+++ b/Sources/App/Helper/Download/Curl.swift
@@ -55,10 +55,10 @@ final class Curl: Sendable {
     /// Chunk size for concurrent downloads
     let chunkSize: Int
     
-    /// Default throw if unauthorized error occures
+    /// Default throw if unauthorized error occurs
     let retryUnauthorized: Bool
 
-    /// If the environment varibale `HTTP_CACHE` is set, use it as a directory to cache all HTTP requests
+    /// If the environment variable `HTTP_CACHE` is set, use it as a directory to cache all HTTP requests
     static var cacheDirectory: String? {
         Environment.get("HTTP_CACHE")
     }

--- a/Sources/App/Helper/FaoEvapotranspiration.swift
+++ b/Sources/App/Helper/FaoEvapotranspiration.swift
@@ -1,4 +1,4 @@
-import Foundation
+﻿import Foundation
 
 extension Meteorology {
     public static let boltzmanConstant = Float(0.20429166e-9)
@@ -17,7 +17,7 @@ extension Meteorology {
         }
 
         let Tmean = (temperature2mCelsiusDaily.max + temperature2mCelsiusDaily.min) / 2
-        /// Leaf wetness inlikely below 10°C. Scale a factor from 5°C - 15°C from 0 to 1
+        /// Leaf wetness inlikely below 10Â°C. Scale a factor from 5Â°C - 15Â°C from 0 to 1
         let temperatureProbability = max(min((Tmean - 5) * 10, 1), 0)
 
         /// Leaf wetness likely at low VPD
@@ -33,7 +33,7 @@ extension Meteorology {
         if precipitation > 1 {
             return min(80 + precipitation * 2, 100)
         }
-        /// Leaf wetness inlikely below 10°C. Scale a factor from 5°C - 15°C from 0 to 1
+        /// Leaf wetness inlikely below 10Â°C. Scale a factor from 5Â°C - 15Â°C from 0 to 1
         let temperatureProbability = max(min((temperature2mCelsius - 5) * 10, 1), 0)
 
         /// Leaf wetness likely at low VPD
@@ -48,19 +48,19 @@ extension Meteorology {
     /// Temperature max/min should be used instead of mean temperature, similar for FAO implementation
     /// As there is an inverse relation between all variables, min/max vlues are not perfectly accurate afterwards
     @inlinable public static func dewpointDaily(temperature2mCelsiusDaily: (max: Float, min: Float), relativeHumidity: Float) -> Float {
-        let β = Float(17.625)
-        let λ = Float(243.04)
-        let meanSat = ((β * temperature2mCelsiusDaily.min) / (λ + temperature2mCelsiusDaily.min) + (β * temperature2mCelsiusDaily.max) / (λ + temperature2mCelsiusDaily.max)) / 2
-        return λ * (log(relativeHumidity / 100) + (meanSat)) / (β - log(relativeHumidity / 100) - (meanSat))
+        let Î² = Float(17.625)
+        let Î» = Float(243.04)
+        let meanSat = ((Î² * temperature2mCelsiusDaily.min) / (Î» + temperature2mCelsiusDaily.min) + (Î² * temperature2mCelsiusDaily.max) / (Î» + temperature2mCelsiusDaily.max)) / 2
+        return Î» * (log(relativeHumidity / 100) + (meanSat)) / (Î² - log(relativeHumidity / 100) - (meanSat))
     }
 
     /// Calculate daily vapor pressure deficit using relative humidity min/max if available
     public static func vaporPressureDeficitDaily(temperature2mCelsiusDailyMax: Float, temperature2mCelsiusDailyMin: Float, relativeHumidity: MaxAndMinOrMean) -> Float {
-        /// Slope of saturation vapour pressure curve at air temperature T [kPa °C-1], (Page 37)
-        let β = Float(17.27) // Actually 17.625 is now recommended. FAO uses the old one.
-        let λ = Float(237.3) // 243.04 new recommendation
-        let e0min = 0.6108 * exp(β * temperature2mCelsiusDailyMin / (temperature2mCelsiusDailyMin + λ))
-        let e0max = 0.6108 * exp(β * temperature2mCelsiusDailyMax / (temperature2mCelsiusDailyMax + λ))
+        /// Slope of saturation vapour pressure curve at air temperature T [kPa Â°C-1], (Page 37)
+        let Î² = Float(17.27) // Actually 17.625 is now recommended. FAO uses the old one.
+        let Î» = Float(237.3) // 243.04 new recommendation
+        let e0min = 0.6108 * exp(Î² * temperature2mCelsiusDailyMin / (temperature2mCelsiusDailyMin + Î»))
+        let e0max = 0.6108 * exp(Î² * temperature2mCelsiusDailyMax / (temperature2mCelsiusDailyMax + Î»))
         /// saturation vapor pressure at air temperature Thr. (kPa)
         let esat = (e0min + e0max) / 2
 
@@ -80,27 +80,27 @@ extension Meteorology {
 
     /// FAO et0 calculation based on https://marais.ch/doc/fao56.pdf
     public static func et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: Float, temperature2mCelsiusDailyMin: Float, temperature2mCelsiusDailyMean: Float, windspeed10mMeterPerSecondMean: Float, shortwaveRadiationMJSum: Float, elevation: Float, extraTerrestrialRadiationSum: Float, relativeHumidity: MaxAndMinOrMean) -> Float {
-        /// short wave radiaton or use Hargreaves’ radiation formula (Page 60)
+        /// short wave radiation or use Hargreaves' radiation formula (Page 60)
         let Rs = shortwaveRadiationMJSum.isNaN ? 0.16 * sqrtf(temperature2mCelsiusDailyMax - temperature2mCelsiusDailyMin) * extraTerrestrialRadiationSum : shortwaveRadiationMJSum
 
         let windspeed2m = scaleWindFactor(from: 10, to: 2) * windspeed10mMeterPerSecondMean
 
-        /// Slope of saturation vapour pressure curve at air temperature T [kPa °C-1], (Page 37)
-        let β = Float(17.27) // Actually 17.625 is now recommended. FAO uses the old one.
-        let λ = Float(237.3) // 243.04 new recommendation
-        let e0min = 0.6108 * exp(β * temperature2mCelsiusDailyMin / (temperature2mCelsiusDailyMin + λ))
-        let e0max = 0.6108 * exp(β * temperature2mCelsiusDailyMax / (temperature2mCelsiusDailyMax + λ))
+        /// Slope of saturation vapour pressure curve at air temperature T [kPa Â°C-1], (Page 37)
+        let Î² = Float(17.27) // Actually 17.625 is now recommended. FAO uses the old one.
+        let Î» = Float(237.3) // 243.04 new recommendation
+        let e0min = 0.6108 * exp(Î² * temperature2mCelsiusDailyMin / (temperature2mCelsiusDailyMin + Î»))
+        let e0max = 0.6108 * exp(Î² * temperature2mCelsiusDailyMax / (temperature2mCelsiusDailyMax + Î»))
         /// saturation vapor pressure at air temperature Thr. (kPa)
         let esat = (e0min + e0max) / 2
 
         ///  the slope of the vapour pressure curve is calculated using mean air temperature
-        let vaporPressurCurveSlope = 4098 * (0.6108 * exp(β * temperature2mCelsiusDailyMean / (temperature2mCelsiusDailyMean + λ))) / powf((temperature2mCelsiusDailyMean + λ), 2)
+        let vaporPressurCurveSlope = 4098 * (0.6108 * exp(Î² * temperature2mCelsiusDailyMean / (temperature2mCelsiusDailyMean + Î»))) / powf((temperature2mCelsiusDailyMean + Î»), 2)
 
         /// Air pressure in kPa. Evaporation at high altitudes is promoted due to low atmospheric pressure as expressed in the psychrometric constant. The effect is, however, small and in the calculation procedures, the average value for a location is sufficient.
         let simplifiedAtmosphericPressure = 101.3 * powf((293 - 0.0065 * elevation) / 293.0, 5.26)
 
-        /// psychrometric constant [kPa °C-1], (Equation 8)
-        let γ = 0.000665 * simplifiedAtmosphericPressure
+        /// psychrometric constant [kPa Â°C-1], (Equation 8)
+        let Î³ = 0.000665 * simplifiedAtmosphericPressure
 
         /// actual vapour pressure [kPa], (Page 37)
         let ea: Float
@@ -128,7 +128,7 @@ extension Meteorology {
         /// clear-sky solar radiation [MJ m-2 day-1] approximated, (Page 51)
         let Rso = (0.75 + 0.00002 * elevation) * extraTerrestrialRadiationSum
 
-        /// relative shortwave radiation (limited to ≤ 1.0. Although daily, could still happen at poles
+        /// relative shortwave radiation (limited to â‰¤ 1.0. Although daily, could still happen at poles
         let Rrel = extraTerrestrialRadiationSum <= 0 ? RrelAproximation : min(Rs / Rso, 1)
 
         /// net outgoing longwave radiation [MJ m-2 day-1]
@@ -141,7 +141,7 @@ extension Meteorology {
         let Ghr = (Rs <= 0) ? 0.5 * Rn : 0.1 * Rn
 
         // evapotranspiration
-        let et0 = (0.408 * vaporPressurCurveSlope * (Rn - Ghr) + γ * (37.0 / (temperature2mCelsiusDailyMean + 273)) * windspeed2m * vaporPressureDeficit) / (vaporPressurCurveSlope + γ * (1 + 0.34 * windspeed2m))
+        let et0 = (0.408 * vaporPressurCurveSlope * (Rn - Ghr) + Î³ * (37.0 / (temperature2mCelsiusDailyMean + 273)) * windspeed2m * vaporPressureDeficit) / (vaporPressurCurveSlope + Î³ * (1 + 0.34 * windspeed2m))
 
         return max(et0, 0)
     }
@@ -152,22 +152,22 @@ extension Meteorology {
 
         let windspeed2m = scaleWindFactor(from: 10, to: 2) * windspeed10mMeterPerSecond
 
-        /// Slope of saturation vapour pressure curve at air temperature T [kPa °C-1], (Page 37)
-        let β = Float(17.27) // Actaually 17.625 is now recommended. FAO uses the old one.
-        let λ = Float(237.3) // 243.04 new recommendation
-        let vaporPressurCurveSlope = 4098 * (0.6108 * exp(β * temperature2mCelsius / (temperature2mCelsius + λ))) / powf((temperature2mCelsius + λ), 2)
+        /// Slope of saturation vapour pressure curve at air temperature T [kPa Â°C-1], (Page 37)
+        let Î² = Float(17.27) // Actaually 17.625 is now recommended. FAO uses the old one.
+        let Î» = Float(237.3) // 243.04 new recommendation
+        let vaporPressurCurveSlope = 4098 * (0.6108 * exp(Î² * temperature2mCelsius / (temperature2mCelsius + Î»))) / powf((temperature2mCelsius + Î»), 2)
 
         /// Air pressure in kPa. Evaporation at high altitudes is promoted due to low atmospheric pressure as expressed in the psychrometric constant. The effect is, however, small and in the calculation procedures, the average value for a location is sufficient.
         let simplifiedAtmosphericPressure = 101.3 * powf((293 - 0.0065 * elevation) / 293.0, 5.26)
 
-        /// psychrometric constant [kPa °C-1], (Equation 8)
-        let γ = 0.000665 * simplifiedAtmosphericPressure
+        /// psychrometric constant [kPa Â°C-1], (Equation 8)
+        let Î³ = 0.000665 * simplifiedAtmosphericPressure
 
         /// saturation vapor pressure at air temperature Thr. (kPa)
-        let esat = 0.6108 * exp((β * temperature2mCelsius) / (temperature2mCelsius + λ))
+        let esat = 0.6108 * exp((Î² * temperature2mCelsius) / (temperature2mCelsius + Î»))
 
         /// actual vapour pressure [kPa], (Page 37)
-        let ea = 0.6108 * exp((β * dewpointCelsius) / (dewpointCelsius + λ))
+        let ea = 0.6108 * exp((Î² * dewpointCelsius) / (dewpointCelsius + Î»))
 
         let vaporPressureDeficit = esat - ea
 
@@ -185,7 +185,7 @@ extension Meteorology {
         /// As a more approximate alternative, one can assume Rs/Rso = 0.4 to 0.6 during nighttime periods in humid and subhumid climates and Rs/Rso = 0.7 to 0.8 in arid and semiarid climates. (Page 75)
         let RrelAproximation = 0.4 + relativeHumidity / 100 * 0.4
 
-        /// relative shortwave radiation (limited to ≤ 1.0
+        /// relative shortwave radiation (limited to â‰¤ 1.0
         let Rrel = extraTerrestrialRadiation <= 0 ? RrelAproximation : min(Rs / Rso, 1)
 
         /// net outgoing longwave radiation [MJ m-2 day-1]
@@ -198,7 +198,7 @@ extension Meteorology {
         let Ghr = (Rs <= 0) ? 0.5 * Rn : 0.1 * Rn
 
         // evapotranspiration
-        let et0 = (0.408 * vaporPressurCurveSlope * (Rn - Ghr) + γ * (37.0 / (temperature2mCelsius + 273)) * windspeed2m * vaporPressureDeficit) / (vaporPressurCurveSlope + γ * (1 + 0.34 * windspeed2m))
+        let et0 = (0.408 * vaporPressurCurveSlope * (Rn - Ghr) + Î³ * (37.0 / (temperature2mCelsius + 273)) * windspeed2m * vaporPressureDeficit) / (vaporPressurCurveSlope + Î³ * (1 + 0.34 * windspeed2m))
 
         return max(et0 * Float(dtSeconds / 3600), 0)
     }

--- a/Sources/App/Helper/FaoEvapotranspiration.swift
+++ b/Sources/App/Helper/FaoEvapotranspiration.swift
@@ -1,4 +1,4 @@
-﻿import Foundation
+﻿?import Foundation
 
 extension Meteorology {
     public static let boltzmanConstant = Float(0.20429166e-9)
@@ -17,7 +17,7 @@ extension Meteorology {
         }
 
         let Tmean = (temperature2mCelsiusDaily.max + temperature2mCelsiusDaily.min) / 2
-        /// Leaf wetness inlikely below 10Â°C. Scale a factor from 5Â°C - 15Â°C from 0 to 1
+        /// Leaf wetness inlikely below 10°C. Scale a factor from 5°C - 15°C from 0 to 1
         let temperatureProbability = max(min((Tmean - 5) * 10, 1), 0)
 
         /// Leaf wetness likely at low VPD
@@ -33,7 +33,7 @@ extension Meteorology {
         if precipitation > 1 {
             return min(80 + precipitation * 2, 100)
         }
-        /// Leaf wetness inlikely below 10Â°C. Scale a factor from 5Â°C - 15Â°C from 0 to 1
+        /// Leaf wetness inlikely below 10°C. Scale a factor from 5°C - 15°C from 0 to 1
         let temperatureProbability = max(min((temperature2mCelsius - 5) * 10, 1), 0)
 
         /// Leaf wetness likely at low VPD
@@ -48,19 +48,19 @@ extension Meteorology {
     /// Temperature max/min should be used instead of mean temperature, similar for FAO implementation
     /// As there is an inverse relation between all variables, min/max vlues are not perfectly accurate afterwards
     @inlinable public static func dewpointDaily(temperature2mCelsiusDaily: (max: Float, min: Float), relativeHumidity: Float) -> Float {
-        let Î² = Float(17.625)
-        let Î» = Float(243.04)
-        let meanSat = ((Î² * temperature2mCelsiusDaily.min) / (Î» + temperature2mCelsiusDaily.min) + (Î² * temperature2mCelsiusDaily.max) / (Î» + temperature2mCelsiusDaily.max)) / 2
-        return Î» * (log(relativeHumidity / 100) + (meanSat)) / (Î² - log(relativeHumidity / 100) - (meanSat))
+        let β = Float(17.625)
+        let λ = Float(243.04)
+        let meanSat = ((β * temperature2mCelsiusDaily.min) / (λ + temperature2mCelsiusDaily.min) + (β * temperature2mCelsiusDaily.max) / (λ + temperature2mCelsiusDaily.max)) / 2
+        return λ * (log(relativeHumidity / 100) + (meanSat)) / (β - log(relativeHumidity / 100) - (meanSat))
     }
 
     /// Calculate daily vapor pressure deficit using relative humidity min/max if available
     public static func vaporPressureDeficitDaily(temperature2mCelsiusDailyMax: Float, temperature2mCelsiusDailyMin: Float, relativeHumidity: MaxAndMinOrMean) -> Float {
-        /// Slope of saturation vapour pressure curve at air temperature T [kPa Â°C-1], (Page 37)
-        let Î² = Float(17.27) // Actually 17.625 is now recommended. FAO uses the old one.
-        let Î» = Float(237.3) // 243.04 new recommendation
-        let e0min = 0.6108 * exp(Î² * temperature2mCelsiusDailyMin / (temperature2mCelsiusDailyMin + Î»))
-        let e0max = 0.6108 * exp(Î² * temperature2mCelsiusDailyMax / (temperature2mCelsiusDailyMax + Î»))
+        /// Slope of saturation vapour pressure curve at air temperature T [kPa °C-1], (Page 37)
+        let β = Float(17.27) // Actually 17.625 is now recommended. FAO uses the old one.
+        let λ = Float(237.3) // 243.04 new recommendation
+        let e0min = 0.6108 * exp(β * temperature2mCelsiusDailyMin / (temperature2mCelsiusDailyMin + λ))
+        let e0max = 0.6108 * exp(β * temperature2mCelsiusDailyMax / (temperature2mCelsiusDailyMax + λ))
         /// saturation vapor pressure at air temperature Thr. (kPa)
         let esat = (e0min + e0max) / 2
 
@@ -85,22 +85,22 @@ extension Meteorology {
 
         let windspeed2m = scaleWindFactor(from: 10, to: 2) * windspeed10mMeterPerSecondMean
 
-        /// Slope of saturation vapour pressure curve at air temperature T [kPa Â°C-1], (Page 37)
-        let Î² = Float(17.27) // Actually 17.625 is now recommended. FAO uses the old one.
-        let Î» = Float(237.3) // 243.04 new recommendation
-        let e0min = 0.6108 * exp(Î² * temperature2mCelsiusDailyMin / (temperature2mCelsiusDailyMin + Î»))
-        let e0max = 0.6108 * exp(Î² * temperature2mCelsiusDailyMax / (temperature2mCelsiusDailyMax + Î»))
+        /// Slope of saturation vapour pressure curve at air temperature T [kPa °C-1], (Page 37)
+        let β = Float(17.27) // Actually 17.625 is now recommended. FAO uses the old one.
+        let λ = Float(237.3) // 243.04 new recommendation
+        let e0min = 0.6108 * exp(β * temperature2mCelsiusDailyMin / (temperature2mCelsiusDailyMin + λ))
+        let e0max = 0.6108 * exp(β * temperature2mCelsiusDailyMax / (temperature2mCelsiusDailyMax + λ))
         /// saturation vapor pressure at air temperature Thr. (kPa)
         let esat = (e0min + e0max) / 2
 
         ///  the slope of the vapour pressure curve is calculated using mean air temperature
-        let vaporPressurCurveSlope = 4098 * (0.6108 * exp(Î² * temperature2mCelsiusDailyMean / (temperature2mCelsiusDailyMean + Î»))) / powf((temperature2mCelsiusDailyMean + Î»), 2)
+        let vaporPressurCurveSlope = 4098 * (0.6108 * exp(β * temperature2mCelsiusDailyMean / (temperature2mCelsiusDailyMean + λ))) / powf((temperature2mCelsiusDailyMean + λ), 2)
 
         /// Air pressure in kPa. Evaporation at high altitudes is promoted due to low atmospheric pressure as expressed in the psychrometric constant. The effect is, however, small and in the calculation procedures, the average value for a location is sufficient.
         let simplifiedAtmosphericPressure = 101.3 * powf((293 - 0.0065 * elevation) / 293.0, 5.26)
 
-        /// psychrometric constant [kPa Â°C-1], (Equation 8)
-        let Î³ = 0.000665 * simplifiedAtmosphericPressure
+        /// psychrometric constant [kPa °C-1], (Equation 8)
+        let γ = 0.000665 * simplifiedAtmosphericPressure
 
         /// actual vapour pressure [kPa], (Page 37)
         let ea: Float
@@ -128,7 +128,7 @@ extension Meteorology {
         /// clear-sky solar radiation [MJ m-2 day-1] approximated, (Page 51)
         let Rso = (0.75 + 0.00002 * elevation) * extraTerrestrialRadiationSum
 
-        /// relative shortwave radiation (limited to â‰¤ 1.0. Although daily, could still happen at poles
+        /// relative shortwave radiation (limited to ≤ 1.0. Although daily, could still happen at poles
         let Rrel = extraTerrestrialRadiationSum <= 0 ? RrelAproximation : min(Rs / Rso, 1)
 
         /// net outgoing longwave radiation [MJ m-2 day-1]
@@ -141,7 +141,7 @@ extension Meteorology {
         let Ghr = (Rs <= 0) ? 0.5 * Rn : 0.1 * Rn
 
         // evapotranspiration
-        let et0 = (0.408 * vaporPressurCurveSlope * (Rn - Ghr) + Î³ * (37.0 / (temperature2mCelsiusDailyMean + 273)) * windspeed2m * vaporPressureDeficit) / (vaporPressurCurveSlope + Î³ * (1 + 0.34 * windspeed2m))
+        let et0 = (0.408 * vaporPressurCurveSlope * (Rn - Ghr) + γ * (37.0 / (temperature2mCelsiusDailyMean + 273)) * windspeed2m * vaporPressureDeficit) / (vaporPressurCurveSlope + γ * (1 + 0.34 * windspeed2m))
 
         return max(et0, 0)
     }
@@ -152,22 +152,22 @@ extension Meteorology {
 
         let windspeed2m = scaleWindFactor(from: 10, to: 2) * windspeed10mMeterPerSecond
 
-        /// Slope of saturation vapour pressure curve at air temperature T [kPa Â°C-1], (Page 37)
-        let Î² = Float(17.27) // Actaually 17.625 is now recommended. FAO uses the old one.
-        let Î» = Float(237.3) // 243.04 new recommendation
-        let vaporPressurCurveSlope = 4098 * (0.6108 * exp(Î² * temperature2mCelsius / (temperature2mCelsius + Î»))) / powf((temperature2mCelsius + Î»), 2)
+        /// Slope of saturation vapour pressure curve at air temperature T [kPa °C-1], (Page 37)
+        let β = Float(17.27) // Actually 17.625 is now recommended. FAO uses the old one.
+        let λ = Float(237.3) // 243.04 new recommendation
+        let vaporPressurCurveSlope = 4098 * (0.6108 * exp(β * temperature2mCelsius / (temperature2mCelsius + λ))) / powf((temperature2mCelsius + λ), 2)
 
         /// Air pressure in kPa. Evaporation at high altitudes is promoted due to low atmospheric pressure as expressed in the psychrometric constant. The effect is, however, small and in the calculation procedures, the average value for a location is sufficient.
         let simplifiedAtmosphericPressure = 101.3 * powf((293 - 0.0065 * elevation) / 293.0, 5.26)
 
-        /// psychrometric constant [kPa Â°C-1], (Equation 8)
-        let Î³ = 0.000665 * simplifiedAtmosphericPressure
+        /// psychrometric constant [kPa °C-1], (Equation 8)
+        let γ = 0.000665 * simplifiedAtmosphericPressure
 
         /// saturation vapor pressure at air temperature Thr. (kPa)
-        let esat = 0.6108 * exp((Î² * temperature2mCelsius) / (temperature2mCelsius + Î»))
+        let esat = 0.6108 * exp((β * temperature2mCelsius) / (temperature2mCelsius + λ))
 
         /// actual vapour pressure [kPa], (Page 37)
-        let ea = 0.6108 * exp((Î² * dewpointCelsius) / (dewpointCelsius + Î»))
+        let ea = 0.6108 * exp((β * dewpointCelsius) / (dewpointCelsius + λ))
 
         let vaporPressureDeficit = esat - ea
 
@@ -185,7 +185,7 @@ extension Meteorology {
         /// As a more approximate alternative, one can assume Rs/Rso = 0.4 to 0.6 during nighttime periods in humid and subhumid climates and Rs/Rso = 0.7 to 0.8 in arid and semiarid climates. (Page 75)
         let RrelAproximation = 0.4 + relativeHumidity / 100 * 0.4
 
-        /// relative shortwave radiation (limited to â‰¤ 1.0
+        /// relative shortwave radiation (limited to ≤ 1.0
         let Rrel = extraTerrestrialRadiation <= 0 ? RrelAproximation : min(Rs / Rso, 1)
 
         /// net outgoing longwave radiation [MJ m-2 day-1]
@@ -198,7 +198,7 @@ extension Meteorology {
         let Ghr = (Rs <= 0) ? 0.5 * Rn : 0.1 * Rn
 
         // evapotranspiration
-        let et0 = (0.408 * vaporPressurCurveSlope * (Rn - Ghr) + Î³ * (37.0 / (temperature2mCelsius + 273)) * windspeed2m * vaporPressureDeficit) / (vaporPressurCurveSlope + Î³ * (1 + 0.34 * windspeed2m))
+        let et0 = (0.408 * vaporPressurCurveSlope * (Rn - Ghr) + γ * (37.0 / (temperature2mCelsius + 273)) * windspeed2m * vaporPressureDeficit) / (vaporPressurCurveSlope + γ * (1 + 0.34 * windspeed2m))
 
         return max(et0 * Float(dtSeconds / 3600), 0)
     }

--- a/Sources/App/Helper/Interpolation.swift
+++ b/Sources/App/Helper/Interpolation.swift
@@ -103,7 +103,7 @@ extension Array where Element == Float {
         }
     }
 
-    /// Take the next value and devide it by dt. Used for precipitation, snow, etc
+    /// Take the next value and divide it by dt. Used for precipitation, snow, etc
     func backwardsSum(timeOld timeLow: TimerangeDt, timeNew time: TimerangeDt, scalefactor: Float) -> [Float] {
         let multiply = Float(time.dtSeconds) / Float(timeLow.dtSeconds)
         return time.map { t in

--- a/Sources/App/Helper/InterpolationInplace.swift
+++ b/Sources/App/Helper/InterpolationInplace.swift
@@ -3,7 +3,7 @@ import Foundation
 extension Array3DFastTime {
     /// Fill in missing data by interpolating using differnet interpolation types
     ///
-    /// Important: Backwards sums like precipitation must be deaveraged before AND should already have a corrected sum. The interpolation code will simply copy the array value of the next element WITHOUT dividing by `dt`. Meaning a 6 hour preciptation value should be devided by 2 before, to preserve the rum correctly
+    /// Important: Backwards sums like precipitation must be deaveraged before AND should already have a corrected sum. The interpolation code will simply copy the array value of the next element WITHOUT dividing by `dt`. Meaning a 6 hour precipitation value should be divided by 2 before, to preserve the sum correctly
     ///
     /// interpolate missing steps.. E.g. `DDDDDD-D-D-D-D-D`
     /// Automatically detects data spacing `--D--D--D` for deaverging or backfilling
@@ -15,7 +15,7 @@ extension Array3DFastTime {
 extension Array2DFastTime {
     /// Fill in missing data by interpolating using differnet interpolation types
     ///
-    /// Important: Backwards sums like precipitation must be deaveraged before AND should already have a corrected sum. The interpolation code will simply copy the array value of the next element WITHOUT dividing by `dt`. Meaning a 6 hour preciptation value should be devided by 2 before, to preserve the rum correctly
+    /// Important: Backwards sums like precipitation must be deaveraged before AND should already have a corrected sum. The interpolation code will simply copy the array value of the next element WITHOUT dividing by `dt`. Meaning a 6 hour precipitation value should be divided by 2 before, to preserve the sum correctly
     ///
     /// interpolate missing steps.. E.g. `DDDDDD-D-D-D-D-D`
     /// Automatically detects data spacing `--D--D--D` for deaverging or backfilling
@@ -28,7 +28,7 @@ extension Array2DFastTime {
 extension Array where Element == Float {
     /// Fill in missing data by interpolating using differnet interpolation types
     ///
-    /// Important: Backwards sums like precipitation must be deaveraged before AND should already have a corrected sum. The interpolation code will simply copy the array value of the next element WITHOUT dividing by `dt`. Meaning a 6 hour preciptation value should be devided by 2 before, to preserve the rum correctly
+    /// Important: Backwards sums like precipitation must be deaveraged before AND should already have a corrected sum. The interpolation code will simply copy the array value of the next element WITHOUT dividing by `dt`. Meaning a 6 hour precipitation value should be divided by 2 before, to preserve the sum correctly
     ///
     /// interpolate missing steps.. E.g. `DDDDDD-D-D-D-D-D`
     /// Automatically detects data spacing `--D--D--D` for deaverging or backfilling

--- a/Sources/App/Helper/Intrinsics/Enums.swift
+++ b/Sources/App/Helper/Intrinsics/Enums.swift
@@ -38,7 +38,7 @@ extension RawRepresentable where Self: CaseIterable, RawValue == String {
 }
 
 extension RawRepresentableString {
-    /// Initialise from string array and also decode comas
+    /// Initialise from string array and also decode commas
     static func load(commaSeparatedOptional: [String]?) throws -> [Self]? {
         guard let commaSeparatedOptional else {
             return nil
@@ -46,7 +46,7 @@ extension RawRepresentableString {
         return try load(commaSeparated: commaSeparatedOptional)
     }
 
-    /// Initialise from string array and also decode comas
+    /// Initialise from string array and also decode commas
     static func load(commaSeparated: [String]) throws -> [Self] {
         return try commaSeparated.flatMap({ s in
             try s.split(separator: ",").map {
@@ -60,7 +60,7 @@ extension RawRepresentableString {
 }
 
 extension Float {
-    /// Initialise from string array and also decode comas
+    /// Initialise from string array and also decode commas
     static func load(commaSeparated: [String]) throws -> [Float] {
         return try commaSeparated.flatMap({ s in
             try s.split(separator: ",").map {
@@ -72,7 +72,7 @@ extension Float {
         })
     }
 
-    /// Initialise from string array and also decode comas
+    /// Initialise from string array and also decode commas
     static func load(commaSeparatedOptional: [String]?) throws -> [Self]? {
         guard let commaSeparatedOptional else {
             return nil
@@ -82,7 +82,7 @@ extension Float {
 }
 
 extension Int {
-    /// Initialise from string array and also decode comas
+    /// Initialise from string array and also decode commas
     static func load(commaSeparated: [String]) throws -> [Int] {
         return try commaSeparated.flatMap({ s in
             try s.split(separator: ",").map {
@@ -94,7 +94,7 @@ extension Int {
         })
     }
 
-    /// Initialise from string array and also decode comas
+    /// Initialise from string array and also decode commas
     static func load(commaSeparatedOptional: [String]?) throws -> [Self]? {
         guard let commaSeparatedOptional else {
             return nil

--- a/Sources/App/Helper/Meteorology.swift
+++ b/Sources/App/Helper/Meteorology.swift
@@ -1,4 +1,4 @@
-import Foundation
+﻿import Foundation
 import CHelper
 
 enum Meteorology {
@@ -176,17 +176,17 @@ enum Meteorology {
     /// Calculate relative humidity from temperature and dewpoint
     /// See https://www.omnicalculator.com/physics/relative-humidity
     @inlinable public static func relativeHumidity(temperature: Float, dewpoint: Float) -> Float {
-        let β = Float(17.625)
-        let λ = Float(243.04)
-        return max(min(100 * exp((β * dewpoint) / (λ + dewpoint)) / exp((β * temperature) / (λ + temperature)), 100), 0)
+        let Î² = Float(17.625)
+        let Î» = Float(243.04)
+        return max(min(100 * exp((Î² * dewpoint) / (Î» + dewpoint)) / exp((Î² * temperature) / (Î» + temperature)), 100), 0)
     }
     
     /// Calculate relative dewpoint from humidity and temperature
     /// See https://www.omnicalculator.com/physics/relative-humidity
     @inlinable public static func dewpoint(temperature: Float, relativeHumidity: Float) -> Float {
-        let β = Float(17.625)
-        let λ = Float(243.04)
-        return λ * (log(relativeHumidity / 100) + ((β * temperature) / (λ + temperature))) / (β - log(relativeHumidity / 100) - ((β * temperature) / (λ + temperature)))
+        let Î² = Float(17.625)
+        let Î» = Float(243.04)
+        return Î» * (log(relativeHumidity / 100) + ((Î² * temperature) / (Î» + temperature))) / (Î² - log(relativeHumidity / 100) - ((Î² * temperature) / (Î» + temperature)))
     }
     
     /// Calculate relative humidity. All variables should be on the same level
@@ -211,7 +211,7 @@ enum Meteorology {
     
     /// Calculate relative humidity using vapor vapor saturation
     /// Accounts for saturation pressure over ice. This is critical to use RH for upper level cloud cover fraction.
-    /// Uses ECMWF-like mixed phase transition between -23°C and 0°C
+    /// Uses ECMWF-like mixed phase transition between -23Â°C and 0Â°C
     /// All variables must be on the same level.
     /// humudity in g/kg, temperature in celsius, pressure in hPa
     @inlinable public static func specificToRelativeHumidity(
@@ -219,20 +219,20 @@ enum Meteorology {
         temperature T_C: Float,
         pressure p_hPa: Float
     ) -> Float {
-        /// Temperature at liquid water. Triple point. 0.01°C. ECMWF IFS since Cy45r1
+        /// Temperature at liquid water. Triple point. 0.01Â°C. ECMWF IFS since Cy45r1
         let T0: Float = 273.16
         /// Temperature for for end mixed freezing phase at -23C
         let Tice: Float = 250.16
         
         // Convert units
         let q = q_gPerKg / 1000.0       // g/kg -> kg/kg
-        let T = T_C + 273.15            // °C -> K
+        let T = T_C + 273.15            // Â°C -> K
         let p = p_hPa * 100.0           // hPa -> Pa
         
         // Vapor pressure from specific humidity (Pa)
         let e = (q * p) / (0.622 + 0.378 * q)
         
-        // Saturation over ice (Murphy & Koop 2005). Accurate range from -110°C to 0.01°C
+        // Saturation over ice (Murphy & Koop 2005). Accurate range from -110Â°C to 0.01Â°C
         let lnEsi = 9.550426
                     - (5723.265 / Float(T))
                     + 3.53068 * log(Float(T))
@@ -268,7 +268,7 @@ enum Meteorology {
         return rh
     }
 
-    /// Wetbulb temperature Stull’s Approximation
+    /// Wetbulb temperature Stull's Approximation
     /// See https://www.omnicalculator.com/physics/wet-bulb
     public static func wetBulbTemperature(temperature t: Float, relativeHumidity rh: Float) -> Float {
         let twet = t * atan(0.151977 * sqrt(rh + 8.313659))

--- a/Sources/App/Helper/NumberExtensions.swift
+++ b/Sources/App/Helper/NumberExtensions.swift
@@ -28,14 +28,14 @@ extension Int {
     }
 
     /// Performs mathematical module keeping the result positive
-    @inlinable func moduloPositive(_ devisor: Int) -> Int {
-        return((self % devisor) + devisor) % devisor
+    @inlinable func moduloPositive(_ divisor: Int) -> Int {
+        return((self % divisor) + divisor) % divisor
     }
 
-    /// Devide the current number using integer devision, and report the reaming part as a fraction
-    @inlinable func moduloFraction(_ devisor: Int) -> (quotient: Int, fraction: Float) {
-        let fraction = Float(self.moduloPositive(devisor)) / Float(devisor)
-        return (self / devisor, fraction)
+    /// Divide the current number using integer division, and report the remaining part as a fraction
+    @inlinable func moduloFraction(_ divisor: Int) -> (quotient: Int, fraction: Float) {
+        let fraction = Float(self.moduloPositive(divisor)) / Float(divisor)
+        return (self / divisor, fraction)
     }
 
     @inlinable func ceil(to toNearest: Int) -> Int {
@@ -75,7 +75,7 @@ extension Range where Element == Int {
         let fileEnd = Swift.min(arrayUpper - fileLower, fileUpper - fileLower)
         let fileStart = fileEnd - array.count
         let file = fileStart ..< fileEnd
-        assert(file.count == array.count, "Offsets missmatch file=\(file.count), array=\(array.count)")
+        assert(file.count == array.count, "Offsets mismatch file=\(file.count), array=\(array.count)")
         return (file, array)
     }
 
@@ -103,7 +103,7 @@ extension Range where Bound == Float {
 }
 
 public extension RandomAccessCollection where Element == Float, Index == Int {
-    /// Calculate linear interpolation. Index and fraction are kept apart, because of floating point inprecisions
+    /// Calculate linear interpolation. Index and fraction are kept apart, because of floating point imprecisions
     @inlinable func interpolateLinear(_ i: Int, _ fraction: Float) -> Float {
         assert(self.count != 0)
         assert(0 <= fraction && fraction <= 1)

--- a/Sources/App/Helper/OmFileSplitter.swift
+++ b/Sources/App/Helper/OmFileSplitter.swift
@@ -39,7 +39,7 @@ struct OmFileSplitter {
     /// icon-eu =  16
     /// icon-d2 = 25
     /// ecmwf = 30
-    /// NOTE: carefull with reducing nchunkLocaiton, because updates will use the wrong buffer size!!!!
+    /// NOTE: careful with reducing nchunkLocation, because updates will use the wrong buffer size!!!!
     static func calcChunknLocations(nTimePerFile: Int) -> Int {
         max(6, 3072 / nTimePerFile)
     }

--- a/Sources/App/Helper/OmReader/OmReaderBlockCache.swift
+++ b/Sources/App/Helper/OmReader/OmReaderBlockCache.swift
@@ -5,10 +5,10 @@ import Foundation
 /**
  Chunk data into blocks of 64k and store blocks in a KV cache.
  
- Cache misses are isolated by the underlaying cache coordinator, preventing same blocks requested from the backend.
+ Cache misses are isolated by the underlying cache coordinator, preventing same blocks requested from the backend.
  Cache hits do not block. Atomic operations are used to prevent race conditions.
  
- Cache keys are linear for 8MB (super block). Linear cache keys can be stored linearly by the underlaying atomic cache. This is the default AWS S3 `multipart_chunksize`.
+ Cache keys are linear for 8MB (super block). Linear cache keys can be stored linearly by the underlying atomic cache. This is the default AWS S3 `multipart_chunksize`.
  Consecutive reads of blocks are merged together. E.g. Two 64 kb reads are merged to a single 128 kb read. This reduces latency if data across multiple blocks is read.
  Only reads within the 8MB super block are merged to optimise for AWS S3 multipart chunk size.
  */
@@ -127,7 +127,7 @@ final class OmReaderBlockCache<Backend: OmFileReaderBackend, Cache: AtomicBlockC
         return .owned(UnsafeRawBufferPointer(data))
     }
     
-    /// Execute a closure with retrieved data. If data is cached, the underlaying data is used to call be closure (zero-copy).
+    /// Execute a closure with retrieved data. If data is cached, the underlying data is used to call be closure (zero-copy).
     func withData<T: Sendable>(offset: Int, count: Int, fn: @Sendable (UnsafeRawBufferPointer) throws -> T) async throws -> T {
         switch try await fetch(offset: offset, count: count) {
         case .borrowed(let data):
@@ -138,7 +138,7 @@ final class OmReaderBlockCache<Backend: OmFileReaderBackend, Cache: AtomicBlockC
         }
     }
     
-    /// Get a exclusive `Data` object which is retrained independent from the underlaying cache.
+    /// Get a exclusive `Data` object which is retrained independent from the underlying cache.
     func getData(offset: Int, count: Int) async throws -> Data {
         switch try await fetch(offset: offset, count: count) {
         case .borrowed(let data):

--- a/Sources/App/Helper/OmSpatialTimestepWriter.swift
+++ b/Sources/App/Helper/OmSpatialTimestepWriter.swift
@@ -308,7 +308,7 @@ actor OmSpatialMultistepWriter {
     }
     
     /// Finalise the time step and return all handles
-    /// If not validTimes are given, use all timestamps from the underlaying writer
+    /// If not validTimes are given, use all timestamps from the underlying writer
     func finalise(completed: Bool, validTimes: [Timestamp]?, uploadS3Bucket: String?) async throws -> [GenericVariableHandle] {
         let validTimes = validTimes ?? writer.map(\.time)
         // Only upload META JSON for the last timestamp

--- a/Sources/App/Helper/Reader/GenericDomain.swift
+++ b/Sources/App/Helper/Reader/GenericDomain.swift
@@ -140,7 +140,7 @@ enum ReaderInterpolation {
     /// This happens with satellite data and missing time steps
     case solar_backwards_missing_not_averaged
 
-    /// Take the next hour, and devide by `dt` to preserve sums like precipitation
+    /// Take the next hour, and divide by `dt` to preserve sums like precipitation
     case backwards_sum
 
     /// Replicate value backwards. E.g. min/max of previous hours

--- a/Sources/App/Helper/Vapor/CIDR.swift
+++ b/Sources/App/Helper/Vapor/CIDR.swift
@@ -128,7 +128,7 @@ extension in6_addr {
                     return false
                 }
 
-                // No partial byte → exact match so far
+                // No partial byte -> exact match so far
                 if remainingBits == 0 {
                     return true
                 }

--- a/Sources/App/Helper/Vapor/RepeatedTaskLifecycle.swift
+++ b/Sources/App/Helper/Vapor/RepeatedTaskLifecycle.swift
@@ -4,7 +4,7 @@ import NIO
 import NIOConcurrencyHelpers
 
 /**
- Run a repeated task as a lifecycle handler. Repeated task is encosled by locks to be thread safe.
+ Run a repeated task as a lifecycle handler. Repeated task is enclosed by locks to be thread safe.
  */
 final class RepeatedTaskLifecycle: LifecycleHandler {
     private let backgroundWatcher: NIOLockedValueBox<RepeatedTask?>

--- a/Sources/App/Helper/Writer/XlsxFormat.swift
+++ b/Sources/App/Helper/Writer/XlsxFormat.swift
@@ -173,7 +173,7 @@ public final class GzipStream {
         }
         repeat {
             if zstream.pointee.avail_out == 0 {
-                /// Increase buffer capacity. Always double underlaying storage.
+                /// Increase buffer capacity. Always double underlying storage.
                 writebuffer.reserveCapacity(minimumWritableBytes: writebuffer.writerIndex)
                 writebuffer.withUnsafeMutableWritableBytes({ ptr in
                     zstream.pointee.avail_out = uInt(ptr.count)

--- a/Sources/App/Icon/IconVariable.swift
+++ b/Sources/App/Icon/IconVariable.swift
@@ -168,12 +168,12 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable, Sendable
     /// Maxima are collected over hourly intervals on all domains. (Prior to 2015-07-07 maxima were collected over 3-hourly intervals on the global grid.)
     case wind_gusts_10m
 
-    /// Height of snow fall limit above MSL. It is defined as the height where the wet bulb temperature Tw first exceeds 1.3◦C (scanning mode from top to bottom).
+    /// Height of snow fall limit above MSL. It is defined as the height where the wet bulb temperature Tw first exceeds 1.3°C (scanning mode from top to bottom).
     /// If this threshold is never reached within the entire atmospheric column, SNOWLMT is undefined (GRIB2 bitmap). Only icon-eu + d2
     case snowfall_height
 
-    /// Height of the 0◦ C isotherm above MSL. In case of multiple 0◦ C isotherms, HZEROCL contains the uppermost one.
-    /// If the temperature is below 0◦ C throughout the entire atmospheric column, HZEROCL is set equal to the topography height (fill value).
+    /// Height of the 0° C isotherm above MSL. In case of multiple 0° C isotherms, HZEROCL contains the uppermost one.
+    /// If the temperature is below 0° C throughout the entire atmospheric column, HZEROCL is set equal to the topography height (fill value).
     case freezing_level_height
 
     /// Relative humidity on 2 meters

--- a/Sources/App/ItaliaMeteoArpae/ItaliaMeteoArpaeVariable.swift
+++ b/Sources/App/ItaliaMeteoArpae/ItaliaMeteoArpaeVariable.swift
@@ -205,8 +205,8 @@ enum ItaliaMeteoArpaeSurfaceVariable: String, CaseIterable, GenericVariable, Gen
     /// LPI Lightning Potential Index . Scales form 0 to ~120
     case lightning_potential
 
-    /// Height of the 0◦ C isotherm above MSL. In case of multiple 0◦ C isotherms, HZEROCL contains the uppermost one.
-    /// If the temperature is below 0◦ C throughout the entire atmospheric column, HZEROCL is set equal to the topography height (fill value).
+    /// Height of the 0° C isotherm above MSL. In case of multiple 0° C isotherms, HZEROCL contains the uppermost one.
+    /// If the temperature is below 0° C throughout the entire atmospheric column, HZEROCL is set equal to the topography height (fill value).
     case freezing_level_height
     case snowfall_height
     case total_column_integrated_water_vapour

--- a/Sources/App/UKMO/UkmoDownloader.swift
+++ b/Sources/App/UKMO/UkmoDownloader.swift
@@ -85,7 +85,7 @@ struct UkmoDownload: AsyncCommand {
         /// Process a range of runs
         if let timeinterval = signature.timeinterval {
             /*if signature.fixSolar {
-                // timeinterval devided by chunk time range
+                // timeinterval divided by chunk time range
                 let time = try Timestamp.parseRange(yyyymmdd: timeinterval)
                 try self.fixSolarFiles(application: context.application, domain: domain, timerange: time)
                 return

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -166,7 +166,7 @@ extension Application {
 
 // configures your application
 public func configure(_ app: Application) throws {
-    TimeZone.ReferenceType.default = TimeZone(secondsFromGMT: 0)
+    TimeZone.ReferenceType.default = TimeZone(secondsFromGMT: 0)!
 
     let corsConfiguration = CORSMiddleware.Configuration(
         allowedOrigin: .all,

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -166,7 +166,7 @@ extension Application {
 
 // configures your application
 public func configure(_ app: Application) throws {
-    TimeZone.ReferenceType.default = TimeZone(abbreviation: "GMT")!
+    TimeZone.ReferenceType.default = TimeZone(secondsFromGMT: 0)
 
     let corsConfiguration = CORSMiddleware.Configuration(
         allowedOrigin: .all,


### PR DESCRIPTION
Nothing fancy here, just cleaning up a pile of small things I noticed:

AI-generated typographic junk in the README heading, smart quotes (curly apostrophes) in a couple swift files, en dashes instead of hyphens in a comment, white bullet chars (◦) where degree symbols (°) should be, zero-width spaces and non-breaking hyphens in README.md. All replaced with plain ASCII equivalents or the correct character.

Two genuine bugs:

1. DwdSisDownloader.swift:77 - 4121/7201*9.5*60 evaluates to zero because Swift does integer division first. That means the satellite sweep time correction was always zero. Changed to Double(4121)/7201*9.5*60.

2. configure.swift:169 - TimeZone(abbreviation: "GMT")! force-unwraps something that could technically return nil. Switched to TimeZone(secondsFromGMT: 0) which never fails.

Spelling - Fixed maybe 30 typos scattered across comments: devide→divide, devisor→divisor, missmatch→mismatch, varibale→variable, sligthly→slightly, Usefull→Useful, comas→commas, encosled→enclosed, carefull→careful, underlaying→underlying, radiaton→radiation, preciptation→precipitation, occures→occurs, devided→divided, etc. Comments only, nothing functional.