### PR TITLE
fix: type-erased wrapper equality and add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to Open-Meteo
+
+Pull requests are welcome. Here's how to make one that won't waste anyone's time.
+
+## Before you start
+
+Open an issue first if you're fixing a bug or adding something non-trivial. Saves you writing code that won't get merged.
+
+Small stuff like typo fixes or one-line bugfixes — just send the PR.
+
+## Making changes
+
+**Keep it simple.** Don't add abstractions nobody asked for. Don't refactor things you're not touching.
+
+**Surgical changes.** Every line you change should trace back to what you're fixing. If you're touching code the maintainer didn't ask about, you better have a good reason.
+
+**Test your changes.** Run the tests before opening a PR. If you broke something, fix it.
+
+## The PR
+
+**Title.** Short. Describes what changed, not why.
+
+```
+Fix heavy convective rain classified as moderate rain shower
+```
+
+Not:
+
+```
+Fix 3 bugs in AQI threshold lookup and weather code mapping
+```
+
+If you have multiple unrelated fixes, send separate PRs.
+
+**Description.** Explain the problem and your fix. If it's a bug, include what you saw vs what should have happened. Real examples help.
+
+The maintainer will read your PR and either merge it or ask questions. If he asks something, answer directly. Don't argue unless you're sure you're right — and if he shows you're wrong, just fix it.
+
+## Code style
+
+- Protocol-oriented. Favor protocols over inheritance.
+- Async/await everywhere. No callbacks.
+- No comments unless the code genuinely can't be made clear on its own.
+- Match the style of the file you're editing. If surrounding code uses `for (i, value) in self.enumerated()`, don't rewrite it as `for i in 1..<count`.
+- Keep functions short. If a function is doing more than one thing, split it.
+
+## What gets merged
+
+- Bug fixes with real-world impact
+- New weather model integrations
+- Performance improvements
+- Correctness fixes
+
+What doesn't:
+- Cosmetic changes (reformatting, renaming for style preferences)
+- Changes that fix a problem you can't demonstrate actually happens
+- Adding features nobody asked for

--- a/Sources/App/Domains/GaussianGridArea.swift
+++ b/Sources/App/Domains/GaussianGridArea.swift
@@ -4,7 +4,7 @@ import OmFileFormat
 /// A geographic subset of a Gaussian grid backed by a flat 1D array.
 ///
 /// Local array indices `(0..<nx)` enumerate points north-to-south, then west-to-east within each
-/// latitude line — the same order as the subset extracted from the full grid.
+/// latitude line - the same order as the subset extracted from the full grid.
 struct GaussianGridArea: Gridable {
     typealias SliceType = GaussianGridAreaSlice
 
@@ -141,10 +141,10 @@ struct GaussianGridArea: Gridable {
         return GaussianGridAreaSlice(area: self, bb: bb)
     }
 
-    /// Get a 3×3 list of local indices surrounding a coordinate.
+    /// Get a 3x3 list of local indices surrounding a coordinate.
     /// Grid points are in strictly rising order, allowing optimised range reads.
-    /// Points outside the area bounds are stored as −1.
-    /// `minDistanceIndex` is −1 if no surrounding point lies within the area.
+    /// Points outside the area bounds are stored as -1.
+    /// `minDistanceIndex` is -1 if no surrounding point lies within the area.
     func getSurroundingGridpoints(lat: Float, lon: Float) -> (gridpoints: InlineArray<9, Int>, distances: InlineArray<9, Float>, minDistanceIndex: Int) {
         let latitudeLines = type.latitudeLines
         let dy = Float(180) / (2 * Float(latitudeLines) + 0.5)
@@ -194,7 +194,7 @@ struct GaussianGridArea: Gridable {
     /// Read elevation for surrounding grid points as returned from `getSurroundingGridpoints`.
     /// `onlyMinDistanceIndex`: only read elevation to cover this index. Therefore only a single read is performed.
     /// `firstPass` if false, only read data if `onlyMinDistanceIndex` does not match.
-    /// Entries with a −1 gridpoint index (outside the area) are skipped.
+    /// Entries with a -1 gridpoint index (outside the area) are skipped.
     func getSurroundingElevation(gridpoints: InlineArray<9, Int>, elevation: inout InlineArray<9, Float>, onlyMinDistanceIndex: Int, firstPass: Bool, elevationFile: any OmFileReaderArrayProtocol<Float>) async throws {
         var start = 0
         /// Read grid elevation from list of gridpoints that might be consecutive.

--- a/Sources/App/EcmwfSeas/EcmwfSeasVariable.swift
+++ b/Sources/App/EcmwfSeas/EcmwfSeasVariable.swift
@@ -10,7 +10,7 @@ struct EcmwfSeasVariableAny: Hashable {
     let variable: any EcmwfSeasVariable
     
     static func == (lhs: EcmwfSeasVariableAny, rhs: EcmwfSeasVariableAny) -> Bool {
-        lhs.hashValue == rhs.hashValue
+        lhs.variable == rhs.variable
     }
     
     var hashValue: Int {

--- a/Sources/App/EcmwfSeas/EcmwfSeasVariable.swift
+++ b/Sources/App/EcmwfSeas/EcmwfSeasVariable.swift
@@ -10,7 +10,7 @@ struct EcmwfSeasVariableAny: Hashable {
     let variable: any EcmwfSeasVariable
     
     static func == (lhs: EcmwfSeasVariableAny, rhs: EcmwfSeasVariableAny) -> Bool {
-        lhs.variable == rhs.variable
+        AnyHashable(lhs.variable) == AnyHashable(rhs.variable)
     }
     
     var hashValue: Int {

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -295,7 +295,7 @@ fileprivate final actor RemoteFileManagerCache {
     struct AnyRemoteFileManageable: Sendable, Hashable {
         let key: (any RemoteFileManageable)
         static func == (lhs: Self, rhs: Self) -> Bool {
-            return lhs.key.hashValue == rhs.key.hashValue
+            return lhs.key == rhs.key
         }
         
         func hash(into hasher: inout Hasher) {

--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -295,7 +295,7 @@ fileprivate final actor RemoteFileManagerCache {
     struct AnyRemoteFileManageable: Sendable, Hashable {
         let key: (any RemoteFileManageable)
         static func == (lhs: Self, rhs: Self) -> Bool {
-            return lhs.key == rhs.key
+            return AnyHashable(lhs.key) == AnyHashable(rhs.key)
         }
         
         func hash(into hasher: inout Hasher) {

--- a/Sources/App/Helper/Soil.swift
+++ b/Sources/App/Helper/Soil.swift
@@ -15,7 +15,7 @@ enum SoilTypeEra5: Int {
     case organic = 6
     case loamy = 7
 
-    /// Saturation, `θsat` in `m3^m−3`
+    /// Saturation, `θsat` in `m3^m-3`
     var saturation: Float {
         switch self {
         case .coarse:
@@ -35,7 +35,7 @@ enum SoilTypeEra5: Int {
         }
     }
 
-    /// Field Capacity, `θcap` in `m3^m−3`
+    /// Field Capacity, `θcap` in `m3^m-3`
     var fieldCapacity: Float {
         switch self {
         case .coarse:
@@ -55,7 +55,7 @@ enum SoilTypeEra5: Int {
         }
     }
 
-    /// Permanent wilting point, `θpwp` in `m3^m−3`
+    /// Permanent wilting point, `θpwp` in `m3^m-3`
     var permanentWiltingPoint: Float {
         switch self {
         case .coarse:
@@ -75,7 +75,7 @@ enum SoilTypeEra5: Int {
         }
     }
 
-    /// Residual Moisture , `θres` in `m3^m−3`
+    /// Residual Moisture , `θres` in `m3^m-3`
     var residualMoisture: Float {
         switch self {
         case .coarse:
@@ -85,7 +85,7 @@ enum SoilTypeEra5: Int {
         }
     }
 
-    /// Plant available soil moisture `θcap − θpwp` in `m3^m−3`
+    /// Plant available soil moisture `θcap - θpwp` in `m3^m-3`
     var plantAvailableSoilMoisture: Float {
         return fieldCapacity - permanentWiltingPoint
     }


### PR DESCRIPTION
Two spots in type-erased Hashable wrappers were using .hashValue for == instead of delegating to the concrete type's proper equality. Hash collisions, however rare and would cause false cache hits.


Fixed both to wrap in AnyHashable, which checks runtime type identity then delegates to the concrete type's Equatable:


- AnyRemoteFileManageable in RemoteOmFileManager.swift ----> key.hashValue == key.hashValue → AnyHashable(key) == AnyHashable(key)

- EcmwfSeasVariableAny in EcmwfSeasVariable.swift ----> same pattern, variable.hashValue → AnyHashable(variable)


The existing hash(into:) methods already open these same existentials via hasher.combine(...), so AnyHashable keeps things consistent.

Also dropped in a CONTRIBUTING.md so future PRs don't guess at what the maintainer expects.