### PR TITLE
Debug Forecast API outage on free API nodes

### DIFF
--- a/Sources/App/Commands/ReadOmCommand.swift
+++ b/Sources/App/Commands/ReadOmCommand.swift
@@ -26,7 +26,7 @@ struct ReadOmCommand: AsyncCommand {
             return
         }
 
-        for case let fileURL as URL in enumerator {
+        for case let fileURL as URL in AnySequence(enumerator) {
             guard fileURL.pathExtension == "om" else { continue }
             let path = fileURL.path
             await readOmFile(path: path, logger: logger)

--- a/Sources/App/Commands/ReadOmCommand.swift
+++ b/Sources/App/Commands/ReadOmCommand.swift
@@ -46,30 +46,40 @@ struct ReadOmCommand: AsyncCommand {
 
             switch dims.count {
             case 2:
+                logger.warning("2D file in \(path)")
                 // Layout: [nLocations, nTime]
                 let nLocations = Int(dims[0])
                 let nTime = Int(dims[1])
                 guard nLocations > 0, nTime > 0 else { return }
-                let center = nLocations / 2
-                _ = try await reader.read(range: [
-                    UInt64(center) ..< UInt64(center + 1),
-                    0 ..< UInt64(nTime)
-                ])
+                for loc in 0..<nLocations {
+                    _ = try await reader.read(range: [
+                        UInt64(loc) ..< UInt64(loc+1),
+                        0 ..< UInt64(nTime)
+                    ])
+                }
+
             case 3:
                 // Layout: [ny, nx, nTime]
                 let ny = Int(dims[0])
                 let nx = Int(dims[1])
                 let nTime = Int(dims[2])
-                guard ny > 0, nx > 0, nTime > 0 else { return }
-                let cy = ny / 2
-                let cx = nx / 2
-                _ = try await reader.read(range: [
-                    UInt64(cy) ..< UInt64(cy + 1),
-                    UInt64(cx) ..< UInt64(cx + 1),
-                    0 ..< UInt64(nTime)
-                ])
+                guard ny > 0, nx > 0, nTime > 0 else { 
+                    logger.warning("Invalid dimensions in \(path)")
+                    return
+                }
+
+                // full scan
+                for y in 0..<ny {
+                    for x in 0..<nx {
+                        _ = try await reader.read(range: [
+                            UInt64(y) ..< UInt64(y+1),
+                            UInt64(x) ..< UInt64(x+1),
+                            0 ..< UInt64(nTime)
+                        ])
+                    }
+                }                
             default:
-                logger.debug("Skipping \(path): unsupported dimension count \(dims.count)")
+                logger.warning("Skipping \(path): unsupported dimension count \(dims.count)")
             }
         } catch {
             logger.warning("Failed to read \(path): \(error)")

--- a/Sources/App/Commands/ReadOmCommand.swift
+++ b/Sources/App/Commands/ReadOmCommand.swift
@@ -1,0 +1,78 @@
+import Foundation
+import OmFileFormat
+import Vapor
+
+/// Recursively reads the data variable of all .om files under DATA_DIRECTORY.
+/// For each file it reads the center pixel [nx/2, ny/2] across all time steps.
+/// Usage: openmeteo-api read-om
+struct ReadOmCommand: AsyncCommand {
+    var help: String { "Recursively read the data variable of all .om files in DATA_DIRECTORY" }
+
+    struct Signature: CommandSignature {}
+
+    func run(using context: CommandContext, signature: Signature) async throws {
+        let logger = context.application.logger
+        let dataDirectory = OpenMeteo.dataDirectory
+
+        logger.info("Scanning \(dataDirectory) for .om files...")
+
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(
+            at: URL(fileURLWithPath: dataDirectory),
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            logger.error("Could not enumerate directory: \(dataDirectory)")
+            return
+        }
+
+        for case let fileURL as URL in enumerator {
+            guard fileURL.pathExtension == "om" else { continue }
+            let path = fileURL.path
+            await readOmFile(path: path, logger: logger)
+        }
+    }
+
+    private func readOmFile(path: String, logger: Logger) async {
+        let now = Timestamp.now().iso8601_YYYY_MM_dd_HH_mm
+        print("(\(now)) reading file \(path)")
+
+        do {
+            let fileHandle = try FileHandle.openFileReading(file: path)
+            let mmapFile = try MmapFile(fn: fileHandle)
+            let reader = try await OmFileReader(fn: mmapFile).expectArray(of: Float.self)
+
+            let dims = reader.getDimensions()
+
+            switch dims.count {
+            case 2:
+                // Layout: [nLocations, nTime]
+                let nLocations = Int(dims[0])
+                let nTime = Int(dims[1])
+                guard nLocations > 0, nTime > 0 else { return }
+                let center = nLocations / 2
+                _ = try await reader.read(range: [
+                    UInt64(center) ..< UInt64(center + 1),
+                    0 ..< UInt64(nTime)
+                ])
+            case 3:
+                // Layout: [ny, nx, nTime]
+                let ny = Int(dims[0])
+                let nx = Int(dims[1])
+                let nTime = Int(dims[2])
+                guard ny > 0, nx > 0, nTime > 0 else { return }
+                let cy = ny / 2
+                let cx = nx / 2
+                _ = try await reader.read(range: [
+                    UInt64(cy) ..< UInt64(cy + 1),
+                    UInt64(cx) ..< UInt64(cx + 1),
+                    0 ..< UInt64(nTime)
+                ])
+            default:
+                logger.debug("Skipping \(path): unsupported dimension count \(dims.count)")
+            }
+        } catch {
+            logger.warning("Failed to read \(path): \(error)")
+        }
+    }
+}

--- a/Sources/App/Commands/ValidateOmFilesCommand.swift
+++ b/Sources/App/Commands/ValidateOmFilesCommand.swift
@@ -4,15 +4,21 @@ import Vapor
 
 /// Recursively reads the data variable of all .om files under DATA_DIRECTORY.
 /// For each file it reads the center pixel [nx/2, ny/2] across all time steps.
-/// Usage: openmeteo-api read-om
-struct ReadOmCommand: AsyncCommand {
-    var help: String { "Recursively read the data variable of all .om files in DATA_DIRECTORY" }
+/// Usage: openmeteo-api validate-om-files
+struct ValidateOmFilesCommand: AsyncCommand {
+    var help: String { "Recursively read the data variable of all .om files in DATA_DIRECTORY." }
 
-    struct Signature: CommandSignature {}
+    struct Signature: CommandSignature {
+        @Option(name: "directory", short: "d", help: "Read all files in this directory")
+        var directory: String?
+        
+        @Flag(name: "full-scan", short: "f", help: "Perform full read. Otherwise only reads the center pixel.")
+        var fullScan: Bool
+    }
 
     func run(using context: CommandContext, signature: Signature) async throws {
         let logger = context.application.logger
-        let dataDirectory = OpenMeteo.dataDirectory
+        let dataDirectory = signature.directory ?? OpenMeteo.dataDirectory
 
         logger.info("Scanning \(dataDirectory) for .om files...")
 
@@ -29,19 +35,17 @@ struct ReadOmCommand: AsyncCommand {
         for case let fileURL as URL in AnySequence(enumerator) {
             guard fileURL.pathExtension == "om" else { continue }
             let path = fileURL.path
-            await readOmFile(path: path, logger: logger)
+            await readOmFile(path: path, logger: logger, fullScan: signature.fullScan)
         }
     }
 
-    private func readOmFile(path: String, logger: Logger) async {
-        let now = Timestamp.now().iso8601_YYYY_MM_dd_HH_mm
-        print("(\(now)) reading file \(path)")
+    private func readOmFile(path: String, logger: Logger, fullScan: Bool) async {
+        logger.info("Reading file \(path)", metadata: ["time": "\(Timestamp.now().iso8601_YYYY_MM_dd_HH_mm)"])
 
         do {
             let fileHandle = try FileHandle.openFileReading(file: path)
             let mmapFile = try MmapFile(fn: fileHandle)
             let reader = try await OmFileReader(fn: mmapFile).expectArray(of: Float.self)
-
             let dims = reader.getDimensions()
 
             switch dims.count {
@@ -51,13 +55,20 @@ struct ReadOmCommand: AsyncCommand {
                 let nLocations = Int(dims[0])
                 let nTime = Int(dims[1])
                 guard nLocations > 0, nTime > 0 else { return }
-                for loc in 0..<nLocations {
+                if fullScan {
+                    for loc in 0..<nLocations {
+                        _ = try await reader.read(range: [
+                            UInt64(loc) ..< UInt64(loc+1),
+                            0 ..< UInt64(nTime)
+                        ])
+                    }
+                } else {
+                    let center = nLocations / 2
                     _ = try await reader.read(range: [
-                        UInt64(loc) ..< UInt64(loc+1),
+                        UInt64(center) ..< UInt64(center + 1),
                         0 ..< UInt64(nTime)
                     ])
                 }
-
             case 3:
                 // Layout: [ny, nx, nTime]
                 let ny = Int(dims[0])
@@ -67,17 +78,26 @@ struct ReadOmCommand: AsyncCommand {
                     logger.warning("Invalid dimensions in \(path)")
                     return
                 }
-
-                // full scan
-                for y in 0..<ny {
-                    for x in 0..<nx {
-                        _ = try await reader.read(range: [
-                            UInt64(y) ..< UInt64(y+1),
-                            UInt64(x) ..< UInt64(x+1),
-                            0 ..< UInt64(nTime)
-                        ])
+                if fullScan {
+                    // full scan
+                    for y in 0..<ny {
+                        for x in 0..<nx {
+                            _ = try await reader.read(range: [
+                                UInt64(y) ..< UInt64(y+1),
+                                UInt64(x) ..< UInt64(x+1),
+                                0 ..< UInt64(nTime)
+                            ])
+                        }
                     }
-                }                
+                } else {
+                    let cy = ny / 2
+                    let cx = nx / 2
+                    _ = try await reader.read(range: [
+                        UInt64(cy) ..< UInt64(cy + 1),
+                        UInt64(cx) ..< UInt64(cx + 1),
+                        0 ..< UInt64(nTime)
+                    ])
+                }
             default:
                 logger.warning("Skipping \(path): unsupported dimension count \(dims.count)")
             }

--- a/Sources/App/Helper/File/OmFileType.swift
+++ b/Sources/App/Helper/File/OmFileType.swift
@@ -92,7 +92,11 @@ enum OmFileType: Hashable, RemoteFileManageable {
             }
         case .staticFile(_, _, _):
             return 24*3600
-        case .run(_, _, _):
+        case .run(_, _, let run):
+            // If run is younger than 24 hours, check every 3 minutes
+            if run.toTimestamp() > now.subtract(hours: 24) {
+                return 3*60
+            }
             return 24*3600
         }
     }

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -63,6 +63,69 @@ final class RemoteFileManager: Sendable {
         }
     }
     
+    /// On cache miss this function is called to create a new reader
+    /// If `forceNew` is set, do not use cached meta data
+    static fileprivate func open<Key: RemoteFileManageable>(key: Key, client: HTTPClient?, logger: Logger, forceNew: Bool) async throws -> (value: LocalOrRemote?, lastValidated: Timestamp) {
+        let localFile = key.getFilePath()
+        if FileManager.default.fileExists(atPath: localFile) {
+            do {
+                let file = try MmapFile(fn: try FileHandle.openFileReading(file: localFile))
+                let reader = try await key.makeLocalReader(file: file)
+                return (.local(reader), .now())
+            } catch OmFileFormatSwiftError.notAnOpenMeteoFile {
+                print("[ ERROR ] Not an OpenMeteo file \(localFile)")
+                return (nil, .now())
+            } catch {
+                print("[ ERROR ] Error while opening file \(localFile): \(error.localizedDescription)")
+                throw error
+            }
+        }
+        
+        guard let client, let remoteFile = key.getRemoteUrl() else {
+            return (nil, .now())
+        }
+        let now = Timestamp.now()
+        let cachedFileMeta = forceNew ? HttpMetaCache.State.missing(lastValidated: Timestamp(0)) : HttpMetaCache.get(url: remoteFile)
+        switch cachedFileMeta {
+        case .missing(let lastValidated):
+            let revalidateSeconds = key.revalidateEverySeconds(modificationTime: nil, now: now)
+            if lastValidated >= now.subtract(seconds: revalidateSeconds) {
+                // safe to assume the file is still missing
+                return (nil, lastValidated)
+            }
+            // need to revalidate
+            guard let file = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile), let reader = try await key.makeRemoteCaptureNotOmFile(file: file) else {
+                // file is still missing
+                return (nil, .now())
+            }
+            return (.remote(reader), lastValidated)
+            
+        case .available(let lastValidated, let count, let lastModified, let eTag):
+            let reader = OmHttpReaderBackend(client: client, logger: logger, url: remoteFile, count: count, lastModified: lastModified, eTag: eTag, lastValidated: lastValidated)
+            let cached = OmReaderBlockCache(backend: reader, cache: OpenMeteo.dataBlockCache, cacheKey: reader.cacheKey)
+            let revalidateSeconds = key.revalidateEverySeconds(modificationTime: lastModified, now: now)
+            if lastValidated >= now.subtract(seconds: revalidateSeconds) {
+                /// Reuse cached meta attributes
+                guard let reader = try await key.makeRemoteCaptureNotOmFile(file: cached) else {
+                    return (nil, lastValidated)
+                }
+                return (.remote(reader), lastValidated)
+            }
+            // need to revalidate
+            guard let new = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile) else {
+                return (nil, .now())
+            }
+            if new.cacheKey != cached.cacheKey {
+                let deletedBlocks = cached.deleteCachedBlocks(olderThanSeconds: 60)
+                logger.warning("OmFileManager: Opened stale file. New file version available. \(deletedBlocks) previously cached blocks have been deleted")
+            }
+            guard let reader = try await key.makeRemoteCaptureNotOmFile(file: new) else {
+                return (nil, .now())
+            }
+            return (.remote(reader), .now())
+        }
+    }
+    
     /**
      Remove entries that have not been accessed for more than 15 minutes
      Revalidate entries older than 1 minute
@@ -281,70 +344,7 @@ fileprivate final actor RemoteFileManagerCache {
         }
     }
     
-    var cache = [AnyRemoteFileManageable: State]()
-    
-    /// On cache miss, create a new reader
-    /// If `forceNew` is set, do not use cached meta data
-    nonisolated private func open<Key: RemoteFileManageable>(key: Key, client: HTTPClient?, logger: Logger, forceNew: Bool) async throws -> (value: LocalOrRemote?, lastValidated: Timestamp) {
-        let localFile = key.getFilePath()
-        if FileManager.default.fileExists(atPath: localFile) {
-            do {
-                let file = try MmapFile(fn: try FileHandle.openFileReading(file: localFile))
-                let reader = try await key.makeLocalReader(file: file)
-                return (.local(reader), .now())
-            } catch OmFileFormatSwiftError.notAnOpenMeteoFile {
-                print("[ ERROR ] Not an OpenMeteo file \(localFile)")
-                return (nil, .now())
-            } catch {
-                print("[ ERROR ] Error while opening file \(localFile): \(error.localizedDescription)")
-                throw error
-            }
-        }
-        
-        guard let client, let remoteFile = key.getRemoteUrl() else {
-            return (nil, .now())
-        }
-        let now = Timestamp.now()
-        let cachedFileMeta = forceNew ? HttpMetaCache.State.missing(lastValidated: Timestamp(0)) : HttpMetaCache.get(url: remoteFile)
-        switch cachedFileMeta {
-        case .missing(let lastValidated):
-            let revalidateSeconds = key.revalidateEverySeconds(modificationTime: nil, now: now)
-            if lastValidated >= now.subtract(seconds: revalidateSeconds) {
-                // safe to assume the file is still missing
-                return (nil, lastValidated)
-            }
-            // need to revalidate
-            guard let file = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile), let reader = try await key.makeRemoteCaptureNotOmFile(file: file) else {
-                // file is still missing
-                return (nil, .now())
-            }
-            return (.remote(reader), lastValidated)
-            
-        case .available(let lastValidated, let count, let lastModified, let eTag):
-            let reader = OmHttpReaderBackend(client: client, logger: logger, url: remoteFile, count: count, lastModified: lastModified, eTag: eTag, lastValidated: lastValidated)
-            let cached = OmReaderBlockCache(backend: reader, cache: OpenMeteo.dataBlockCache, cacheKey: reader.cacheKey)
-            let revalidateSeconds = key.revalidateEverySeconds(modificationTime: lastModified, now: now)
-            if lastValidated >= now.subtract(seconds: revalidateSeconds) {
-                /// Reuse cached meta attributes
-                guard let reader = try await key.makeRemoteCaptureNotOmFile(file: cached) else {
-                    return (nil, lastValidated)
-                }
-                return (.remote(reader), lastValidated)
-            }
-            // need to revalidate
-            guard let new = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile) else {
-                return (nil, .now())
-            }
-            if new.cacheKey != cached.cacheKey {
-                let deletedBlocks = cached.deleteCachedBlocks(olderThanSeconds: 60)
-                logger.warning("OmFileManager: Opened stale file. New file version available. \(deletedBlocks) previously cached blocks have been deleted")
-            }
-            guard let reader = try await key.makeRemoteCaptureNotOmFile(file: new) else {
-                return (nil, .now())
-            }
-            return (.remote(reader), .now())
-        }
-    }
+    private var cache = [AnyRemoteFileManageable: State]()
     
     /**
      Get a resource identified by a key. If the request is currently being requested, enqueue the request
@@ -356,7 +356,7 @@ fileprivate final actor RemoteFileManagerCache {
             cache[key] = .running([])
             do {
                 OmStatistics.currentlyOpeningFiles.add(1, ordering: .relaxed)
-                let (data, lastValidated) = try await open(key: key.key, client: client, logger: logger, forceNew: forceNew)
+                let (data, lastValidated) = try await RemoteFileManager.open(key: key.key, client: client, logger: logger, forceNew: forceNew)
                 guard case .running(let queued) = cache.updateValue(.cached(.init(value: data, lastValidated: lastValidated)), forKey: key) else {
                     fatalError("State was not .running()")
                 }

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -111,6 +111,8 @@ fileprivate final actor RemoteFileManagerCache {
         var remoteDeleted = 0
         var remoteRevalidated = 0
         var remoteCheckedExist = 0
+        var currentlyOpeningFiles = 0
+        var currentlyWaitingOnOpeningFiles = 0
         var lastPrint = Timestamp.now()
         
         mutating func reset() {
@@ -229,6 +231,7 @@ fileprivate final actor RemoteFileManagerCache {
             // Value not cached or needs to be refreshed
             cache[key] = .running([])
             do {
+                statistics.currentlyOpeningFiles += 1
                 let (data, lastValidated) = try await open(key: key.key, client: client, logger: logger, forceNew: forceNew)
                 guard case .running(let queued) = cache.updateValue(.cached(.init(value: data, lastValidated: lastValidated)), forKey: key) else {
                     fatalError("State was not .running()")
@@ -236,6 +239,7 @@ fileprivate final actor RemoteFileManagerCache {
                 queued.forEach {
                     $0.resume(with: .success(data))
                 }
+                statistics.currentlyOpeningFiles -= 1
                 return data
             } catch {
                 guard case .running(let queued) = cache.removeValue(forKey: key) else {
@@ -244,6 +248,7 @@ fileprivate final actor RemoteFileManagerCache {
                 queued.forEach({
                     $0.resume(with: .failure(error))
                 })
+                statistics.currentlyOpeningFiles -= 1
                 throw error
             }
         }
@@ -252,9 +257,11 @@ fileprivate final actor RemoteFileManagerCache {
             entry.lastAccessed = .now()
             return entry.value
         case .running(let running):
+            statistics.currentlyWaitingOnOpeningFiles += 1
             let value = try await withCheckedThrowingContinuation { continuation in
                 cache[key] = .running(running + [continuation])
             }
+            statistics.currentlyWaitingOnOpeningFiles -= 1
             return value
         }
     }

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -1,5 +1,6 @@
 import OmFileFormat
 import Vapor
+import Synchronization
 
 
 /**
@@ -62,13 +63,161 @@ final class RemoteFileManager: Sendable {
         }
     }
     
+    /**
+     Remove entries that have not been accessed for more than 15 minutes
+     Revalidate entries older than 1 minute
+     Called every second
+     Does not block the cache manager actor. Uses atomics to keep track of last access times.
+     Could consider some kind of tree structure with partial locks (maybe also atomic)
+     */
+    func revalidate(client: HTTPClient, logger: Logger) async throws {
+        var running = 0
+        var total = 0
+        OmStatistics.ticks.add(1, ordering: .relaxed)
+        let startRevalidation = DispatchTime.now()
+                
+        let now = Timestamp.now()
+        let removeLastAccessedThan = now.subtract(minutes: 15)
+        for key in await cache.getKeys() {
+            let state = await cache.getEntry(key: key)
+            let key2 = key.key
+            total += 1
+            guard case .cached(let entry) = state else {
+                running += 1
+                continue
+            }
+            // Evict unused entries after 15 minutes
+            if entry.lastAccessed.load(ordering: .relaxed) < removeLastAccessedThan.timeIntervalSince1970 {
+                OmStatistics.inactivity.add(1, ordering: .relaxed)
+                await cache.removeEntry(forKey: key)
+                continue
+            }
+            
+            // Check if local files got deleted or overwritten every minute
+            if case .local(let local) = entry.value, entry.lastValidatedLocal.load(ordering: .relaxed) < now.subtract(minutes: 1).timeIntervalSince1970 {
+                if local.fn.file.wasDeleted() {
+                    OmStatistics.localModified.add(1, ordering: .relaxed)
+                    await cache.removeEntry(forKey: key)
+                    continue
+                }
+                entry.lastValidatedLocal.store(now.timeIntervalSince1970, ordering: .relaxed)
+            }
+            
+            // Check if a local file is now available every minute
+            if entry.value == nil, entry.lastValidatedLocal.load(ordering: .relaxed) < now.subtract(minutes: 1).timeIntervalSince1970 {
+                if FileManager.default.fileExists(atPath: key2.getFilePath()) {
+                    OmStatistics.localModified.add(1, ordering: .relaxed)
+                    await cache.removeEntry(forKey: key)
+                    continue
+                }
+                entry.lastValidatedLocal.store(now.timeIntervalSince1970, ordering: .relaxed)
+            }
+            
+            if let remoteFile = key2.getRemoteUrl() {
+                // Remote file is open
+                if case .remote(let old) = entry.value {
+                    let revalidateSeconds = key2.revalidateEverySeconds(modificationTime: old.fn.backend.lastModifiedTimestamp, now: now)
+                    if old.fn.backend.lastValidated.timeIntervalSince1970 > entry.lastValidated.load(ordering: .relaxed) {
+                        /// Update meta cache to also reflect updates in `lastBackendFetchTimestamp`
+                        try HttpMetaCache.set(url: remoteFile, state: .available(lastValidated: old.fn.backend.lastValidated, contentLength: old.fn.backend.count, lastModified: old.fn.backend.lastModifiedTimestamp, eTag: old.fn.backend.eTag))
+                    }
+                    let lastValidated = max(entry.lastValidated.load(ordering: .relaxed), old.fn.backend.lastValidated.timeIntervalSince1970)
+                    if lastValidated < now.subtract(seconds: revalidateSeconds).timeIntervalSince1970 {
+                        entry.lastValidated.store(Timestamp.now().timeIntervalSince1970, ordering: .relaxed)
+                        OmStatistics.remoteRevalidated.add(1, ordering: .relaxed)
+                        if let new = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile) {
+                            guard old.fn.cacheKey != new.cacheKey else {
+                                continue // do not update if the existing entry is the same
+                            }
+                            OmStatistics.remoteModified.add(1, ordering: .relaxed)
+                            let activeBlocks = old.fn.listOfActiveBlocks(maxAgeSeconds: 15*60)
+                            logger.error("OmFileManager: Remote file modified \(key). \(activeBlocks.count) blocks active in the last 15 minutes")
+                            if activeBlocks.count > 0 {
+                                let startPreload = DispatchTime.now()
+                                try await new.preloadBlocks(blocks: activeBlocks)
+                                logger.error("OmFileManager: Preload completed in \(startPreload.timeElapsedPretty())")
+                            }
+                            guard let reader = try await key2.makeRemoteCaptureNotOmFile(file: new) else {
+                                await cache.setEntry(forKey: key, value: nil)
+                                continue
+                            }
+                            await cache.setEntry(forKey: key, value: .remote(reader))
+                        } else {
+                            // File was deleted on remote server
+                            logger.error("OmFileManager: Remote file deleted \(key).")
+                            OmStatistics.remoteDeleted.add(1, ordering: .relaxed)
+                            await cache.setEntry(forKey: key, value: nil)
+                        }
+                        // Remove data from local cache
+                        // Keep blocks that have been accessed less than 60 seconds ago, because they still could be used
+                        // If they are deleted, the cache might immediately write new data into the cached slot
+                        let deletedBlocks = old.fn.deleteCachedBlocks(olderThanSeconds: 60)
+                        if deletedBlocks > 0 {
+                            logger.error("OmFileManager: \(deletedBlocks) blocks have been deleted")
+                        }
+                    }
+                }
+                if entry.value == nil {
+                    // Check if a remote file is now available on the remote server
+                    let revalidateSeconds = key2.revalidateEverySeconds(modificationTime: nil, now: now)
+                    if entry.lastValidated.load(ordering: .relaxed) < now.subtract(seconds: revalidateSeconds).timeIntervalSince1970 {
+                        entry.lastValidated.store(Timestamp.now().timeIntervalSince1970, ordering: .relaxed)
+                        OmStatistics.remoteCheckedExist.add(1, ordering: .relaxed)
+                        if let new = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile), let reader = try await key2.makeRemoteCaptureNotOmFile(file: new)  {
+                            OmStatistics.remoteModified.add(1, ordering: .relaxed)
+                            await cache.setEntry(forKey: key, value: .remote(reader))
+                        }
+                    }
+                }
+            }
+        }
+        if total > 0, OmStatistics.lastPrintUnitTimestampSeconds.load(ordering: .relaxed) < Timestamp.now().subtract(minutes: 1).timeIntervalSince1970 {
+            logger.error("OmFileManager: \(total) open files, \(running) running. Revalidation took \(startRevalidation.timeElapsedPretty()). \(OmStatistics.toString())")
+            if OpenMeteo.remoteDataDirectory != nil {
+                logger.error("\(OpenMeteo.dataBlockCache.cache.statistics().prettyPrint)")
+            }
+            OmStatistics.reset()
+        }
+    }
+    
     /// Called every second from a life cycle handler on an available thread
     func backgroundTask(application: Application) async throws {
-        try await cache.revalidate(client: application.http.client.shared, logger: application.logger)
+        try await revalidate(client: application.http.client.shared, logger: application.logger)
     }
 }
 
-fileprivate enum LocalOrRemote {
+
+/// Runtime statistics print to the console regularly
+/// Could be further improved
+enum OmStatistics {
+    static let ticks = Atomic(0)
+    static let inactivity = Atomic(0)
+    static let localModified = Atomic(0)
+    static let remoteModified = Atomic(0)
+    static let remoteDeleted = Atomic(0)
+    static let remoteRevalidated = Atomic(0)
+    static let remoteCheckedExist = Atomic(0)
+    static let currentlyOpeningFiles = Atomic(0)
+    static let currentlyWaitingOnOpeningFiles = Atomic(0)
+    static let lastPrintUnitTimestampSeconds = Atomic(0)
+    
+    
+    static func reset() {
+        inactivity.store(0, ordering: .relaxed)
+        localModified.store(0, ordering: .relaxed)
+        remoteModified.store(0, ordering: .relaxed)
+        remoteDeleted.store(0, ordering: .relaxed)
+        remoteRevalidated.store(0, ordering: .relaxed)
+        remoteCheckedExist.store(0, ordering: .relaxed)
+        lastPrintUnitTimestampSeconds.store(Timestamp.now().timeIntervalSince1970, ordering: .relaxed)
+    }
+    
+    static func toString() -> String {
+        return "inactivity=\(inactivity.load(ordering: .relaxed)) localModified=\(localModified.load(ordering: .relaxed)) remoteModified=\(remoteModified.load(ordering: .relaxed)) remoteDeleted=\(remoteDeleted.load(ordering: .relaxed)) remoteRevalidated=\(remoteRevalidated.load(ordering: .relaxed)) remoteCheckedExist=\(remoteCheckedExist.load(ordering: .relaxed)) currentlyOpeningFiles=\(currentlyOpeningFiles.load(ordering: .relaxed)) currentlyWaitingOnOpeningFiles=\(currentlyWaitingOnOpeningFiles.load(ordering: .relaxed))"
+    }
+}
+
+fileprivate enum LocalOrRemote: Sendable {
     case local(any LocalFileRepresentable)
     case remote(any RemoteFileRepresentable)
 }
@@ -91,8 +240,8 @@ fileprivate extension OmHttpReaderBackend {
  KV cache, but a resource is resolved not in parallel
  */
 fileprivate final actor RemoteFileManagerCache {
-        /// Wrap `any RemoteFileManageable` into a hashable key
-    struct AnyRemoteFileManageable: Hashable {
+    /// Wrap `any RemoteFileManageable` into a hashable key
+    struct AnyRemoteFileManageable: Sendable, Hashable {
         let key: (any RemoteFileManageable)
         static func == (lhs: Self, rhs: Self) -> Bool {
             return lhs.key.hashValue == rhs.key.hashValue
@@ -103,45 +252,21 @@ fileprivate final actor RemoteFileManagerCache {
         }
     }
     
-    struct Statistics {
-        var ticks = 0
-        var inactivity = 0
-        var localModified = 0
-        var remoteModified = 0
-        var remoteDeleted = 0
-        var remoteRevalidated = 0
-        var remoteCheckedExist = 0
-        var currentlyOpeningFiles = 0
-        var currentlyWaitingOnOpeningFiles = 0
-        var lastPrint = Timestamp.now()
-        
-        mutating func reset() {
-            inactivity = 0
-            localModified = 0
-            remoteModified = 0
-            remoteDeleted = 0
-            remoteRevalidated = 0
-            remoteCheckedExist = 0
-            lastPrint = Timestamp.now()
-        }
-    }
-    
-    
-    final class Entry {
-        var value: LocalOrRemote?
-        var lastValidated: Timestamp
-        var lastValidatedLocal: Timestamp
-        var lastAccessed: Timestamp
+    final class Entry: Sendable {
+        let value: LocalOrRemote?
+        let lastValidated: Atomic<Int>
+        let lastValidatedLocal: Atomic<Int>
+        let lastAccessed: Atomic<Int>
         
         init(value: LocalOrRemote?, lastValidated: Timestamp = .now(), lastAccessed: Timestamp = .now()) {
             self.value = value
-            self.lastValidated = lastValidated
-            self.lastAccessed = lastAccessed
-            self.lastValidatedLocal = .now()
+            self.lastValidated = .init(lastValidated.timeIntervalSince1970)
+            self.lastAccessed = .init(lastAccessed.timeIntervalSince1970)
+            self.lastValidatedLocal = .init(Timestamp.now().timeIntervalSince1970)
         }
     }
     
-    enum State {
+    enum State: Sendable {
         /// Value and last accessed timestamp
         case cached(Entry)
         case running([CheckedContinuation<LocalOrRemote?, any Error>])
@@ -157,7 +282,6 @@ fileprivate final actor RemoteFileManagerCache {
     }
     
     var cache = [AnyRemoteFileManageable: State]()
-    var statistics: Statistics = .init()
     
     /// On cache miss, create a new reader
     /// If `forceNew` is set, do not use cached meta data
@@ -231,7 +355,7 @@ fileprivate final actor RemoteFileManagerCache {
             // Value not cached or needs to be refreshed
             cache[key] = .running([])
             do {
-                statistics.currentlyOpeningFiles += 1
+                OmStatistics.currentlyOpeningFiles.add(1, ordering: .relaxed)
                 let (data, lastValidated) = try await open(key: key.key, client: client, logger: logger, forceNew: forceNew)
                 guard case .running(let queued) = cache.updateValue(.cached(.init(value: data, lastValidated: lastValidated)), forKey: key) else {
                     fatalError("State was not .running()")
@@ -239,7 +363,7 @@ fileprivate final actor RemoteFileManagerCache {
                 queued.forEach {
                     $0.resume(with: .success(data))
                 }
-                statistics.currentlyOpeningFiles -= 1
+                OmStatistics.currentlyOpeningFiles.subtract(1, ordering: .relaxed)
                 return data
             } catch {
                 guard case .running(let queued) = cache.removeValue(forKey: key) else {
@@ -248,138 +372,38 @@ fileprivate final actor RemoteFileManagerCache {
                 queued.forEach({
                     $0.resume(with: .failure(error))
                 })
-                statistics.currentlyOpeningFiles -= 1
+                OmStatistics.currentlyOpeningFiles.subtract(1, ordering: .relaxed)
                 throw error
             }
         }
         switch state {
         case .cached(let entry):
-            entry.lastAccessed = .now()
+            entry.lastAccessed.store(Timestamp.now().timeIntervalSince1970, ordering: .relaxed)
             return entry.value
         case .running(let running):
-            statistics.currentlyWaitingOnOpeningFiles += 1
+            OmStatistics.currentlyWaitingOnOpeningFiles.add(1, ordering: .relaxed)
             let value = try await withCheckedThrowingContinuation { continuation in
                 cache[key] = .running(running + [continuation])
             }
-            statistics.currentlyWaitingOnOpeningFiles -= 1
+            OmStatistics.currentlyWaitingOnOpeningFiles.subtract(1, ordering: .relaxed)
             return value
         }
     }
     
-    /**
-     Remove entries that have not been accessed for more than 15 minutes
-     Revalidate entries older than 1 minute
-     Called every second
-     */
-    func revalidate(client: HTTPClient, logger: Logger) async throws {
-        var running = 0
-        var total = 0
-        statistics.ticks += 1
-        let startRevalidation = DispatchTime.now()
-        
-        // TODO: Revalidation may take >100ms and could potentially block API calls. Implement a different caching system that does not block all entries while validating new entries.
-        
-        let now = Timestamp.now()
-        let removeLastAccessedThan = now.subtract(minutes: 15)
-        for (key, state) in cache {
-            let key2 = key.key
-            total += 1
-            guard case .cached(let entry) = state else {
-                running += 1
-                continue
-            }
-            // Evict unused entries after 15 minutes
-            if entry.lastAccessed < removeLastAccessedThan {
-                statistics.inactivity += 1
-                cache.removeValue(forKey: key)
-                continue
-            }
-            
-            // Check if local files got deleted or overwritten every minute
-            if case .local(let local) = entry.value, entry.lastValidatedLocal < now.subtract(minutes: 1) {
-                if local.fn.file.wasDeleted() {
-                    statistics.localModified += 1
-                    cache.removeValue(forKey: key)
-                    continue
-                }
-                entry.lastValidatedLocal = now
-            }
-            
-            // Check if a local file is now available every minute
-            if entry.value == nil, entry.lastValidatedLocal < now.subtract(minutes: 1) {
-                if FileManager.default.fileExists(atPath: key2.getFilePath()) {
-                    statistics.localModified += 1
-                    cache.removeValue(forKey: key)
-                    continue
-                }
-                entry.lastValidatedLocal = now
-            }
-            
-            if let remoteFile = key2.getRemoteUrl() {
-                // Remote file is open
-                if case .remote(let old) = entry.value {
-                    let revalidateSeconds = key2.revalidateEverySeconds(modificationTime: old.fn.backend.lastModifiedTimestamp, now: now)
-                    if old.fn.backend.lastValidated > entry.lastValidated {
-                        /// Update meta cache to also reflect updates in `lastBackendFetchTimestamp`
-                        try HttpMetaCache.set(url: remoteFile, state: .available(lastValidated: old.fn.backend.lastValidated, contentLength: old.fn.backend.count, lastModified: old.fn.backend.lastModifiedTimestamp, eTag: old.fn.backend.eTag))
-                    }
-                    let lastValidated = max(entry.lastValidated, old.fn.backend.lastValidated)
-                    if lastValidated < now.subtract(seconds: revalidateSeconds) {
-                        entry.lastValidated = .now()
-                        statistics.remoteRevalidated += 1
-                        if let new = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile) {
-                            guard old.fn.cacheKey != new.cacheKey else {
-                                continue // do not update if the existing entry is the same
-                            }
-                            statistics.remoteModified += 1
-                            let activeBlocks = old.fn.listOfActiveBlocks(maxAgeSeconds: 15*60)
-                            logger.error("OmFileManager: Remote file modified \(key). \(activeBlocks.count) blocks active in the last 15 minutes")
-                            if activeBlocks.count > 0 {
-                                let startPreload = DispatchTime.now()
-                                try await new.preloadBlocks(blocks: activeBlocks)
-                                logger.error("OmFileManager: Preload completed in \(startPreload.timeElapsedPretty())")
-                            }
-                            guard let reader = try await key2.makeRemoteCaptureNotOmFile(file: new) else {
-                                entry.value = nil
-                                continue
-                            }
-                            entry.value = .remote(reader)
-                        } else {
-                            // File was deleted on remote server
-                            logger.error("OmFileManager: Remote file deleted \(key).")
-                            statistics.remoteDeleted += 1
-                            entry.value = nil
-                        }
-                        // Remove data from local cache
-                        // Keep blocks that have been accessed less than 60 seconds ago, because they still could be used
-                        // If they are deleted, the cache might immediately write new data into the cached slot
-                        let deletedBlocks = old.fn.deleteCachedBlocks(olderThanSeconds: 60)
-                        if deletedBlocks > 0 {
-                            logger.error("OmFileManager: \(deletedBlocks) blocks have been deleted")
-                        }
-                    }
-                }
-                if entry.value == nil {
-                    // Check if a remote file is now available on the remote server
-                    let revalidateSeconds = key2.revalidateEverySeconds(modificationTime: nil, now: now)
-                    if entry.lastValidated < now.subtract(seconds: revalidateSeconds) {
-                        entry.lastValidated = .now()
-                        statistics.remoteCheckedExist += 1
-                        if let new = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile), let reader = try await key2.makeRemoteCaptureNotOmFile(file: new)  {
-                            statistics.remoteModified += 1
-                            entry.value = .remote(reader)
-                        }
-                    }
-                }
-            }
-        }
-        if total > 0, statistics.lastPrint < Timestamp.now().subtract(minutes: 1) {
-            logger.error("OmFileManager: \(total) open files, \(running) running. Revalidation took \(startRevalidation.timeElapsedPretty()). \(statistics)")
-            if OpenMeteo.remoteDataDirectory != nil {
-                logger.error("\(OpenMeteo.dataBlockCache.cache.statistics().prettyPrint)")
-            }
-            statistics.reset()
-        }
+    func getKeys() -> [AnyRemoteFileManageable] {
+        return cache.keys.map{$0}
+    }
+    
+    func getEntry(key: AnyRemoteFileManageable) -> State? {
+        return cache[key]
+    }
+    
+    func setEntry(forKey key: AnyRemoteFileManageable, value: LocalOrRemote?) {
+        return cache[key] = State.cached(Entry(value: value))
+    }
+    
+    func removeEntry(forKey key: AnyRemoteFileManageable) {
+        cache.removeValue(forKey: key)
     }
 }
 

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -150,46 +150,47 @@ final class RemoteFileManager: Sendable {
                 continue
             }
             // Evict unused entries after 15 minutes
-            if entry.lastAccessed.load(ordering: .relaxed) < removeLastAccessedThan.timeIntervalSince1970 {
+            if entry.lastAccessed < removeLastAccessedThan {
                 OmStatistics.inactivity.add(1, ordering: .relaxed)
                 await cache.removeEntry(forKey: key)
                 continue
             }
             
             // Check if local files got deleted or overwritten every minute
-            if case .local(let local) = entry.value, entry.lastValidatedLocal.load(ordering: .relaxed) < now.subtract(minutes: 1).timeIntervalSince1970 {
+            if case .local(let local) = entry.value, entry.lastValidatedLocal < now.subtract(minutes: 1) {
                 if local.fn.file.wasDeleted() {
                     OmStatistics.localModified.add(1, ordering: .relaxed)
                     await cache.removeEntry(forKey: key)
                     continue
                 }
-                entry.lastValidatedLocal.store(now.timeIntervalSince1970, ordering: .relaxed)
+                await cache.setEntry(forKey: key, value: entry.with(lastValidatedLocal: now))
+                continue
             }
             
             // Check if a local file is now available every minute
-            if entry.value == nil, entry.lastValidatedLocal.load(ordering: .relaxed) < now.subtract(minutes: 1).timeIntervalSince1970 {
+            if entry.value == nil, entry.lastValidatedLocal < now.subtract(minutes: 1) {
                 if FileManager.default.fileExists(atPath: key2.getFilePath()) {
                     OmStatistics.localModified.add(1, ordering: .relaxed)
                     await cache.removeEntry(forKey: key)
                     continue
                 }
-                entry.lastValidatedLocal.store(now.timeIntervalSince1970, ordering: .relaxed)
+                await cache.setEntry(forKey: key, value: entry.with(lastValidatedLocal: now))
             }
             
             if let remoteFile = key2.getRemoteUrl() {
                 // Remote file is open
                 if case .remote(let old) = entry.value {
                     let revalidateSeconds = key2.revalidateEverySeconds(modificationTime: old.fn.backend.lastModifiedTimestamp, now: now)
-                    if old.fn.backend.lastValidated.timeIntervalSince1970 > entry.lastValidated.load(ordering: .relaxed) {
+                    if old.fn.backend.lastValidated > entry.lastValidated {
                         /// Update meta cache to also reflect updates in `lastBackendFetchTimestamp`
                         try HttpMetaCache.set(url: remoteFile, state: .available(lastValidated: old.fn.backend.lastValidated, contentLength: old.fn.backend.count, lastModified: old.fn.backend.lastModifiedTimestamp, eTag: old.fn.backend.eTag))
                     }
-                    let lastValidated = max(entry.lastValidated.load(ordering: .relaxed), old.fn.backend.lastValidated.timeIntervalSince1970)
-                    if lastValidated < now.subtract(seconds: revalidateSeconds).timeIntervalSince1970 {
-                        entry.lastValidated.store(Timestamp.now().timeIntervalSince1970, ordering: .relaxed)
-                        OmStatistics.remoteRevalidated.add(1, ordering: .relaxed)
+                    let lastValidated = max(entry.lastValidated, old.fn.backend.lastValidated)
+                    if lastValidated < now.subtract(seconds: revalidateSeconds) {
+                        await cache.setEntry(forKey: key, value: entry.with(lastValidated: now))
                         if let new = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile) {
                             guard old.fn.cacheKey != new.cacheKey else {
+                                await cache.setEntry(forKey: key, value: entry.with(lastValidated: now))
                                 continue // do not update if the existing entry is the same
                             }
                             OmStatistics.remoteModified.add(1, ordering: .relaxed)
@@ -201,15 +202,15 @@ final class RemoteFileManager: Sendable {
                                 logger.error("OmFileManager: Preload completed in \(startPreload.timeElapsedPretty())")
                             }
                             guard let reader = try await key2.makeRemoteCaptureNotOmFile(file: new) else {
-                                await cache.setEntry(forKey: key, value: nil)
+                                await cache.setEntry(forKey: key, value: entry.with(value: nil, lastValidated: now))
                                 continue
                             }
-                            await cache.setEntry(forKey: key, value: .remote(reader))
+                            await cache.setEntry(forKey: key, value: entry.with(value: .remote(reader), lastValidated: now))
                         } else {
                             // File was deleted on remote server
                             logger.error("OmFileManager: Remote file deleted \(key).")
                             OmStatistics.remoteDeleted.add(1, ordering: .relaxed)
-                            await cache.setEntry(forKey: key, value: nil)
+                            await cache.setEntry(forKey: key, value: entry.with(value: nil, lastValidated: now))
                         }
                         // Remove data from local cache
                         // Keep blocks that have been accessed less than 60 seconds ago, because they still could be used
@@ -223,12 +224,13 @@ final class RemoteFileManager: Sendable {
                 if entry.value == nil {
                     // Check if a remote file is now available on the remote server
                     let revalidateSeconds = key2.revalidateEverySeconds(modificationTime: nil, now: now)
-                    if entry.lastValidated.load(ordering: .relaxed) < now.subtract(seconds: revalidateSeconds).timeIntervalSince1970 {
-                        entry.lastValidated.store(Timestamp.now().timeIntervalSince1970, ordering: .relaxed)
+                    if entry.lastValidated < now.subtract(seconds: revalidateSeconds) {
                         OmStatistics.remoteCheckedExist.add(1, ordering: .relaxed)
                         if let new = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile), let reader = try await key2.makeRemoteCaptureNotOmFile(file: new)  {
                             OmStatistics.remoteModified.add(1, ordering: .relaxed)
-                            await cache.setEntry(forKey: key, value: .remote(reader))
+                            await cache.setEntry(forKey: key, value: entry.with(value: .remote(reader), lastValidated: now))
+                        } else {
+                            await cache.setEntry(forKey: key, value: entry.with(lastValidated: now))
                         }
                     }
                 }
@@ -315,21 +317,25 @@ fileprivate final actor RemoteFileManagerCache {
         }
     }
     
-    final class Entry: Sendable {
+    struct Entry {
         let value: LocalOrRemote?
-        let lastValidated: Atomic<Int>
-        let lastValidatedLocal: Atomic<Int>
-        let lastAccessed: Atomic<Int>
+        let lastValidated: Timestamp
+        let lastValidatedLocal: Timestamp
+        let lastAccessed: Timestamp
         
-        init(value: LocalOrRemote?, lastValidated: Timestamp = .now(), lastAccessed: Timestamp = .now()) {
+        init(value: LocalOrRemote?, lastValidated: Timestamp = .now(), lastValidatedLocal: Timestamp = .now(), lastAccessed: Timestamp = .now()) {
             self.value = value
-            self.lastValidated = .init(lastValidated.timeIntervalSince1970)
-            self.lastAccessed = .init(lastAccessed.timeIntervalSince1970)
-            self.lastValidatedLocal = .init(Timestamp.now().timeIntervalSince1970)
+            self.lastValidated = lastValidated
+            self.lastValidatedLocal = lastValidatedLocal
+            self.lastAccessed = lastAccessed
+        }
+        
+        func with(value: LocalOrRemote? = nil, lastValidated: Timestamp? = nil, lastValidatedLocal: Timestamp? = nil, lastAccessed: Timestamp? = nil) -> Self {
+            return .init(value: value ?? self.value, lastValidated: lastValidated ?? self.lastValidated, lastValidatedLocal: lastValidatedLocal ?? self.lastValidatedLocal, lastAccessed: lastAccessed ?? self.lastAccessed)
         }
     }
     
-    enum State: Sendable {
+    enum State {
         /// Value and last accessed timestamp
         case cached(Entry)
         case running([CheckedContinuation<LocalOrRemote?, any Error>])
@@ -378,7 +384,7 @@ fileprivate final actor RemoteFileManagerCache {
         }
         switch state {
         case .cached(let entry):
-            entry.lastAccessed.store(Timestamp.now().timeIntervalSince1970, ordering: .relaxed)
+            cache[key] = .cached(Entry(value: entry.value, lastValidated: entry.lastValidated, lastValidatedLocal: entry.lastValidatedLocal, lastAccessed: .now()))
             return entry.value
         case .running(let running):
             OmStatistics.currentlyWaitingOnOpeningFiles.add(1, ordering: .relaxed)
@@ -398,8 +404,8 @@ fileprivate final actor RemoteFileManagerCache {
         return cache[key]
     }
     
-    func setEntry(forKey key: AnyRemoteFileManageable, value: LocalOrRemote?) {
-        return cache[key] = State.cached(Entry(value: value))
+    func setEntry(forKey key: AnyRemoteFileManageable, value: Entry) {
+        return cache[key] = .cached(value)
     }
     
     func removeEntry(forKey key: AnyRemoteFileManageable) {

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -374,10 +374,12 @@ fileprivate final actor RemoteFileManagerCache {
             return entry.value
         case .running(let running):
             OmStatistics.currentlyWaitingOnOpeningFiles.add(1, ordering: .relaxed)
+            defer {
+                OmStatistics.currentlyWaitingOnOpeningFiles.subtract(1, ordering: .relaxed)
+            }
             let value = try await withCheckedThrowingContinuation { continuation in
                 cache[key] = .running(running + [continuation])
             }
-            OmStatistics.currentlyWaitingOnOpeningFiles.subtract(1, ordering: .relaxed)
             return value
         }
     }

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -160,8 +160,8 @@ fileprivate final actor RemoteFileManagerCache {
     nonisolated private func open<Key: RemoteFileManageable>(key: Key, client: HTTPClient?, logger: Logger, forceNew: Bool) async throws -> (value: LocalOrRemote?, lastValidated: Timestamp) {
         let localFile = key.getFilePath()
         if FileManager.default.fileExists(atPath: localFile) {
-            let file = try MmapFile(fn: try FileHandle.openFileReading(file: localFile))
             do {
+                let file = try MmapFile(fn: try FileHandle.openFileReading(file: localFile))
                 let reader = try await key.makeLocalReader(file: file)
                 return (.local(reader), .now())
             } catch OmFileFormatSwiftError.notAnOpenMeteoFile {

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -366,7 +366,7 @@ fileprivate final actor RemoteFileManagerCache {
                 }
             }
         }
-        if total > 0, statistics.lastPrint > Timestamp.now().subtract(minutes: 5) {
+        if total > 0, statistics.lastPrint < Timestamp.now().subtract(minutes: 1) {
             logger.error("OmFileManager: \(total) open files, \(running) running. Revalidation took \(startRevalidation.timeElapsedPretty()). \(statistics)")
             if OpenMeteo.remoteDataDirectory != nil {
                 logger.error("\(OpenMeteo.dataBlockCache.cache.statistics().prettyPrint)")

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -128,12 +128,14 @@ fileprivate final actor RemoteFileManagerCache {
     final class Entry {
         var value: LocalOrRemote?
         var lastValidated: Timestamp
+        var lastValidatedLocal: Timestamp
         var lastAccessed: Timestamp
         
         init(value: LocalOrRemote?, lastValidated: Timestamp = .now(), lastAccessed: Timestamp = .now()) {
             self.value = value
             self.lastValidated = lastValidated
             self.lastAccessed = lastAccessed
+            self.lastValidatedLocal = .now()
         }
     }
     
@@ -287,23 +289,23 @@ fileprivate final actor RemoteFileManagerCache {
             }
             
             // Check if local files got deleted or overwritten every minute
-            if case .local(let local) = entry.value, entry.lastValidated < now.subtract(minutes: 1) {
+            if case .local(let local) = entry.value, entry.lastValidatedLocal < now.subtract(minutes: 1) {
                 if local.fn.file.wasDeleted() {
                     statistics.localModified += 1
                     cache.removeValue(forKey: key)
                     continue
                 }
-                entry.lastValidated = now
+                entry.lastValidatedLocal = now
             }
             
             // Check if a local file is now available every minute
-            if entry.value == nil, entry.lastValidated < now.subtract(minutes: 1) {
+            if entry.value == nil, entry.lastValidatedLocal < now.subtract(minutes: 1) {
                 if FileManager.default.fileExists(atPath: key2.getFilePath()) {
                     statistics.localModified += 1
                     cache.removeValue(forKey: key)
                     continue
                 }
-                entry.lastValidated = now
+                entry.lastValidatedLocal = now
             }
             
             if let remoteFile = key2.getRemoteUrl() {

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -167,6 +167,9 @@ fileprivate final actor RemoteFileManagerCache {
             } catch OmFileFormatSwiftError.notAnOpenMeteoFile {
                 print("[ ERROR ] Not an OpenMeteo file \(localFile)")
                 return (nil, .now())
+            } catch {
+                print("[ ERROR ] Error while opening file \(localFile): \(error.localizedDescription)")
+                throw error
             }
         }
         

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -127,117 +127,105 @@ final class RemoteFileManager: Sendable {
     }
     
     /**
-     Remove entries that have not been accessed for more than 15 minutes
-     Revalidate entries older than 1 minute
-     Called every second
-     Does not block the cache manager actor. Uses atomics to keep track of last access times.
-     Could consider some kind of tree structure with partial locks (maybe also atomic)
+     Check local and remote files for modifications
+     Called every second.
+     Removes entries that have not been accessed for more than 15 minutes.
+     Revalidates local files every minutes.
+     Revalidates remote files on demand.
+     Does not block the cache manager actor. Gets list of entries to check and validates them outside actor isolation.
      */
     func revalidate(client: HTTPClient, logger: Logger) async throws {
-        var running = 0
-        var total = 0
-        OmStatistics.ticks.add(1, ordering: .relaxed)
         let startRevalidation = DispatchTime.now()
-                
         let now = Timestamp.now()
-        let removeLastAccessedThan = now.subtract(minutes: 15)
-        for key in await cache.getKeys() {
-            let state = await cache.getEntry(key: key)
-            let key2 = key.key
-            total += 1
-            guard case .cached(let entry) = state else {
-                running += 1
-                continue
-            }
-            // Evict unused entries after 15 minutes
-            if entry.lastAccessed < removeLastAccessedThan {
-                OmStatistics.inactivity.add(1, ordering: .relaxed)
-                await cache.removeEntry(forKey: key)
-                continue
-            }
-            
-            // Check if local files got deleted or overwritten every minute
-            if case .local(let local) = entry.value, entry.lastValidatedLocal < now.subtract(minutes: 1) {
+        
+        // Remove unused entries
+        await cache.removeLastAccessed(olderThan: now.subtract(minutes: 15))
+        
+        // Every minute: Check if local files got added or deleted
+        // Local File IO is blocking, therefore we get a list of keys and check it outside actor isolation
+        for (key, entry) in await cache.entriesLastValidatedLocal(olderThan: now.subtract(minutes: 1)) {
+            if case .local(let local) = entry.value {
+                // Local file open. Check if it was deleted
                 if local.fn.file.wasDeleted() {
                     OmStatistics.localModified.add(1, ordering: .relaxed)
                     await cache.removeEntry(forKey: key)
                     continue
                 }
-                await cache.setEntry(forKey: key, value: entry.with(lastValidatedLocal: now))
-                continue
-            }
-            
-            // Check if a local file is now available every minute
-            if entry.value == nil, entry.lastValidatedLocal < now.subtract(minutes: 1) {
-                if FileManager.default.fileExists(atPath: key2.getFilePath()) {
+            } else {
+                // Local file is missing, or a remote file is open
+                // Check if a file is now available locally
+                if FileManager.default.fileExists(atPath: key.key.getFilePath()) {
                     OmStatistics.localModified.add(1, ordering: .relaxed)
                     await cache.removeEntry(forKey: key)
                     continue
                 }
-                await cache.setEntry(forKey: key, value: entry.with(lastValidatedLocal: now))
             }
-            
-            if let remoteFile = key2.getRemoteUrl() {
-                // Remote file is open
-                if case .remote(let old) = entry.value {
-                    let revalidateSeconds = key2.revalidateEverySeconds(modificationTime: old.fn.backend.lastModifiedTimestamp, now: now)
-                    if old.fn.backend.lastValidated > entry.lastValidated {
-                        /// Update meta cache to also reflect updates in `lastBackendFetchTimestamp`
-                        try HttpMetaCache.set(url: remoteFile, state: .available(lastValidated: old.fn.backend.lastValidated, contentLength: old.fn.backend.count, lastModified: old.fn.backend.lastModifiedTimestamp, eTag: old.fn.backend.eTag))
-                    }
-                    let lastValidated = max(entry.lastValidated, old.fn.backend.lastValidated)
-                    if lastValidated < now.subtract(seconds: revalidateSeconds) {
-                        await cache.setEntry(forKey: key, value: entry.with(lastValidated: now))
-                        if let new = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile) {
-                            guard old.fn.cacheKey != new.cacheKey else {
-                                await cache.setEntry(forKey: key, value: entry.with(lastValidated: now))
-                                continue // do not update if the existing entry is the same
-                            }
-                            OmStatistics.remoteModified.add(1, ordering: .relaxed)
-                            let activeBlocks = old.fn.listOfActiveBlocks(maxAgeSeconds: 15*60)
-                            logger.error("OmFileManager: Remote file modified \(key). \(activeBlocks.count) blocks active in the last 15 minutes")
-                            if activeBlocks.count > 0 {
-                                let startPreload = DispatchTime.now()
-                                try await new.preloadBlocks(blocks: activeBlocks)
-                                logger.error("OmFileManager: Preload completed in \(startPreload.timeElapsedPretty())")
-                            }
-                            guard let reader = try await key2.makeRemoteCaptureNotOmFile(file: new) else {
-                                await cache.setEntry(forKey: key, value: entry.with(value: nil, lastValidated: now))
-                                continue
-                            }
-                            await cache.setEntry(forKey: key, value: entry.with(value: .remote(reader), lastValidated: now))
-                        } else {
-                            // File was deleted on remote server
-                            logger.error("OmFileManager: Remote file deleted \(key).")
-                            OmStatistics.remoteDeleted.add(1, ordering: .relaxed)
-                            await cache.setEntry(forKey: key, value: entry.with(value: nil, lastValidated: now))
-                        }
-                        // Remove data from local cache
-                        // Keep blocks that have been accessed less than 60 seconds ago, because they still could be used
-                        // If they are deleted, the cache might immediately write new data into the cached slot
-                        let deletedBlocks = old.fn.deleteCachedBlocks(olderThanSeconds: 60)
-                        if deletedBlocks > 0 {
-                            logger.error("OmFileManager: \(deletedBlocks) blocks have been deleted")
-                        }
-                    }
+            await cache.setEntry(forKey: key, value: entry.with(lastValidatedLocal: now))
+        }
+        
+        /// Update `HttpMetaCache` with latest `lastValidated` timestamps if required
+        /// `HttpMetaCache.set` could be blocking, therefore we perform this action outside actor isolation
+        for (remoteFile, state) in await cache.activeRemoteFilesToUpdateHttpMeta() {
+            /// Update meta cache to also reflect updates in `lastBackendFetchTimestamp`
+            try HttpMetaCache.set(url: remoteFile, state: state)
+        }
+        
+        /// Validate open remote files
+        for (key, entry) in await cache.activeRemoteFilesToValidate() {
+            // Remote file is open
+            guard let remoteFile = key.key.getRemoteUrl(), case .remote(let old) = entry.value  else {
+                continue
+            }
+            OmStatistics.remoteRevalidated.add(1, ordering: .relaxed)
+            if let new = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile) {
+                guard old.fn.cacheKey != new.cacheKey else {
+                    await cache.setEntry(forKey: key, value: entry.with(lastValidated: now))
+                    old.fn.backend.lastValidated = now
+                    continue // do not update if the existing entry is the same
                 }
-                if entry.value == nil {
-                    // Check if a remote file is now available on the remote server
-                    let revalidateSeconds = key2.revalidateEverySeconds(modificationTime: nil, now: now)
-                    if entry.lastValidated < now.subtract(seconds: revalidateSeconds) {
-                        OmStatistics.remoteCheckedExist.add(1, ordering: .relaxed)
-                        if let new = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile), let reader = try await key2.makeRemoteCaptureNotOmFile(file: new)  {
-                            OmStatistics.remoteModified.add(1, ordering: .relaxed)
-                            await cache.setEntry(forKey: key, value: entry.with(value: .remote(reader), lastValidated: now))
-                        } else {
-                            await cache.setEntry(forKey: key, value: entry.with(lastValidated: now))
-                        }
-                    }
+                OmStatistics.remoteModified.add(1, ordering: .relaxed)
+                guard let reader = try await key.key.makeRemoteCaptureNotOmFile(file: new) else {
+                    await cache.setEntry(forKey: key, value: entry.with(value: nil, lastValidated: now))
+                    continue
                 }
+                let activeBlocks = old.fn.listOfActiveBlocks(maxAgeSeconds: 15*60)
+                logger.error("OmFileManager: Remote file modified \(key). \(activeBlocks.count) blocks active in the last 15 minutes")
+                if activeBlocks.count > 0 {
+                    // TODO: Consider: While we are preloading, another call could fail and we fetch data twice. Solution could be some kind of preload manager
+                    let startPreload = DispatchTime.now()
+                    try await new.preloadBlocks(blocks: activeBlocks)
+                    logger.error("OmFileManager: Preload completed in \(startPreload.timeElapsedPretty())")
+                }
+                await cache.setEntry(forKey: key, value: entry.with(value: .remote(reader), lastValidated: now))
+            } else {
+                // File was deleted on remote server
+                logger.error("OmFileManager: Remote file deleted \(key).")
+                OmStatistics.remoteDeleted.add(1, ordering: .relaxed)
+                await cache.setEntry(forKey: key, value: entry.with(value: nil, lastValidated: now))
+            }
+            // Remove data from local cache
+            // Keep blocks that have been accessed less than 60 seconds ago, because they still could be used
+            // If they are deleted, the cache might immediately write new data into the cached slot
+            let deletedBlocks = old.fn.deleteCachedBlocks(olderThanSeconds: 60)
+            if deletedBlocks > 0 {
+                logger.error("OmFileManager: \(deletedBlocks) blocks have been deleted")
             }
         }
+        
+        /// Validate missing remote files
+        for (key, entry, remoteFile) in await cache.missingRemoteFilesToValidate() {
+            OmStatistics.remoteCheckedExist.add(1, ordering: .relaxed)
+            if let new = try await OmHttpReaderBackend.makeRemoteReaderAndCacheMeta(client: client, logger: logger, url: remoteFile),
+                let reader = try await key.key.makeRemoteCaptureNotOmFile(file: new)  {
+                OmStatistics.remoteModified.add(1, ordering: .relaxed)
+                await cache.setEntry(forKey: key, value: entry.with(value: .remote(reader), lastValidated: now))
+            } else {
+                await cache.setEntry(forKey: key, value: entry.with(lastValidated: now))
+            }
+        }
+        let total = await cache.count()
         if total > 0, OmStatistics.lastPrintUnitTimestampSeconds.load(ordering: .relaxed) < Timestamp.now().subtract(minutes: 1).timeIntervalSince1970 {
-            logger.error("OmFileManager: \(total) open files, \(running) running. Revalidation took \(startRevalidation.timeElapsedPretty()). \(OmStatistics.toString())")
+            logger.error("OmFileManager: \(total) open files. Revalidation took \(startRevalidation.timeElapsedPretty()). \(OmStatistics.toString())")
             if OpenMeteo.remoteDataDirectory != nil {
                 logger.error("\(OpenMeteo.dataBlockCache.cache.statistics().prettyPrint)")
             }
@@ -255,7 +243,6 @@ final class RemoteFileManager: Sendable {
 /// Runtime statistics print to the console regularly
 /// Could be further improved
 enum OmStatistics {
-    static let ticks = Atomic(0)
     static let inactivity = Atomic(0)
     static let localModified = Atomic(0)
     static let remoteModified = Atomic(0)
@@ -265,7 +252,6 @@ enum OmStatistics {
     static let currentlyOpeningFiles = Atomic(0)
     static let currentlyWaitingOnOpeningFiles = Atomic(0)
     static let lastPrintUnitTimestampSeconds = Atomic(0)
-    
     
     static func reset() {
         inactivity.store(0, ordering: .relaxed)
@@ -396,12 +382,69 @@ fileprivate final actor RemoteFileManagerCache {
         }
     }
     
-    func getKeys() -> [AnyRemoteFileManageable] {
-        return cache.keys.map{$0}
+    /// If a file has not been used for 15 minutes, remove it from cache
+    func removeLastAccessed(olderThan: Timestamp) {
+        for (key, state) in cache {
+            guard case .cached(let entry) = state else {
+                continue
+            }
+            // Evict unused entries after 15 minutes
+            if entry.lastAccessed < olderThan {
+                OmStatistics.inactivity.add(1, ordering: .relaxed)
+                cache.removeValue(forKey: key)
+            }
+        }
     }
     
-    func getEntry(key: AnyRemoteFileManageable) -> State? {
-        return cache[key]
+    /// Get entries that have not been validated locally for a while
+    func entriesLastValidatedLocal(olderThan: Timestamp) -> [(key: AnyRemoteFileManageable, value: Entry)] {
+        return cache.compactMap({ (key, state) in
+            guard case .cached(let entry) = state else {
+                return nil
+            }
+            return entry.lastValidatedLocal < olderThan ? (key, entry) : nil
+        })
+    }
+    
+    /// Open files that need to be revalidated
+    func activeRemoteFilesToValidate() -> [(key: AnyRemoteFileManageable, value: Entry)] {
+        let now = Timestamp.now()
+        return cache.compactMap({ (key, state) in
+            guard case .cached(let entry) = state, case .remote(let old) = entry.value else {
+                return nil
+            }
+            let revalidateSeconds = key.key.revalidateEverySeconds(modificationTime: old.fn.backend.lastModifiedTimestamp, now: now)
+            let lastValidated = max(entry.lastValidated, old.fn.backend.lastValidated)
+            return lastValidated < now.subtract(seconds: revalidateSeconds) ? (key, entry) : nil
+        })
+    }
+    
+    /// If the backend was able to fetch data in the meantime, update the local cache
+    func activeRemoteFilesToUpdateHttpMeta() -> [(remoteFile: String, state: HttpMetaCache.State)] {
+        return cache.compactMap({ (key, state) in
+            guard case .cached(let entry) = state, case .remote(let old) = entry.value, let remoteFile = key.key.getRemoteUrl() else {
+                return nil
+            }
+            return old.fn.backend.lastValidated > entry.lastValidated ? (remoteFile, .available(
+                lastValidated: old.fn.backend.lastValidated,
+                contentLength: old.fn.backend.count,
+                lastModified: old.fn.backend.lastModifiedTimestamp,
+                eTag: old.fn.backend.eTag
+            )) : nil
+        })
+    }
+    
+    /// Files to check if they got added to the remote server
+    func missingRemoteFilesToValidate() -> [(key: AnyRemoteFileManageable, value: Entry, remoteFile: String)] {
+        let now = Timestamp.now()
+        return cache.compactMap({ (key, state) in
+            guard case .cached(let entry) = state, let remoteFile = key.key.getRemoteUrl(), entry.value == nil else {
+                return nil
+            }
+            // Check if a remote file is now available on the remote server
+            let revalidateSeconds = key.key.revalidateEverySeconds(modificationTime: nil, now: now)
+            return entry.lastValidated < now.subtract(seconds: revalidateSeconds) ? (key, entry, remoteFile) : nil
+        })
     }
     
     func setEntry(forKey key: AnyRemoteFileManageable, value: Entry) {
@@ -410,6 +453,10 @@ fileprivate final actor RemoteFileManagerCache {
     
     func removeEntry(forKey key: AnyRemoteFileManageable) {
         cache.removeValue(forKey: key)
+    }
+    
+    func count() -> Int {
+        cache.count
     }
 }
 

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -62,7 +62,7 @@ final class RemoteFileManager: Sendable {
         }
     }
     
-    /// Called every 10 seconds from a life cycle handler on an available thread
+    /// Called every second from a life cycle handler on an available thread
     func backgroundTask(application: Application) async throws {
         try await cache.revalidate(client: application.http.client.shared, logger: application.logger)
     }
@@ -259,14 +259,16 @@ fileprivate final actor RemoteFileManagerCache {
     
     /**
      Remove entries that have not been accessed for more than 15 minutes
-     Revalidate entries older than 3 minutes.
-     Called every 10 seconds
+     Revalidate entries older than 1 minute
+     Called every second
      */
     func revalidate(client: HTTPClient, logger: Logger) async throws {
         var running = 0
         var total = 0
         statistics.ticks += 1
         let startRevalidation = DispatchTime.now()
+        
+        // TODO: Revalidation may take >100ms and could potentially block API calls. Implement a different caching system that does not block all entries while validating new entries.
         
         let now = Timestamp.now()
         let removeLastAccessedThan = now.subtract(minutes: 15)
@@ -284,18 +286,24 @@ fileprivate final actor RemoteFileManagerCache {
                 continue
             }
             
-            // Always check if local files got deleted or overwritten
-            if case .local(let local) = entry.value, local.fn.file.wasDeleted() {
-                statistics.localModified += 1
-                cache.removeValue(forKey: key)
-                continue
+            // Check if local files got deleted or overwritten every minute
+            if case .local(let local) = entry.value, entry.lastValidated < now.subtract(minutes: 1) {
+                if local.fn.file.wasDeleted() {
+                    statistics.localModified += 1
+                    cache.removeValue(forKey: key)
+                    continue
+                }
+                entry.lastValidated = now
             }
             
-            // Always check if a local file is now available
-            if entry.value == nil, FileManager.default.fileExists(atPath: key2.getFilePath()) {
-                statistics.localModified += 1
-                cache.removeValue(forKey: key)
-                continue
+            // Check if a local file is now available every minute
+            if entry.value == nil, entry.lastValidated < now.subtract(minutes: 1) {
+                if FileManager.default.fileExists(atPath: key2.getFilePath()) {
+                    statistics.localModified += 1
+                    cache.removeValue(forKey: key)
+                    continue
+                }
+                entry.lastValidated = now
             }
             
             if let remoteFile = key2.getRemoteUrl() {

--- a/Sources/App/Helper/OmReader/OmHttpReaderBackend.swift
+++ b/Sources/App/Helper/OmReader/OmHttpReaderBackend.swift
@@ -32,7 +32,12 @@ final class OmHttpReaderBackend: OmFileReaderBackend, Sendable {
     
     /// Timestamp when the last data was successfully fetched from the backend.
     var lastValidated: Timestamp {
-        return Timestamp(lastValidatedAtomic.load(ordering: .relaxed))
+        get {
+            return Timestamp(lastValidatedAtomic.load(ordering: .relaxed))
+        }
+        set {
+            lastValidatedAtomic.store(newValue.timeIntervalSince1970, ordering: .relaxed)
+        }
     }
     
     typealias DataType = ByteBuffer

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -178,7 +178,6 @@ public func configure(_ app: Application) throws {
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
 
     app.commands.use(BenchmarkCommand(), as: "benchmark")
-    app.asyncCommands.use(ReadOmCommand(), as: "read-test")
     app.asyncCommands.use(MigrationCommand(), as: "migration")
     app.asyncCommands.use(DownloadIconCommand(), as: "download")
     app.asyncCommands.use(DownloadCmaCommand(), as: "download-cma")
@@ -214,7 +213,7 @@ public func configure(_ app: Application) throws {
     app.asyncCommands.use(ExportCommand(), as: "export")
     app.asyncCommands.use(MergeYearlyCommand(), as: "merge-yearly")
     app.asyncCommands.use(ConvertOmCommand(), as: "convert-om")
-    app.asyncCommands.use(ReadOmCommand(), as: "read-om")
+    app.asyncCommands.use(ValidateOmFilesCommand(), as: "validate-om-files")
     app.asyncCommands.use(DownloadEcmwfSeasCommand(), as: "download-ecmwf-seas")
     app.asyncCommands.use(DwdSisDownloader(), as: "download-dwd-sis")
 

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -249,7 +249,7 @@ public func configure(_ app: Application) throws {
     // Those background tasks are not executed in parallel. The delay is after the call completes
     app.lifecycle.repeatedTask(
         initialDelay: .seconds(0),
-        delay: .seconds(10),
+        delay: .seconds(1),
         RemoteFileManager.instance.backgroundTask
     )
 

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -178,6 +178,7 @@ public func configure(_ app: Application) throws {
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
 
     app.commands.use(BenchmarkCommand(), as: "benchmark")
+    app.asyncCommands.use(ReadOmCommand(), as: "read-test")
     app.asyncCommands.use(MigrationCommand(), as: "migration")
     app.asyncCommands.use(DownloadIconCommand(), as: "download")
     app.asyncCommands.use(DownloadCmaCommand(), as: "download-cma")
@@ -213,6 +214,7 @@ public func configure(_ app: Application) throws {
     app.asyncCommands.use(ExportCommand(), as: "export")
     app.asyncCommands.use(MergeYearlyCommand(), as: "merge-yearly")
     app.asyncCommands.use(ConvertOmCommand(), as: "convert-om")
+    app.asyncCommands.use(ReadOmCommand(), as: "read-om")
     app.asyncCommands.use(DownloadEcmwfSeasCommand(), as: "download-ecmwf-seas")
     app.asyncCommands.use(DwdSisDownloader(), as: "download-dwd-sis")
 


### PR DESCRIPTION
Rewrote file manager revalidation system. Removes locks while checking for local file system changes. Unsure if this cause the outage, but useful anyways.