### PR TITLE
feat: option to generate data_run for IFS after only a certain amount of forecast hours

### DIFF
--- a/Sources/App/EcmwfEcpds/EcmwfEcpdsDownloader.swift
+++ b/Sources/App/EcmwfEcpds/EcmwfEcpdsDownloader.swift
@@ -151,7 +151,7 @@ struct DownloadEcmwfEcpdsCommand: AsyncCommand {
     }
     
     /// Download multiple runs from ECMWF MARS archives, convert them and upload to S3
-    func downloadMars(application: Application, domain: EcmwfEcpdsDomain, runs: TimerangeDt, concurrent: Int, key: String, email: String, uploadS3Bucket: String?, params: String?) async throws {
+    func downloadMars(application: Application, domain: EcmwfEcpdsDomain, runs: TimerangeDt, concurrent: Int, key: String, email: String, uploadS3Bucket: String?, params paramsOverwrite: String?) async throws {
         let logger = application.logger
         let dtSeconds = domain.dtSeconds
         
@@ -204,7 +204,7 @@ struct DownloadEcmwfEcpdsCommand: AsyncCommand {
             let paramsMain = "\(paramsSide)/rsn/sd/98.174/ocu/ocv/145.151/130.151/34.128"
             // "100u/100v/10fg/10u/10v/200u/200v/2d/2t/cp/fal/fdir/fsr/hcc/kx/lcc/mcc/mn2t/msl/mucape/mucin/mx2t/pev/ptype/ro/rsn/sd/sf/skt/ssrd/stl1/stl2/stl3/stl4/swvl1/swvl2/swvl3/swvl4/tcc/tcwv/tp/20.3/blh/98.174/ocu/ocv/145.151/130.151/34.128"
             
-            let params = params ?? (isMainRun ? paramsMain : paramsSide)
+            let params = paramsOverwrite ?? (isMainRun ? paramsMain : paramsSide)
             
             logger.info("Downloading run \(run.iso8601_YYYY_MM_dd_HH_mm)")
             
@@ -281,6 +281,10 @@ struct DownloadEcmwfEcpdsCommand: AsyncCommand {
                             while true {
                                 let lastStep = await deaverager.lastStep(variable, member) ?? 0
                                 let step = lastStep + (lastStep >= 144 ? 6 : lastStep >= 90 ? 3 : 1)
+                                
+                                /// Delta time seconds considering irregular timesteps
+                                let dtSeconds = (step - lastStep) * 3600
+                                
                                 let time = run.add(hours: step)
                                 guard var data = await inMemoryAccumulated.remove(variable: variable, timestamp: time, member: member) else {
                                     break
@@ -300,8 +304,8 @@ struct DownloadEcmwfEcpdsCommand: AsyncCommand {
                             return
                         }
                         
-                        // Scaling before compression with scalefactor
-                        if let fma = variable.multiplyAdd(dtSeconds: dtSeconds) {
+                        // Scaling before compression with scalefactor. Note: does not set dtSeconds because aggregated data is processed above
+                        if let fma = variable.multiplyAdd(dtSeconds: 0) {
                             grib2d.array.data.multiplyAdd(multiply: fma.multiply, add: fma.add)
                         }
                         
@@ -325,7 +329,7 @@ struct DownloadEcmwfEcpdsCommand: AsyncCommand {
                     if stepsArray.last == steps {
                         /// Convert to time-series and upload to AWS
                         let handles = try await writer.finalise(completed: true, validTimes: nil, uploadS3Bucket: nil)
-                        try await GenericVariableHandle.convert(logger: logger, domain: domain, createNetcdf: false, run: run, handles: handles, concurrent: concurrent, writeUpdateJson: false, uploadS3Bucket: uploadS3Bucket, uploadS3OnlyProbabilities: false, generateTimeSeries: false)
+                        try await GenericVariableHandle.convert(logger: logger, domain: domain, createNetcdf: false, run: run, handles: handles, concurrent: concurrent, writeUpdateJson: false, uploadS3Bucket: uploadS3Bucket, uploadS3OnlyProbabilities: false, generateTimeSeries: false, fullRunSkipMeta: paramsOverwrite != nil)
 
                         if let directory = OpenMeteo.dataRunDirectory, uploadS3Bucket != nil {
                             // Delete run directory after S3 upload

--- a/Sources/App/EcmwfEcpds/EcmwfEcpdsDownloader.swift
+++ b/Sources/App/EcmwfEcpds/EcmwfEcpdsDownloader.swift
@@ -153,7 +153,6 @@ struct DownloadEcmwfEcpdsCommand: AsyncCommand {
     /// Download multiple runs from ECMWF MARS archives, convert them and upload to S3
     func downloadMars(application: Application, domain: EcmwfEcpdsDomain, runs: TimerangeDt, concurrent: Int, key: String, email: String, uploadS3Bucket: String?, params paramsOverwrite: String?) async throws {
         let logger = application.logger
-        let dtSeconds = domain.dtSeconds
         
         struct EcmwfQuery: Encodable {
             let `class` = "od"
@@ -295,7 +294,7 @@ struct DownloadEcmwfEcpdsCommand: AsyncCommand {
                                 }
                                 // Scaling before compression with scalefactor
                                 if let fma = variable.multiplyAdd(dtSeconds: dtSeconds) {
-                                    grib2d.array.data.multiplyAdd(multiply: fma.multiply, add: fma.add)
+                                    data.data.multiplyAdd(multiply: fma.multiply, add: fma.add)
                                 }
                                 let count = await inMemoryAccumulated.data.count
                                 logger.info("Writing accumulated variable \(variable) member \(member) unit=\(unit) timestamp \(time.format_YYYYMMddHH) backlog \(count)")

--- a/Sources/App/EcmwfEcpds/EcmwfEcpdsDownloader.swift
+++ b/Sources/App/EcmwfEcpds/EcmwfEcpdsDownloader.swift
@@ -43,6 +43,9 @@ struct DownloadEcmwfEcpdsCommand: AsyncCommand {
         
         @Option(name: "params", help: "ECMWF params list for downloading")
         var downloadParams: String?
+        
+        @Option(name: "short-cut-off-hour", help: "Forecast hour which to generate a short cut off and upload data_run earlier to S3")
+        var shortCutOff: String?
 
     }
 
@@ -76,9 +79,10 @@ struct DownloadEcmwfEcpdsCommand: AsyncCommand {
         }
 
         logger.info("Downloading domain ECMWF run '\(run.iso8601_YYYY_MM_dd_HH_mm)'")
+        let shortCutOff = signature.shortCutOff.map(Int.init) ?? nil
 
         try await downloadEcmwfElevation(application: context.application, domain: domain, run: run)
-        let handles = try await downloadEcmwf(application: context.application, domain: domain, server: server, run: run, concurrent: nConcurrent, maxForecastHour: signature.maxForecastHour, uploadS3Bucket: signature.uploadS3BucketSpatial)
+        let handles = try await downloadEcmwf(application: context.application, domain: domain, server: server, run: run, concurrent: nConcurrent, maxForecastHour: signature.maxForecastHour, uploadS3Bucket: signature.uploadS3BucketSpatial, shortCutOffHour: shortCutOff)
         try await GenericVariableHandle.convert(logger: logger, domain: domain, createNetcdf: signature.createNetcdf, run: run, handles: handles, concurrent: nConcurrent, writeUpdateJson: true, uploadS3Bucket: signature.uploadS3Bucket, uploadS3OnlyProbabilities: signature.uploadS3OnlyProbabilities, generateTimeSeries: !signature.skipTimeseries)
     }
 
@@ -340,7 +344,7 @@ struct DownloadEcmwfEcpdsCommand: AsyncCommand {
     }
 
     /// Download ECMWF ifs open data
-    func downloadEcmwf(application: Application, domain: EcmwfEcpdsDomain, server: String, run: Timestamp, concurrent: Int, maxForecastHour: Int?, uploadS3Bucket: String?) async throws -> [GenericVariableHandle] {
+    func downloadEcmwf(application: Application, domain: EcmwfEcpdsDomain, server: String, run: Timestamp, concurrent: Int, maxForecastHour: Int?, uploadS3Bucket: String?, shortCutOffHour: Int?) async throws -> [GenericVariableHandle] {
         if domain == .wam {
             return try await downloadEcmwfWam(application: application, domain: domain, server: server, run: run, concurrent: concurrent, maxForecastHour: maxForecastHour, uploadS3Bucket: uploadS3Bucket)
         }
@@ -361,8 +365,13 @@ struct DownloadEcmwfEcpdsCommand: AsyncCommand {
         let storeOnDisk = true
         /// Run AWS upload in the background
         var uploadTask: Task<(), any Error>? = nil
+        
+        /// Run AWS upload in the background
+        var uploadTaskShortCutOff: Task<(), any Error>? = nil
+        
+        var handles = [GenericVariableHandle]()
 
-        let handles: [GenericVariableHandle] = try await timestamps.enumerated().asyncFlatMap { (i,timestamp) -> [GenericVariableHandle] in
+        for (i,timestamp) in timestamps.enumerated() {
             let hour = (timestamp.timeIntervalSince1970 - run.timeIntervalSince1970) / 3600
             let time = DispatchTime.now()
             logger.info("Downloading hour \(hour) [Time \(Timestamp.now().iso8601_YYYY_MM_dd_HH_mm)]")
@@ -465,14 +474,22 @@ struct DownloadEcmwfEcpdsCommand: AsyncCommand {
             logger.info("Completed hour \(hour) [Time \(Timestamp.now().iso8601_YYYY_MM_dd_HH_mm), elapsed \(time.timeElapsedPretty())]")
             
             let completed = i == timestamps.count - 1            
-            let handles = try await writer.finalise()
+            handles.append(contentsOf: try await writer.finalise())
             try await uploadTask?.value
             uploadTask = Task {
                 try await writer.writeMetaAndAWSUpload(completed: completed, validTimes: Array(timestamps[0...i]), uploadS3Bucket: uploadS3Bucket)
             }
-            return handles
+            
+            if hour == shortCutOffHour {
+                let handles = handles
+                uploadTaskShortCutOff = Task {
+                    try await GenericVariableHandle.convert(logger: logger, domain: domain, createNetcdf: false, run: run, handles: handles, concurrent: concurrent, writeUpdateJson: true, uploadS3Bucket: uploadS3Bucket, uploadS3OnlyProbabilities: false, generateFullRun: true, generateTimeSeries: false)
+                }
+            }
+            
         }
         try await uploadTask?.value
+        try await uploadTaskShortCutOff?.value
         await curl.printStatistics()
         return handles
     }

--- a/Sources/App/Helper/DomainRegistry.swift
+++ b/Sources/App/Helper/DomainRegistry.swift
@@ -661,7 +661,7 @@ extension DomainRegistry {
     }
     
     /// Upload time-series optimised per RUN files to S3 `/data_run/<domain>/<run>/<variable>.om`
-    func syncToS3PerRun(logger: Logger, bucket: String, run: Timestamp) throws {
+    func syncToS3PerRun(logger: Logger, bucket: String, run: Timestamp, skipMeta: Bool) throws {
         let dir = rawValue
         guard let directory = OpenMeteo.dataRunDirectory else {
             return
@@ -681,11 +681,13 @@ extension DomainRegistry {
                 exclude: ["*~", "meta.json"],
                 profile: profile
             )
-            try Process.awsCopy(
-                src: "\(src)meta.json",
-                dest: "\(dest)meta.json",
-                profile: profile
-            )
+            if !skipMeta {
+                try Process.awsCopy(
+                    src: "\(src)meta.json",
+                    dest: "\(dest)meta.json",
+                    profile: profile
+                )
+            }
             // Additional sync to make sure everything is synced
             try Process.awsSync(
                 src: "\(directory)\(dir)/",

--- a/Sources/App/Helper/DomainRegistry.swift
+++ b/Sources/App/Helper/DomainRegistry.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AsyncHTTPClient
 import Logging
 
 /**
@@ -533,6 +534,15 @@ enum DomainRegistry: String, CaseIterable {
         case .ukmo_uk_ensemble_mean_2km:
             return UkmoDomain.uk_ensemble_mean_2km
         }
+    }
+    
+    /// Get meta information of a specific run
+    func getFullRunMeta(client: HTTPClient?, logger: Logger, run: Timestamp) async throws -> FullRunMetaJson? {
+        return try await RemoteFileManager.instance.get(
+            file: FullRunMetaFile.run(self, run),
+            client: client,
+            logger: logger
+        )
     }
 }
 

--- a/Sources/App/Helper/File/FullRunMetaJson.swift
+++ b/Sources/App/Helper/File/FullRunMetaJson.swift
@@ -51,8 +51,8 @@ enum FullRunMetaFile: RemoteFileManageableJson {
         switch self {
         case .latest(_):
             return 30
-        case .run(_, _):
-            return modificationTime == nil ? 30 : 24*3600
+        case .run(_, let run):
+            return modificationTime == nil ? 30 : run > now.subtract(hours: 24) ? 5*60 : 24*3600
         }
     }
     

--- a/Sources/App/Helper/ForecastapiQuery.swift
+++ b/Sources/App/Helper/ForecastapiQuery.swift
@@ -554,6 +554,7 @@ enum ForecastApiError: Error {
     case latitudeAndLongitudeMaximum(max: Int)
     case latitudeAndLongitudeCountMustBeTheSame
     case coordinatesAndTimezoneCountMustBeTheSame
+    case modelRunUnavailable(model: DomainRegistry, run: Timestamp)
     case locationIdCountMustBeTheSame
     case startAndEndDateCountMustBeTheSame
     case coordinatesAndStartEndDatesCountMustBeTheSame
@@ -617,6 +618,8 @@ extension ForecastApiError: AbortError {
             return "Parameter '\(name)' is required"
         case .parameterMustNotBeSet(let name):
             return "Parameter '\(name)' must not be set"
+        case .modelRunUnavailable(model: let model, run: let run):
+            return "The requested model run is not available. Model: \(model), run: \(run.iso8601_YYYY_MM_dd_HH_mmZ)"
         }
     }
 }

--- a/Sources/App/Helper/OmFileSplitter.swift
+++ b/Sources/App/Helper/OmFileSplitter.swift
@@ -84,6 +84,9 @@ struct OmFileSplitter {
         
         /// Read individual runs from dedicated database
         if let run = time.run {
+            guard try await domain.getFullRunMeta(client: httpClient, logger: logger, run: run.toTimestamp()) != nil else {
+                throw ForecastApiError.modelRunUnavailable(model: domain, run: run.toTimestamp())
+            }
             let file = OmFileType.run(domain: domain, variable: variable, run: run)
             try await RemoteFileManager.instance.with(file: file, client: httpClient, logger: logger) { (reader, timestamps, _) in
                 guard let timestamps else {
@@ -185,6 +188,9 @@ struct OmFileSplitter {
         
         /// Read individual runs from dedicated database
         if let run = time.run {
+            guard try await domain.getFullRunMeta(client: httpClient, logger: logger, run: run.toTimestamp()) != nil else {
+                throw ForecastApiError.modelRunUnavailable(model: domain, run: run.toTimestamp())
+            }
             let file = OmFileType.run(domain: domain, variable: variable.omFileName.file, run: run)
             try await RemoteFileManager.instance.with(file: file, client: httpClient, logger: logger) { (reader, timestamps, _) in
                 guard let timestamps else {

--- a/Sources/App/Helper/Writer/GenericVariableHandle.swift
+++ b/Sources/App/Helper/Writer/GenericVariableHandle.swift
@@ -36,7 +36,8 @@ struct GenericVariableHandle: Sendable {
 
     /// Process concurrently
     /// Note: domain is now ignored, because GenericVariableHandle can now domain property. Makes it easier for ensemble mean calculation
-    static func convert(logger: Logger, domain domainIgnored: GenericDomain, createNetcdf: Bool, run: Timestamp?, handles: [Self], concurrent: Int, writeUpdateJson: Bool, uploadS3Bucket: String?, uploadS3OnlyProbabilities: Bool, compression: OmCompressionType = .pfor_delta2d_int16, generateFullRun: Bool = true, generateTimeSeries: Bool = true) async throws {
+    /// If `fullRunSkipMeta` do not generate meta.json for each run
+    static func convert(logger: Logger, domain domainIgnored: GenericDomain, createNetcdf: Bool, run: Timestamp?, handles: [Self], concurrent: Int, writeUpdateJson: Bool, uploadS3Bucket: String?, uploadS3OnlyProbabilities: Bool, compression: OmCompressionType = .pfor_delta2d_int16, generateFullRun: Bool = true, generateTimeSeries: Bool = true, fullRunSkipMeta: Bool = false) async throws {
         for (_, handles) in handles.groupedPreservedOrder(by: {"\($0.domain)"}) {
             let domain = handles[0].domain
             
@@ -116,14 +117,15 @@ struct GenericVariableHandle: Sendable {
             if generateFullRun, OpenMeteo.dataRunDirectory != nil, let run, run.hour % 3 == 0 {
                 logger.info("Generate full run data [Time \(Timestamp.now().iso8601_YYYY_MM_dd_HH_mm)]")
                 let startTimeFullRun = DispatchTime.now()
-                try await generateFullRunData(logger: logger, domain: domain, run: run, handles: handles, concurrent: concurrent, compression: compression)
+                try await generateFullRunData(logger: logger, domain: domain, run: run, handles: handles, concurrent: concurrent, compression: compression, skipMeta: fullRunSkipMeta)
                 logger.info("Full run convert in \(startTimeFullRun.timeElapsedPretty()) [Time \(Timestamp.now().iso8601_YYYY_MM_dd_HH_mm)]")
                 
                 if let uploadS3Bucket {
                     try domain.domainRegistry.syncToS3PerRun(
                         logger: logger,
                         bucket: uploadS3Bucket,
-                        run:run
+                        run:run,
+                        skipMeta: fullRunSkipMeta
                     )
                 }
             }
@@ -131,7 +133,7 @@ struct GenericVariableHandle: Sendable {
     }
     
     /// Generate time-series optimised files for each variable per run. `/data_run/<domain>/<run>/<variable>.om`
-    static func generateFullRunData(logger: Logger, domain: GenericDomain, run: Timestamp, handles: [Self], concurrent: Int, compression: OmCompressionType) async throws {
+    static func generateFullRunData(logger: Logger, domain: GenericDomain, run: Timestamp, handles: [Self], concurrent: Int, compression: OmCompressionType, skipMeta: Bool) async throws {
         let grid = domain.grid
         let nx = grid.nx
         let ny = grid.ny
@@ -224,7 +226,9 @@ struct GenericVariableHandle: Sendable {
             progress.finish()
         }
         let validTimes = handles.flatMap({$0.time.map({$0})}).uniqued().sorted()
-        try FullRunMetaJson.write(domain: domain, run: run, validTimes: validTimes)
+        if !skipMeta {
+            try FullRunMetaJson.write(domain: domain, run: run, validTimes: validTimes)
+        }
     }
 
     private static func convertConcurrent(logger: Logger, domain: GenericDomain, createNetcdf: Bool, run: Timestamp?, handles: [Self], onlyGeneratePreviousDays: Bool, concurrent: Int, compression: OmCompressionType) async throws {

--- a/Sources/App/UKMO/UkmoVariable.swift
+++ b/Sources/App/UKMO/UkmoVariable.swift
@@ -210,6 +210,14 @@ enum UkmoSurfaceVariable: String, CaseIterable, UkmoVariableDownloadable, Generi
                 break
             }
         case .global_ensemble_20km:
+            if forecastHour == 0 {
+                switch self {
+                case .precipitation, .rain, .hail, .snowfall_water_equivalent, .showers:
+                    return nil
+                default:
+                    break
+                }
+            }
             switch self {
             case .temperature_2m:
                 return "temperature_at_screen_level"
@@ -258,6 +266,14 @@ enum UkmoSurfaceVariable: String, CaseIterable, UkmoVariableDownloadable, Generi
                 break
             }
         case .uk_ensemble_2km:
+            if forecastHour == 0 {
+                switch self {
+                case .precipitation, .rain, .hail, .snowfall_water_equivalent, .showers, .shortwave_radiation, .direct_radiation, .wind_gusts_10m, .cape, .cloud_cover_low, .cloud_cover_mid, .cloud_cover_high, .surface_temperature, .snow_depth_water_equivalent:
+                    return nil
+                default:
+                    break
+                }
+            }
             switch self {
             case .temperature_2m:
                 return "temperature_at_screen_level"
@@ -275,8 +291,8 @@ enum UkmoSurfaceVariable: String, CaseIterable, UkmoVariableDownloadable, Generi
                 return "relative_humidity_at_screen_level"
             case .precipitation:
                 return "precipitation_accumulation-PT01H"
-            case .showers:
-                return "rainfall_accumulation_from_convection-PT01H"
+            case .rain:
+                return "rainfall_accumulation-PT01H"
             case .wind_gusts_10m:
                 return "wind_gust_at_10m"
             case .pressure_msl:
@@ -893,6 +909,7 @@ enum UkmoUkvEnsembleVariable: String, CaseIterable, GenericVariable {
 //    case precipitation
     case snowfall_water_equivalent
     case precipitation
+    case rain
 //    case hail
 //    case showers
 //    case freezing_level_height
@@ -911,7 +928,7 @@ enum UkmoUkvEnsembleVariable: String, CaseIterable, GenericVariable {
     var storePreviousForecast: Bool {
         switch self {
         case .temperature_2m, .relative_humidity_2m: return true
-        case .precipitation, .snowfall_water_equivalent: return true
+        case .precipitation, .snowfall_water_equivalent, .rain: return true
         case .wind_speed_10m, .wind_direction_10m: return true
         case .pressure_msl: return true
         case .cloud_cover: return true
@@ -941,7 +958,7 @@ enum UkmoUkvEnsembleVariable: String, CaseIterable, GenericVariable {
             return 1
         case .relative_humidity_2m:
             return 1
-        case .precipitation:
+        case .precipitation ,.rain:
             return 10
         case .wind_gusts_10m:
             return 10
@@ -982,7 +999,7 @@ enum UkmoUkvEnsembleVariable: String, CaseIterable, GenericVariable {
             return .hermite(bounds: 0...100)
         case .wind_speed_10m:
             return .hermite(bounds: 0...10e9)
-        case .precipitation:
+        case .precipitation ,.rain:
             return .backwards_sum
         case .snowfall_water_equivalent, .snow_depth_water_equivalent:
             return .backwards_sum
@@ -1013,7 +1030,7 @@ enum UkmoUkvEnsembleVariable: String, CaseIterable, GenericVariable {
             return .percentage
         case .relative_humidity_2m:
             return .percentage
-        case .precipitation, .snow_depth_water_equivalent:
+        case .precipitation, .snow_depth_water_equivalent, .rain:
             return .millimetre
         case .wind_gusts_10m:
             return .metrePerSecond


### PR DESCRIPTION
ECMWF IFS HRES is now processed after 3 days (72 hours) of forecast and uploaded to the [single runs API](https://open-meteo.com/en/docs/single-runs-api). Because Open-Meteo is also using the PRE-SCHEDULE delivery option from ECMWF, the IFS forecast is available with very low delay. This is relevant for day-ahead energy forecasting where latency matters