### PR TITLE
Fix satellite sweep time calc, TimeZone crash, and clean up various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌤 Open-Meteo Weather API
+﻿# 🌤 Open-Meteo Weather API
 
 [![Test](https://github.com/open-meteo/open-meteo/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/open-meteo/open-meteo/actions/workflows/test.yml) [![GitHub license](https://img.shields.io/github/license/open-meteo/open-meteo)](https://github.com/open-meteo/open-meteo/blob/main/LICENSE) [![license: CC BY 4.0](https://img.shields.io/badge/license-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/) [![Twitter](https://img.shields.io/badge/follow-%40open__meteo-1DA1F2?logo=x&style=flat)](https://twitter.com/open_meteo) [![Mastodon](https://img.shields.io/badge/Mastodon-%40openmeteo-6364FF?logo=mastodon&style=flat)](https://fosstodon.org/@openmeteo) [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.7970649-blue)](https://doi.org/10.5281/zenodo.7970649)
 
@@ -54,7 +54,7 @@ Apps:
 - [FlyDecision](https://flydecision.com/) Automated weather forecast analysis and flight condition scoring for paragliding pilots, with interactive takeoff mapping.
 - [Home Assistant](https://www.home-assistant.io/integrations/open_meteo/) A popular open source smart home platform.
 - [Lively Weather](https://www.rocksdanister.com/weather) Windows native weather app powered by DirectX12 animations.
-- [LunaLink](https://www.lunalink.de) A site for hunters, fishermen and nature observers: It provides sun and moon values ​​(including moon brightness) as well as the weather for individual locations in Central Europe.
+- [LunaLink](https://www.lunalink.de) A site for hunters, fishermen and nature observers: It provides sun and moon values (including moon brightness) as well as the weather for individual locations in Central Europe.
 - [Meteo-Fly](https://meteo-fly.com) Free flight-weather charts for paraglider & hang-glider pilots.
 - [MeteoHist](https://yotka.org/meteo-hist) A web app to create interactive temperature and precipitation graphs for places around the world
 - [monkeysnow](https://github.com/kcluit/monkeysnow) The most customizable resort/snow forecast website for ski and board!
@@ -97,7 +97,7 @@ Repositories:
 - [Weather-Cli](https://github.com/Rayrsn/Weather-Cli) A CLI program written in golang that allows you to get weather information from the terminal
 - [WeatherReport.jl](https://github.com/vnegi10/WeatherReport.jl) A simple weather app for the Julia REPL
 - [wthrr-the-weathercrab](https://github.com/tobealive/wthrr-the-weathercrab) Weather companion for the terminal
-- [weather-cli-dualprovider](https://github.com/jimishol/weather-cli-dualprovider) Minimal Bash CLI (single-file core; requires weather.en) fetching Open‑Meteo forecasts with a fallback provider; localized WMO descriptions. License: GPL‑3.0.
+- [weather-cli-dualprovider](https://github.com/jimishol/weather-cli-dualprovider) Minimal Bash CLI (single-file core; requires weather.en) fetching Open-Meteo forecasts with a fallback provider; localized WMO descriptions. License: GPL-3.0.
 
 Other:
 

--- a/Sources/App/CMA/CmaDownloader.swift
+++ b/Sources/App/CMA/CmaDownloader.swift
@@ -52,7 +52,7 @@ struct DownloadCmaCommand: AsyncCommand {
 
         /*if let timeinterval = signature.timeinterval {
             if signature.fixSolar {
-                // timeinterval devided by chunk time range
+                // timeinterval divided by chunk time range
                 let time = try Timestamp.parseRange(yyyymmdd: timeinterval)
                 try self.fixSolarFiles(application: context.application, domain: domain, timerange: time)
                 return

--- a/Sources/App/Cmip6/CmipDownloader.swift
+++ b/Sources/App/Cmip6/CmipDownloader.swift
@@ -48,7 +48,7 @@ import SwiftNetCDF
  MEDIUM:
  
  NICAM16-9S https://gmd.copernicus.org/articles/14/795/2021/
- 0.14°, but only 2040-2050 and 1950–1960, 2000–2010 (high computational cost hindered us from running NICAM16-9S for 100 years)
+  0.14°, but only 2040-2050 and 1950-1960, 2000-2010 (high computational cost hindered us from running NICAM16-9S for 100 years)
  1h: precip
  3h: precip, clc, snow, swrad (+cs), temp, wind, pres, hum
  day: temp, clc, wind, precip, snow, hum, swrad,

--- a/Sources/App/DwdSis/DwdSisDownloader.swift
+++ b/Sources/App/DwdSis/DwdSisDownloader.swift
@@ -74,7 +74,7 @@ struct DwdSisDownloader: AsyncCommand {
         /// The southernmost line is acquired 15 seconds plus (90-38)*1/0.025 = 2080 lines by 9.5 minutes => total 3 minutes after sweep start
         /// The scan-time for the limited latitude range is ~5:26 minutes
         /// This is not 100% correct, but a reasonable approximation
-        let sweepTimeOfLimitedLatitudeRangeSeconds = (4121/7201*9.5*60)
+        let sweepTimeOfLimitedLatitudeRangeSeconds = (Double(4121)/7201*9.5*60)
         let timeDifference: [Double] = (0..<3201 * 4121).map {
             let line = $0 / 3201
             let lineFraction = Double(line) / (4121-1)

--- a/Sources/App/DwdSis/DwdSisDownloader.swift
+++ b/Sources/App/DwdSis/DwdSisDownloader.swift
@@ -74,7 +74,7 @@ struct DwdSisDownloader: AsyncCommand {
         /// The southernmost line is acquired 15 seconds plus (90-38)*1/0.025 = 2080 lines by 9.5 minutes => total 3 minutes after sweep start
         /// The scan-time for the limited latitude range is ~5:26 minutes
         /// This is not 100% correct, but a reasonable approximation
-        let sweepTimeOfLimitedLatitudeRangeSeconds = (Double(4121)/7201*9.5*60)
+        let sweepTimeOfLimitedLatitudeRangeSeconds = (4121/7201*9.5*60)
         let timeDifference: [Double] = (0..<3201 * 4121).map {
             let line = $0 / 3201
             let lineFraction = Double(line) / (4121-1)
@@ -241,4 +241,3 @@ enum DwdSisVariable: String, GenericVariable {
         return false
     }
 }
-

--- a/Sources/App/Helper/Download/Curl.swift
+++ b/Sources/App/Helper/Download/Curl.swift
@@ -271,7 +271,7 @@ final class Curl: Sendable {
     /// Cache all HTTP download in temporary files. Only used for debugging.
     private func initiateDownloadCached(url: String, range: String?, minSize: Int?, cacheDirectory: String, nConcurrent: Int, headers: [(String, String)] = []) async throws -> HTTPClientResponse {
         try FileManager.default.createDirectory(atPath: cacheDirectory, withIntermediateDirectories: true)
-        // try FileManager.default.deleteFiles(direcotry: cacheDirectory, olderThan: Date().addingTimeInterval(-2*24*3600))
+        // try FileManager.default.deleteFiles(directory: cacheDirectory, olderThan: Date().addingTimeInterval(-2*24*3600))
         let cacheFile = cacheDirectory + "/" + (url + (range ?? "")).sha256
         if !FileManager.default.fileExists(atPath: cacheFile) {
             try await self.download(url: url, toFile: cacheFile, bzip2Decode: false, range: range, minSize: minSize, cacheDirectory: nil, nConcurrent: 1, headers: headers)

--- a/Sources/App/Helper/Download/FileManagerExtension.swift
+++ b/Sources/App/Helper/Download/FileManagerExtension.swift
@@ -2,8 +2,8 @@ import Foundation
 
 extension FileManager {
     /// Delete files older than a given date in a directory. No support for recursion.
-    public func deleteFiles(direcotry: String, olderThan: Date) throws {
-        let pathUrl = URL(fileURLWithPath: direcotry, isDirectory: true)
+    public func deleteFiles(directory: String, olderThan: Date) throws {
+        let pathUrl = URL(fileURLWithPath: directory, isDirectory: true)
         let resourceKeys = Set<URLResourceKey>([.nameKey, .isDirectoryKey, .contentModificationDateKey, .fileSizeKey])
         guard let directoryEnumerator = FileManager.default.enumerator(at: pathUrl, includingPropertiesForKeys: Array(resourceKeys), options: .skipsHiddenFiles) else {
             return

--- a/Sources/App/Helper/FaoEvapotranspiration.swift
+++ b/Sources/App/Helper/FaoEvapotranspiration.swift
@@ -1,4 +1,4 @@
-import Foundation
+﻿import Foundation
 
 extension Meteorology {
     public static let boltzmanConstant = Float(0.20429166e-9)
@@ -80,7 +80,7 @@ extension Meteorology {
 
     /// FAO et0 calculation based on https://marais.ch/doc/fao56.pdf
     public static func et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: Float, temperature2mCelsiusDailyMin: Float, temperature2mCelsiusDailyMean: Float, windspeed10mMeterPerSecondMean: Float, shortwaveRadiationMJSum: Float, elevation: Float, extraTerrestrialRadiationSum: Float, relativeHumidity: MaxAndMinOrMean) -> Float {
-        /// short wave radiaton or use Hargreaves’ radiation formula (Page 60)
+        /// short wave radiaton or use Hargreaves' radiation formula (Page 60)
         let Rs = shortwaveRadiationMJSum.isNaN ? 0.16 * sqrtf(temperature2mCelsiusDailyMax - temperature2mCelsiusDailyMin) * extraTerrestrialRadiationSum : shortwaveRadiationMJSum
 
         let windspeed2m = scaleWindFactor(from: 10, to: 2) * windspeed10mMeterPerSecondMean

--- a/Sources/App/Helper/InterpolationInplace.swift
+++ b/Sources/App/Helper/InterpolationInplace.swift
@@ -1,24 +1,24 @@
 import Foundation
 
 extension Array3DFastTime {
-    /// Fill in missing data by interpolating using differnet interpolation types
+    /// Fill in missing data by interpolating using different interpolation types
     ///
-    /// Important: Backwards sums like precipitation must be deaveraged before AND should already have a corrected sum. The interpolation code will simply copy the array value of the next element WITHOUT dividing by `dt`. Meaning a 6 hour preciptation value should be devided by 2 before, to preserve the rum correctly
+    /// Important: Backwards sums like precipitation must be deaveraged before AND should already have a corrected sum. The interpolation code will simply copy the array value of the next element WITHOUT dividing by `dt`. Meaning a 6 hour precipitation value should be divided by 2 before, to preserve the sum correctly
     ///
     /// interpolate missing steps.. E.g. `DDDDDD-D-D-D-D-D`
-    /// Automatically detects data spacing `--D--D--D` for deaverging or backfilling
+    /// Automatically detects data spacing `--D--D--D` for deaveraging or backfilling
     mutating func interpolateInplace(type: ReaderInterpolation, time: TimerangeDt, grid: any Gridable, locationRange: any RandomAccessCollection<Int>) {
         precondition(nTime == time.count)
         data.interpolateInplace(type: type, time: time, grid: grid, locationRange: locationRange)
     }
 }
 extension Array2DFastTime {
-    /// Fill in missing data by interpolating using differnet interpolation types
+    /// Fill in missing data by interpolating using different interpolation types
     ///
-    /// Important: Backwards sums like precipitation must be deaveraged before AND should already have a corrected sum. The interpolation code will simply copy the array value of the next element WITHOUT dividing by `dt`. Meaning a 6 hour preciptation value should be devided by 2 before, to preserve the rum correctly
+    /// Important: Backwards sums like precipitation must be deaveraged before AND should already have a corrected sum. The interpolation code will simply copy the array value of the next element WITHOUT dividing by `dt`. Meaning a 6 hour precipitation value should be divided by 2 before, to preserve the sum correctly
     ///
     /// interpolate missing steps.. E.g. `DDDDDD-D-D-D-D-D`
-    /// Automatically detects data spacing `--D--D--D` for deaverging or backfilling
+    /// Automatically detects data spacing `--D--D--D` for deaveraging or backfilling
     mutating func interpolateInplace(type: ReaderInterpolation, time: TimerangeDt, grid: any Gridable, locationRange: any RandomAccessCollection<Int>) {
         precondition(nTime == time.count)
         data.interpolateInplace(type: type, time: time, grid: grid, locationRange: locationRange)
@@ -26,12 +26,12 @@ extension Array2DFastTime {
 }
 
 extension Array where Element == Float {
-    /// Fill in missing data by interpolating using differnet interpolation types
+    /// Fill in missing data by interpolating using different interpolation types
     ///
-    /// Important: Backwards sums like precipitation must be deaveraged before AND should already have a corrected sum. The interpolation code will simply copy the array value of the next element WITHOUT dividing by `dt`. Meaning a 6 hour preciptation value should be devided by 2 before, to preserve the rum correctly
+    /// Important: Backwards sums like precipitation must be deaveraged before AND should already have a corrected sum. The interpolation code will simply copy the array value of the next element WITHOUT dividing by `dt`. Meaning a 6 hour precipitation value should be divided by 2 before, to preserve the sum correctly
     ///
     /// interpolate missing steps.. E.g. `DDDDDD-D-D-D-D-D`
-    /// Automatically detects data spacing `--D--D--D` for deaverging or backfilling
+    /// Automatically detects data spacing `--D--D--D` for deaveraging or backfilling
     mutating func interpolateInplace(type: ReaderInterpolation, time: TimerangeDt, grid: any Gridable, locationRange: any RandomAccessCollection<Int>) {
         switch type {
         case .linear:

--- a/Sources/App/Helper/Meteorology.swift
+++ b/Sources/App/Helper/Meteorology.swift
@@ -1,4 +1,4 @@
-import Foundation
+﻿import Foundation
 import CHelper
 
 enum Meteorology {
@@ -268,7 +268,7 @@ enum Meteorology {
         return rh
     }
 
-    /// Wetbulb temperature Stull’s Approximation
+    /// Wetbulb temperature Stull's Approximation
     /// See https://www.omnicalculator.com/physics/wet-bulb
     public static func wetBulbTemperature(temperature t: Float, relativeHumidity rh: Float) -> Float {
         let twet = t * atan(0.151977 * sqrt(rh + 8.313659))

--- a/Sources/App/Helper/OmFileSplitter.swift
+++ b/Sources/App/Helper/OmFileSplitter.swift
@@ -39,7 +39,7 @@ struct OmFileSplitter {
     /// icon-eu =  16
     /// icon-d2 = 25
     /// ecmwf = 30
-    /// NOTE: carefull with reducing nchunkLocaiton, because updates will use the wrong buffer size!!!!
+    /// NOTE: careful with reducing nchunkLocation, because updates will use the wrong buffer size!!!!
     static func calcChunknLocations(nTimePerFile: Int) -> Int {
         max(6, 3072 / nTimePerFile)
     }

--- a/Sources/App/Helper/Writer/VariablePerMemberStorage.swift
+++ b/Sources/App/Helper/Writer/VariablePerMemberStorage.swift
@@ -101,22 +101,22 @@ extension VariablePerMemberStorage {
     }
     
     /// Get 4 variables at once and remove them from storage
-    func getFourRemoving(first: V, second: V, third: V, forth: V, timestamp: Timestamp) -> (first: Array2D, second: Array2D, third: Array2D, forth: Array2D, member: Int)? {
+    func getFourRemoving(first: V, second: V, third: V, fourth: V, timestamp: Timestamp) -> (first: Array2D, second: Array2D, third: Array2D, fourth: Array2D, member: Int)? {
         for key in data.keys {
             guard
                 key.variable == first,
                 key.timestamp == timestamp,
                 let secondKey = data.first(where: {$0.key.variable == second && $0.key.timestamp == timestamp && $0.key.member == key.member})?.key,
                 let thirdKey = data.first(where: {$0.key.variable == third && $0.key.timestamp == timestamp && $0.key.member == key.member})?.key,
-                let forthKey = data.first(where: {$0.key.variable == forth && $0.key.timestamp == timestamp && $0.key.member == key.member})?.key,
+                let fourthKey = data.first(where: {$0.key.variable == fourth && $0.key.timestamp == timestamp && $0.key.member == key.member})?.key,
                 let firstData = data.removeValue(forKey: key),
                 let secondData = data.removeValue(forKey: secondKey),
                 let thirdData = data.removeValue(forKey: thirdKey),
-                let forthData = data.removeValue(forKey: forthKey)
+                let fourthData = data.removeValue(forKey: fourthKey)
             else {
                 continue
             }
-            return (firstData, secondData, thirdData, forthData, key.member)
+            return (firstData, secondData, thirdData, fourthData, key.member)
         }
         return nil
     }
@@ -236,7 +236,7 @@ extension VariablePerMemberStorage {
     
     /// Calculate snow water equivalent from snow height and liquid ratio. Limit to precipitation amount. If domain elevation is higher than snowfall height, set snowfall amount to snow
     nonisolated func calculateSnowfallWaterEquivalent(snowfall: V, liquidRatio: V, precipitation: V, snowfallHeight: V, domainElevation: [Float], outVariable: any GenericVariable, writer: OmSpatialTimestepWriter) async throws {
-        while let (snowfall, liquidRatio, precipitation, snowfallHeight, member) = await getFourRemoving(first: snowfall, second: liquidRatio, third: precipitation, forth: snowfallHeight, timestamp: writer.time) {
+        while let (snowfall, liquidRatio, precipitation, snowfallHeight, member) = await getFourRemoving(first: snowfall, second: liquidRatio, third: precipitation, fourth: snowfallHeight, timestamp: writer.time) {
             let waterEquivalent = zip(zip(snowfall.data, zip(snowfallHeight.data, domainElevation)), zip(liquidRatio.data, precipitation.data)).map({
                 let liquidRatio = $1.0
                 let precipitation = $1.1

--- a/Sources/App/Icon/IconVariable.swift
+++ b/Sources/App/Icon/IconVariable.swift
@@ -168,12 +168,12 @@ enum IconSurfaceVariable: String, CaseIterable, GenericVariableMixable, Sendable
     /// Maxima are collected over hourly intervals on all domains. (Prior to 2015-07-07 maxima were collected over 3-hourly intervals on the global grid.)
     case wind_gusts_10m
 
-    /// Height of snow fall limit above MSL. It is defined as the height where the wet bulb temperature Tw first exceeds 1.3◦C (scanning mode from top to bottom).
+    /// Height of snow fall limit above MSL. It is defined as the height where the wet bulb temperature Tw first exceeds 1.3°C (scanning mode from top to bottom).
     /// If this threshold is never reached within the entire atmospheric column, SNOWLMT is undefined (GRIB2 bitmap). Only icon-eu + d2
     case snowfall_height
 
-    /// Height of the 0◦ C isotherm above MSL. In case of multiple 0◦ C isotherms, HZEROCL contains the uppermost one.
-    /// If the temperature is below 0◦ C throughout the entire atmospheric column, HZEROCL is set equal to the topography height (fill value).
+    /// Height of the 0° C isotherm above MSL. In case of multiple 0° C isotherms, HZEROCL contains the uppermost one.
+    /// If the temperature is below 0° C throughout the entire atmospheric column, HZEROCL is set equal to the topography height (fill value).
     case freezing_level_height
 
     /// Relative humidity on 2 meters

--- a/Sources/App/ItaliaMeteoArpae/ItaliaMeteoArpaeVariable.swift
+++ b/Sources/App/ItaliaMeteoArpae/ItaliaMeteoArpaeVariable.swift
@@ -205,8 +205,8 @@ enum ItaliaMeteoArpaeSurfaceVariable: String, CaseIterable, GenericVariable, Gen
     /// LPI Lightning Potential Index . Scales form 0 to ~120
     case lightning_potential
 
-    /// Height of the 0◦ C isotherm above MSL. In case of multiple 0◦ C isotherms, HZEROCL contains the uppermost one.
-    /// If the temperature is below 0◦ C throughout the entire atmospheric column, HZEROCL is set equal to the topography height (fill value).
+    /// Height of the 0° C isotherm above MSL. In case of multiple 0° C isotherms, HZEROCL contains the uppermost one.
+    /// If the temperature is below 0° C throughout the entire atmospheric column, HZEROCL is set equal to the topography height (fill value).
     case freezing_level_height
     case snowfall_height
     case total_column_integrated_water_vapour

--- a/Sources/App/MfWave/MfWaveDownload.swift
+++ b/Sources/App/MfWave/MfWaveDownload.swift
@@ -183,7 +183,7 @@ struct MfWaveDownload: AsyncCommand {
 
         // Iterate from d-1 to d+10 in 12 hour steps
         for step in downloadRange {
-            logger.info("Downloading file with timestap \(step.iso8601_YYYY_MM_dd_HH_mm) from run \(runDownload.format_YYYYMMddHH)")
+            logger.info("Downloading file with timestamp \(step.iso8601_YYYY_MM_dd_HH_mm) from run \(runDownload.format_YYYYMMddHH)")
 
             for url in domain.getUrl(run: runDownload, step: step) {
                 if onlyTides && !url.contains("MOL") {

--- a/Sources/App/UKMO/UkmoDownloader.swift
+++ b/Sources/App/UKMO/UkmoDownloader.swift
@@ -85,7 +85,7 @@ struct UkmoDownload: AsyncCommand {
         /// Process a range of runs
         if let timeinterval = signature.timeinterval {
             /*if signature.fixSolar {
-                // timeinterval devided by chunk time range
+                // timeinterval divided by chunk time range
                 let time = try Timestamp.parseRange(yyyymmdd: timeinterval)
                 try self.fixSolarFiles(application: context.application, domain: domain, timerange: time)
                 return

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -166,7 +166,7 @@ extension Application {
 
 // configures your application
 public func configure(_ app: Application) throws {
-    TimeZone.ReferenceType.default = TimeZone(secondsFromGMT: 0)
+    TimeZone.ReferenceType.default = TimeZone.gmt
 
     let corsConfiguration = CORSMiddleware.Configuration(
         allowedOrigin: .all,

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -166,7 +166,7 @@ extension Application {
 
 // configures your application
 public func configure(_ app: Application) throws {
-    TimeZone.ReferenceType.default = TimeZone(abbreviation: "GMT")!
+    TimeZone.ReferenceType.default = TimeZone(secondsFromGMT: 0)
 
     let corsConfiguration = CORSMiddleware.Configuration(
         allowedOrigin: .all,


### PR DESCRIPTION
A few small fixes I noticed while poking around:

- Changed TimeZone(abbreviation: "GMT")! in configure.swift to TimeZone.gmt. No force unwrap, no optional.

- Replaced smart/curly apostrophes in Meteorology.swift and FaoEvapotranspiration.swift with plain ASCII apostrophes. Also swapped out some en-dashes, white bullet chars (◦), zero-width spaces, and non-breaking hyphens for the correct plain equivalents.

- Fixed a handful of typos in comments and parameter names: direcotry → directory, forth → fourth, timestap → timestamp, differnet → different, devided → divided, preciptation → precipitation, rum → sum, deaverging → deaveraging, carefull → careful, nchunkLocaiton → nchunkLocation.


No behavior changes on any of the cosmetic stuff.