### PR TITLE
fix: fallback to nearest cell selection if elevation is nan

### DIFF
--- a/Sources/App/Domains/Gridable.swift
+++ b/Sources/App/Domains/Gridable.swift
@@ -95,6 +95,10 @@ extension Gridable {
 
         switch mode {
         case .land:
+            guard !elevation.isNaN else {
+                // if no elevation is given, we cannot do terrain optimised matching, so just return nearest
+                return try await findPointNearest(lat: lat, lon: lon, elevationFile: elevationFile)
+            }
             return try await findPointTerrainOptimised(lat: lat, lon: lon, elevation: elevation, elevationFile: elevationFile)
         case .sea:
             return try await findPointInSea(lat: lat, lon: lon, elevationFile: elevationFile)
@@ -217,11 +221,6 @@ extension Gridable {
 
     /// Analyse 3x3 locations around the desired coordinate and return the best elevation match
     func findPointTerrainOptimised(lat: Float, lon: Float, elevation: Float, elevationFile: any OmFileReaderArrayProtocol<Float>) async throws -> (gridpoint: Int, gridElevation: ElevationOrSea)? {
-        guard !elevation.isNaN else {
-            // if no elevation is given, we cannot do terrain optimised matching, so just return nearest
-            return try await findPointNearest(lat: lat, lon: lon, elevationFile: elevationFile)
-        }
-        
         guard let center = findPoint(lat: lat, lon: lon) else {
             return nil
         }

--- a/Sources/App/Domains/Gridable.swift
+++ b/Sources/App/Domains/Gridable.swift
@@ -217,6 +217,11 @@ extension Gridable {
 
     /// Analyse 3x3 locations around the desired coordinate and return the best elevation match
     func findPointTerrainOptimised(lat: Float, lon: Float, elevation: Float, elevationFile: any OmFileReaderArrayProtocol<Float>) async throws -> (gridpoint: Int, gridElevation: ElevationOrSea)? {
+        guard !elevation.isNaN else {
+            // if no elevation is given, we cannot do terrain optimised matching, so just return nearest
+            return try await findPointNearest(lat: lat, lon: lon, elevationFile: elevationFile)
+        }
+        
         guard let center = findPoint(lat: lat, lon: lon) else {
             return nil
         }


### PR DESCRIPTION
It is unnecessary to iterate over neighboring grid cells, if elevation corrections are disabled via `elevation=nan`.