### PR TITLE
fix: Lock contention in ConcurrencyGroupLimiter

### DIFF
--- a/Sources/App/Dem/DemController.swift
+++ b/Sources/App/Dem/DemController.swift
@@ -41,7 +41,7 @@ fileprivate struct DemResponder: ForecastapiResponder {
         return Float(nVariablesModels ?? latitude.count)
     }
 
-    func response(format: ForecastResultFormatWithOptions?, concurrencySlot: Int?, prefetch: Bool) async throws -> Response {
+    func response(format: ForecastResultFormatWithOptions?, concurrencySlot: Int?, prefetch: Bool, logger: Logger) async throws -> Response {
         let elevation = try await zip(latitude, longitude).asyncMap { latitude, longitude in
             try await Dem90.read(lat: latitude, lon: longitude, logger: logger, httpClient: httpClient)
         }

--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffersWriter.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffersWriter.swift
@@ -7,11 +7,11 @@ extension ForecastapiResult {
     /// Convert data into a FlatBuffers scheme far fast binary encoding and transfer
     /// Each `ForecastapiResult` is converted indifuavually into an flatbuffer message -> very long time-VariableWithValues require a lot of memory
     /// Data is using `size prefixed` flatbuffers to allow streaming of multiple messages for multiple locations
-    func toFlatbuffersResponse(fixedGenerationTime: Double?, concurrencySlot: Int? = nil) throws -> Response {
+    func toFlatbuffersResponse(fixedGenerationTime: Double?, concurrencySlot: Int?, logger: Logger) throws -> Response {
         // First excution outside stream, to capture potential errors better
         // var first = try self.first?()
         let response = Response(body: .init(asyncStream: { writer in
-            try await writer.submit(concurrencySlot: concurrencySlot) {
+            try await writer.submit(concurrencySlot: concurrencySlot, logger: logger) {
                 // TODO: Zero-copy for flatbuffer to NIO bytebuffer conversion. Probably writing an optimised flatbuffer encoder would be better.
                 // TODO: Estimate initial buffer size
                 let initialSize = Int32(4096) // Int32(((first?.estimatedFlatbufferSize ?? 4096)/4096+1)*4096)

--- a/Sources/App/Helper/NumberExtensions.swift
+++ b/Sources/App/Helper/NumberExtensions.swift
@@ -17,6 +17,38 @@ public extension Float {
     }
 }
 
+private let _pow10: [Int] = [1, 10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000]
+
+extension Double {
+    /// Format to a fixed number of decimal places without Foundation/printf overhead.
+    func formatted(decimals: Int) -> String {
+        guard decimals > 0 else {
+            return String(Int(self.rounded()))
+        }
+        let factor = _pow10[decimals]
+        let abs_val = self < 0 ? -self : self
+        let scaled = Int((abs_val * Double(factor)).rounded())
+        let intPart = scaled / factor
+        let fracPart = scaled % factor
+        return self < 0 ? "-\(intPart).\(fracPart.zeroPadded(len: decimals))" : "\(intPart).\(fracPart.zeroPadded(len: decimals))"
+    }
+}
+
+extension Float {
+    /// Format to a fixed number of decimal places without Foundation/printf overhead.
+    func formatted(decimals: Int) -> String {
+        guard decimals > 0 else {
+            return String(Int(self.rounded()))
+        }
+        let factor = _pow10[decimals]
+        let abs_val = self < 0 ? -self : self
+        let scaled = Int((abs_val * Float(factor)).rounded())
+        let intPart = scaled / factor
+        let fracPart = scaled % factor
+        return self < 0 ? "-\(intPart).\(fracPart.zeroPadded(len: decimals))" : "\(intPart).\(fracPart.zeroPadded(len: decimals))"
+    }
+}
+
 extension Int {
     /// Integer division, but round up instead of floor
     @inlinable func divideRoundedUp(divisor: Int) -> Int {
@@ -24,7 +56,10 @@ extension Int {
     }
 
     func zeroPadded(len: Int) -> String {
-        return String(format: "%0\(len)d", self)
+        let s = String(self)
+        let pad = len - s.count
+        guard pad > 0 else { return s }
+        return String(repeating: "0", count: pad) + s
     }
 
     /// Performs mathematical module keeping the result positive

--- a/Sources/App/Helper/Vapor/ApiKeyManager.swift
+++ b/Sources/App/Helper/Vapor/ApiKeyManager.swift
@@ -83,7 +83,7 @@ public final actor ApiKeyManager {
         guard let apiKeysPath = Environment.get("API_APIKEYS_PATH") else {
             return
         }
-        let concurrencyLimit = apiConcurrencyLimiter.stats()
+        let concurrencyLimit = await ConcurrencyGroupLimiter.instance.stats()
         let logger = application.logger
         if (0..<10).contains(Timestamp.now().second) {
             let usage = await ApiKeyManager.instance.getUsage()
@@ -180,41 +180,44 @@ extension Request {
             } else {
                 slot = address.rateLimitSlot
             }
-            try await apiConcurrencyLimiter.wait(slot: slot, maxConcurrent: 1, maxConcurrentHard: 5)
-            defer {
-                apiConcurrencyLimiter.release(slot: slot)
-            }
             if isCFWorker {
                 try await RateLimiter.instance.check(int64: slot)
             } else {
                 try await RateLimiter.instance.check(address: address)
             }
-            
-            let params = try parseApiParams()
-            guard params.apikey == nil && headers.contains(name: "X-Api-Key") == false else {
-                guard self.method != .POST else {
-                    throw ForecastApiError.generic(message: "Please use the customer- prefixed URL for POST requests")
+            try await ConcurrencyGroupLimiter.instance.wait(slot: slot, maxConcurrent: 1, maxConcurrentHard: 5)
+            let response: Response
+            do {
+                let params = try parseApiParams()
+                guard params.apikey == nil && headers.contains(name: "X-Api-Key") == false else {
+                    guard self.method != .POST else {
+                        throw ForecastApiError.generic(message: "Please use the customer- prefixed URL for POST requests")
+                    }
+                    let url = "\(scheme)://customer-\(host)/\(url.string)"
+                    guard url.count < 3500 else {
+                        throw ForecastApiError.generic(message: "Your API URL is too long for automatic redirection from the open-access API to the commercial endpoints. Instead, use the 'customer-' prefixed URLs directly. Refer to the API documentation and select 'Usage -> Commercial' to obtain the correct customer URLs.")
+                    }
+                    return self.redirect(to: url)
                 }
-                let url = "\(scheme)://customer-\(host)/\(url.string)"
-                guard url.count < 3500 else {
-                    throw ForecastApiError.generic(message: "Your API URL is too long for automatic redirection from the open-access API to the commercial endpoints. Instead, use the 'customer-' prefixed URLs directly. Refer to the API documentation and select 'Usage -> Commercial' to obtain the correct customer URLs.")
+                let responder = try await fn(host, params)
+                if responder.numberOfLocations > OpenMeteo.numberOfLocationsMaximum {
+                    throw ForecastApiError.generic(message: "Only up to \(OpenMeteo.numberOfLocationsMaximum) locations can be requested at once")
                 }
-                return self.redirect(to: url)
+                let weight = responder.calculateQueryWeight(nVariablesModels: nil)
+                guard weight <= RateLimiter.limitHourly else {
+                    throw ForecastApiError.generic(message: "Your API call requests too much data. Please reduce the number of variables, locations and/or weather models.")
+                }
+                response = try await responder.response(format: params.formatWithOptions, concurrencySlot: slot, prefetch: weight < 10)
+                if isCFWorker {
+                    await RateLimiter.instance.increment(int64: slot, count: weight)
+                } else {
+                    await RateLimiter.instance.increment(address: address, count: weight)
+                }
+            } catch {
+                await ConcurrencyGroupLimiter.instance.release(slot: slot)
+                throw error
             }
-            let responder = try await fn(host, params)
-            if responder.numberOfLocations > OpenMeteo.numberOfLocationsMaximum {
-                throw ForecastApiError.generic(message: "Only up to \(OpenMeteo.numberOfLocationsMaximum) locations can be requested at once")
-            }
-            let weight = responder.calculateQueryWeight(nVariablesModels: nil)
-            guard weight <= RateLimiter.limitHourly else {
-                throw ForecastApiError.generic(message: "Your API call requests too much data. Please reduce the number of variables, locations and/or weather models.")
-            }
-            let response = try await responder.response(format: params.formatWithOptions, concurrencySlot: slot, prefetch: weight < 10)
-            if isCFWorker {
-                await RateLimiter.instance.increment(int64: slot, count: weight)
-            } else {
-                await RateLimiter.instance.increment(address: address, count: weight)
-            }
+            await ConcurrencyGroupLimiter.instance.release(slot: slot)
             return response
         }
 
@@ -236,17 +239,22 @@ extension Request {
         let numberOfLocationsMaximum = limit >= 20_000_000 ? 200_000 : 10_000
         let maxConcurrent = max(2, limit / 5_000_000)
         let slot = apikey.hash
-        try await apiConcurrencyLimiter.wait(slot: slot, maxConcurrent: maxConcurrent, maxConcurrentHard: resNode ? 1024 : 256)
-        defer {
-            apiConcurrencyLimiter.release(slot: slot)
+        try await ConcurrencyGroupLimiter.instance.wait(slot: slot, maxConcurrent: maxConcurrent, maxConcurrentHard: resNode ? 1024 : 256)
+        let response: Response
+        do {
+            let responder = try await fn(host, params)
+            if responder.numberOfLocations > numberOfLocationsMaximum {
+                throw ForecastApiError.generic(message: "Only up to \(numberOfLocationsMaximum) locations can be requested at once")
+            }
+            let weight = responder.calculateQueryWeight(nVariablesModels: nil)
+            response = try await responder.response(format: params.formatWithOptions, concurrencySlot: slot, prefetch: weight < 10)
+            await ApiKeyManager.instance.increment(apikey: String.SubSequence(apikey), weight: weight)
         }
-        let responder = try await fn(host, params)
-        if responder.numberOfLocations > numberOfLocationsMaximum {
-            throw ForecastApiError.generic(message: "Only up to \(numberOfLocationsMaximum) locations can be requested at once")
+        catch {
+            await ConcurrencyGroupLimiter.instance.release(slot: slot)
+            throw error
         }
-        let weight = responder.calculateQueryWeight(nVariablesModels: nil)
-        let response = try await responder.response(format: params.formatWithOptions, concurrencySlot: slot, prefetch: weight < 10)
-        await ApiKeyManager.instance.increment(apikey: String.SubSequence(apikey), weight: weight)
+        await ConcurrencyGroupLimiter.instance.release(slot: slot)
         return response
     }
 }

--- a/Sources/App/Helper/Vapor/ApiKeyManager.swift
+++ b/Sources/App/Helper/Vapor/ApiKeyManager.swift
@@ -185,7 +185,7 @@ extension Request {
             } else {
                 try await RateLimiter.instance.check(address: address)
             }
-            try await ConcurrencyGroupLimiter.instance.wait(slot: slot, maxConcurrent: 1, maxConcurrentHard: 5)
+            try await ConcurrencyGroupLimiter.instance.wait(slot: slot, maxConcurrent: RateLimiter.concurrencyLimit, maxConcurrentHard: RateLimiter.concurrencyLimitHard)
             let response: Response
             do {
                 let params = try parseApiParams()

--- a/Sources/App/Helper/Vapor/ApiKeyManager.swift
+++ b/Sources/App/Helper/Vapor/ApiKeyManager.swift
@@ -83,11 +83,13 @@ public final actor ApiKeyManager {
         guard let apiKeysPath = Environment.get("API_APIKEYS_PATH") else {
             return
         }
-        let concurrencyLimit = await ConcurrencyGroupLimiter.instance.stats()
+
         let logger = application.logger
         if (0..<10).contains(Timestamp.now().second) {
             let usage = await ApiKeyManager.instance.getUsage()
-            logger.error("API key usage: \(usage). Concurrency \(concurrencyLimit)")
+            let timeStats = DispatchTime.now()
+            let concurrencyLimit = await ConcurrencyGroupLimiter.instance.stats()
+            logger.error("API key usage: \(usage). Concurrency \(concurrencyLimit) (collection time \(timeStats.timeElapsedPretty()))")
         }
         let keys = KeyAndLimit.readApiKeys(path: apiKeysPath)
         guard keys.count > 0 else {
@@ -158,7 +160,7 @@ extension Request {
             let params = try parseApiParams()
             let responder = try await fn(nil, params)
             let weight = responder.calculateQueryWeight(nVariablesModels: nil)
-            return try await responder.response(format: params.formatWithOptions, concurrencySlot: nil, prefetch: weight < 10)
+            return try await responder.response(format: params.formatWithOptions, concurrencySlot: nil, prefetch: weight < 10, logger: logger)
         }
         let isDevNode = host.contains("eu0") || host.contains("us0")
         let isFreeApi = host.starts(with: subdomain) || alias.contains(where: { host.starts(with: $0) }) == true || isDevNode
@@ -207,7 +209,7 @@ extension Request {
                 guard weight <= RateLimiter.limitHourly else {
                     throw ForecastApiError.generic(message: "Your API call requests too much data. Please reduce the number of variables, locations and/or weather models.")
                 }
-                response = try await responder.response(format: params.formatWithOptions, concurrencySlot: slot, prefetch: weight < 10)
+                response = try await responder.response(format: params.formatWithOptions, concurrencySlot: slot, prefetch: weight < 10, logger: logger)
                 if isCFWorker {
                     await RateLimiter.instance.increment(int64: slot, count: weight)
                 } else {
@@ -247,7 +249,7 @@ extension Request {
                 throw ForecastApiError.generic(message: "Only up to \(numberOfLocationsMaximum) locations can be requested at once")
             }
             let weight = responder.calculateQueryWeight(nVariablesModels: nil)
-            response = try await responder.response(format: params.formatWithOptions, concurrencySlot: slot, prefetch: weight < 10)
+            response = try await responder.response(format: params.formatWithOptions, concurrencySlot: slot, prefetch: weight < 10, logger: logger)
             await ApiKeyManager.instance.increment(apikey: String.SubSequence(apikey), weight: weight)
         }
         catch {

--- a/Sources/App/Helper/Vapor/ConcurrencyGroupLimiter.swift
+++ b/Sources/App/Helper/Vapor/ConcurrencyGroupLimiter.swift
@@ -1,74 +1,50 @@
-import NIOConcurrencyHelpers
-
-let apiConcurrencyLimiter = ConcurrencyGroupLimiter()
-
 /**
  Limit concurrency in different slots
- 
- See: https://forums.swift.org/t/semaphore-alternatives-for-structured-concurrency/59353/3
  */
-final class ConcurrencyGroupLimiter: @unchecked Sendable {
-    let lock = NIOLock()
+actor ConcurrencyGroupLimiter {
+    static let instance = ConcurrencyGroupLimiter()
+    
     /// Number of running per slot
     private var counts: [Int: Int] = [:]
     private var waiters: [Int: [CheckedContinuation<Void, Never>]] = [:]
 
-    init() {}
-
     func stats() -> (monitored_ips: Int, total_running: Int, queued_requests: Int) {
-        lock.withLock {
-            return (counts.count, counts.reduce(0, { $0 + $1.value }), waiters.reduce(0, { $0 + $1.value.count }))
-        }
+        (counts.count, counts.reduce(0, { $0 + $1.value }), waiters.reduce(0, { $0 + $1.value.count }))
     }
 
     func wait(slot: Int, maxConcurrent: Int, maxConcurrentHard: Int) async throws {
-        lock.lock()
-        guard let count = self.counts[slot] else {
-            self.counts[slot] = 1
-            lock.unlock()
+        guard let count = counts[slot] else {
+            counts[slot] = 1
             // print("Single request slot \(slot)")
             return
         }
         guard count < maxConcurrentHard else {
-            lock.unlock()
             throw RateLimitError.tooManyConcurrentRequests
         }
         counts[slot] = count + 1
-        guard count < maxConcurrent else {
-            await withCheckedContinuation {
-                // print("Queuing request slot \(slot)")
-                waiters[slot, default: []].append($0)
-                lock.unlock()
-            }
-            return
+        if count >= maxConcurrent {
+            // print("Queuing request slot \(slot)")
+            await withCheckedContinuation { waiters[slot, default: []].append($0) }
         }
-        lock.unlock()
     }
 
     func release(slot: Int) {
-        lock.lock()
-        guard let count = self.counts[slot] else {
+        guard let count = counts[slot] else {
             fatalError("Released slot \(slot) but it was not in use")
         }
         guard count > 1 else {
             // print("All requests finished for slot \(slot)")
-            self.counts.removeValue(forKey: slot)
-            lock.unlock()
+            counts.removeValue(forKey: slot)
             return
         }
-        self.counts[slot] = count - 1
-        guard var slotWaiters = waiters[slot], !slotWaiters.isEmpty else {
-            lock.unlock()
+        counts[slot] = count - 1
+        guard let cont = waiters[slot]?.removeFirst() else {
             return // no other requests are queued
         }
-        // print("Running queued request at slot \(slot)")
-        let cont = slotWaiters.removeFirst()
-        if slotWaiters.isEmpty {
+        if waiters[slot]?.isEmpty == true {
             waiters.removeValue(forKey: slot)
-        } else {
-            waiters[slot] = slotWaiters
         }
-        lock.unlock()
+        // print("Running queued request at slot \(slot)")
         cont.resume()
     }
 }

--- a/Sources/App/Helper/Vapor/ConcurrencyGroupLimiter.swift
+++ b/Sources/App/Helper/Vapor/ConcurrencyGroupLimiter.swift
@@ -11,13 +11,13 @@ final class ConcurrencyGroupLimiter: @unchecked Sendable {
     let lock = NIOLock()
     /// Number of running per slot
     private var counts: [Int: Int] = [:]
-    private var waiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var waiters: [Int: [CheckedContinuation<Void, Never>]] = [:]
 
     init() {}
 
     func stats() -> (monitored_ips: Int, total_running: Int, queued_requests: Int) {
         lock.withLock {
-            return (counts.count, counts.reduce(0, { $0 + $1.value }), waiters.count)
+            return (counts.count, counts.reduce(0, { $0 + $1.value }), waiters.reduce(0, { $0 + $1.value.count }))
         }
     }
 
@@ -37,7 +37,7 @@ final class ConcurrencyGroupLimiter: @unchecked Sendable {
         guard count < maxConcurrent else {
             await withCheckedContinuation {
                 // print("Queuing request slot \(slot)")
-                waiters.append((slot, $0))
+                waiters[slot, default: []].append($0)
                 lock.unlock()
             }
             return
@@ -57,13 +57,17 @@ final class ConcurrencyGroupLimiter: @unchecked Sendable {
             return
         }
         self.counts[slot] = count - 1
-        guard let index = waiters.firstIndex(where: { $0.0 == slot }) else {
+        guard var slotWaiters = waiters[slot], !slotWaiters.isEmpty else {
             lock.unlock()
             return // no other requests are queued
         }
         // print("Running queued request at slot \(slot)")
-        let cont = waiters[index].1
-        waiters.remove(at: index)
+        let cont = slotWaiters.removeFirst()
+        if slotWaiters.isEmpty {
+            waiters.removeValue(forKey: slot)
+        } else {
+            waiters[slot] = slotWaiters
+        }
         lock.unlock()
         cont.resume()
     }

--- a/Sources/App/Helper/Vapor/RateLimiter.swift
+++ b/Sources/App/Helper/Vapor/RateLimiter.swift
@@ -12,6 +12,10 @@ final actor RateLimiter {
     static let limitHourly = Float(Environment.get("CALL_LIMIT_HOURLY").flatMap(Int.init) ?? 5_000)
 
     private static let limitMinutely = Float(Environment.get("CALL_LIMIT_MINUTELY").flatMap(Int.init) ?? 600)
+    
+    static let concurrencyLimit = Environment.get("CONCURRENCY_LIMIT").flatMap(Int.init) ?? 1
+    
+    static let concurrencyLimitHard = Environment.get("CONCURRENCY_LIMIT_HARD").flatMap(Int.init) ?? 5
 
     private var dailyPerIPv4 = [UInt32: Float]()
 

--- a/Sources/App/Helper/Writer/CsvWriter.swift
+++ b/Sources/App/Helper/Writer/CsvWriter.swift
@@ -4,9 +4,9 @@ import Vapor
 
 extension ForecastapiResult {
     /// Streaming CSV format. Once 3kb of text is accumulated, flush to next handler -> response compressor
-    func toCsvResponse(concurrencySlot: Int? = nil, withLocationHeader: Bool = true) throws -> Response {
+    func toCsvResponse(concurrencySlot: Int?, withLocationHeader: Bool = true, logger: Logger) throws -> Response {
         let response = Response(body: .init(asyncStream: { writer in
-            try await writer.submit(concurrencySlot: concurrencySlot) {
+            try await writer.submit(concurrencySlot: concurrencySlot, logger: logger) {
                 var b = BufferAndAsyncWriter(writer: writer)
                 let multiLocation = results.count > 1
 

--- a/Sources/App/Helper/Writer/CsvWriter.swift
+++ b/Sources/App/Helper/Writer/CsvWriter.swift
@@ -81,7 +81,7 @@ extension ApiSectionSingle {
         b.buffer.writeString(time)
         for e in columns {
             if e.value.isFinite {
-                b.buffer.writeString(",\(String(format: "%.\(e.unit.significantDigits)f", e.value))")
+                b.buffer.writeString(",\(e.value.formatted(decimals: e.unit.significantDigits))")
             } else {
                 b.buffer.writeString(",NaN")
             }
@@ -119,7 +119,7 @@ extension ApiSectionString {
                 switch e.data {
                 case .float(let a):
                     if a[i].isFinite {
-                        b.buffer.writeString(",\(String(format: "%.\(e.unit.significantDigits)f", a[i]))")
+                        b.buffer.writeString(",\(a[i].formatted(decimals: e.unit.significantDigits))")
                     } else {
                         b.buffer.writeString(",NaN")
                     }

--- a/Sources/App/Helper/Writer/ForecastApiResult.swift
+++ b/Sources/App/Helper/Writer/ForecastApiResult.swift
@@ -9,7 +9,7 @@ protocol FlatBuffersVariable: RawRepresentableString {
 
 protocol ForecastapiResponder {
     func calculateQueryWeight(nVariablesModels: Int?) -> Float
-    func response(format: ForecastResultFormatWithOptions?, concurrencySlot: Int?, prefetch: Bool) async throws -> Response
+    func response(format: ForecastResultFormatWithOptions?, concurrencySlot: Int?, prefetch: Bool, logger: Logger) async throws -> Response
 
     var numberOfLocations: Int { get }
 }
@@ -208,7 +208,7 @@ struct ForecastapiResult<Model: ModelFlatbufferSerialisable>: ForecastapiRespond
 
     /// Output the given result set with a specified format
     /// timestamp and fixedGenerationTime are used to overwrite dynamic fields in unit tests
-    func response(format: ForecastResultFormatWithOptions?, concurrencySlot: Int? = nil, prefetch: Bool = true) async throws -> Response {
+    func response(format: ForecastResultFormatWithOptions?, concurrencySlot: Int? = nil, prefetch: Bool = true, logger: Logger) async throws -> Response {
         if case .xlsx = format, results.count > 100 {
             throw ForecastApiError.generic(message: "XLSX supports only up to 100 locations")
         }
@@ -221,7 +221,7 @@ struct ForecastapiResult<Model: ModelFlatbufferSerialisable>: ForecastapiRespond
         }
         switch format ?? .json() {
         case .json(let fixedGenerationTime):
-            return try toJsonResponse(fixedGenerationTime: fixedGenerationTime, concurrencySlot: concurrencySlot)
+            return try toJsonResponse(fixedGenerationTime: fixedGenerationTime, concurrencySlot: concurrencySlot, logger: logger)
         case .xlsx(let timestamp, let locationInformation):
             switch locationInformation {
             case .omit:
@@ -232,12 +232,12 @@ struct ForecastapiResult<Model: ModelFlatbufferSerialisable>: ForecastapiRespond
         case .csv(let locationInformation):
             switch locationInformation {
                 case .omit:
-                    return try toCsvResponse(concurrencySlot: concurrencySlot, withLocationHeader: false)
+                return try toCsvResponse(concurrencySlot: concurrencySlot, withLocationHeader: false, logger: logger)
                 case .section:
-                    return try toCsvResponse(concurrencySlot: concurrencySlot, withLocationHeader: true)
+                return try toCsvResponse(concurrencySlot: concurrencySlot, withLocationHeader: true, logger: logger)
             }
         case .flatbuffers(let fixedGenerationTime):
-            return try toFlatbuffersResponse(fixedGenerationTime: fixedGenerationTime, concurrencySlot: concurrencySlot)
+            return try toFlatbuffersResponse(fixedGenerationTime: fixedGenerationTime, concurrencySlot: concurrencySlot, logger: logger)
         }
     }
 

--- a/Sources/App/Helper/Writer/ForecastApiResult.swift
+++ b/Sources/App/Helper/Writer/ForecastApiResult.swift
@@ -65,9 +65,9 @@ extension ModelFlatbufferSerialisable {
 
     /// e.g. `52.52N13.42E38m`
     var formatedCoordinatesFilename: String {
-        let lat = latitude < 0 ? String(format: "%.2fS", abs(latitude)) : String(format: "%.2fN", latitude)
-        let ele = elevation.map { $0.isFinite ? String(format: "%.0fm", $0) : "" } ?? ""
-        return longitude < 0 ? String(format: "\(lat)%.2fW\(ele)", abs(longitude)) : String(format: "\(lat)%.2fE\(ele)", longitude)
+        let lat = latitude < 0 ? "\(abs(latitude).formatted(decimals: 2))S" : "\(latitude.formatted(decimals: 2))N"
+        let ele = elevation.map { $0.isFinite ? "\($0.formatted(decimals: 0))m" : "" } ?? ""
+        return longitude < 0 ? "\(lat)\(abs(longitude).formatted(decimals: 2))W\(ele)" : "\(lat)\(longitude.formatted(decimals: 2))E\(ele)"
     }
 }
 

--- a/Sources/App/Helper/Writer/JsonWriter.swift
+++ b/Sources/App/Helper/Writer/JsonWriter.swift
@@ -3,7 +3,7 @@ import Vapor
 
 extension AsyncBodyStreamWriter {
     /// Execute async code and capture any errors. In case of error, print the error to the output stream
-    func submit(concurrencySlot: Int?, _ task: @escaping () async throws -> Void) async throws {
+    func submit(concurrencySlot: Int?, logger: Logger, _ task: @escaping () async throws -> Void) async throws {
         if let concurrencySlot {
             try await ConcurrencyGroupLimiter.instance.wait(slot: concurrencySlot, maxConcurrent: .max, maxConcurrentHard: .max)
         }
@@ -13,10 +13,15 @@ extension AsyncBodyStreamWriter {
                 await ConcurrencyGroupLimiter.instance.release(slot: concurrencySlot)
             }
         } catch {
-            try await write(.buffer(.init(string: "Unexpected error while streaming data: \(error)")))
-            try await write(.end)
             if let concurrencySlot {
                 await ConcurrencyGroupLimiter.instance.release(slot: concurrencySlot)
+            }
+            logger.info("Error during streaming", error: error)
+            do {
+                try await write(.buffer(.init(string: "Unexpected error while streaming data: \(error)")))
+                try await write(.end)
+            } catch {
+                logger.info("Error during streaming end", error: error)
             }
         }
     }
@@ -29,11 +34,11 @@ extension ForecastapiResult {
      Memory footprint is therefore much smaller and fits better into L2/L3 caches.
      Additionally code is fully async, to not block the a thread for almost a second to generate a JSON response...
      */
-    func toJsonResponse(fixedGenerationTime: Double?, concurrencySlot: Int?) throws -> Response {
+    func toJsonResponse(fixedGenerationTime: Double?, concurrencySlot: Int?, logger: Logger) throws -> Response {
         // First excution outside stream, to capture potential errors better
         // var first = try self.first?()
         let response = Response(body: .init(asyncStream: { writer in
-            try await writer.submit(concurrencySlot: concurrencySlot) {
+            try await writer.submit(concurrencySlot: concurrencySlot, logger: logger) {
                 var b = BufferAndAsyncWriter(writer: writer)
                 /// For multiple locations, create an array of results
                 let isMultiPoint = results.count > 1

--- a/Sources/App/Helper/Writer/JsonWriter.swift
+++ b/Sources/App/Helper/Writer/JsonWriter.swift
@@ -104,9 +104,8 @@ extension ForecastapiResult.PerLocation {
             b.buffer.writeString(",\"interval\":\(current.dtSeconds)")
             /// Write data
             for e in current.columns {
-                let format = "%.\(e.unit.significantDigits)f"
                 b.buffer.writeString(",")
-                b.buffer.writeString("\"\(e.variable.rawValue)\":\(e.value.isFinite ? String(format: format, e.value) : "null")")
+                b.buffer.writeString("\"\(e.variable.rawValue)\":\(e.value.isFinite ? e.value.formatted(decimals: e.unit.significantDigits) : "null")")
             }
             b.buffer.writeString("}")
             try await b.flushIfRequired()
@@ -152,7 +151,6 @@ extension ForecastapiResult.PerLocation {
                 var firstValue = true
                 switch e.data {
                 case .float(let floats):
-                    let format = "%.\(e.unit.significantDigits)f"
                     for v in floats {
                         if firstValue {
                             firstValue = false
@@ -160,7 +158,7 @@ extension ForecastapiResult.PerLocation {
                             b.buffer.writeString(",")
                         }
                         if v.isFinite {
-                            b.buffer.writeString(String(format: format, v))
+                            b.buffer.writeString(v.formatted(decimals: e.unit.significantDigits))
                         } else {
                             b.buffer.writeString("null")
                         }

--- a/Sources/App/Helper/Writer/JsonWriter.swift
+++ b/Sources/App/Helper/Writer/JsonWriter.swift
@@ -16,12 +16,12 @@ extension AsyncBodyStreamWriter {
             if let concurrencySlot {
                 await ConcurrencyGroupLimiter.instance.release(slot: concurrencySlot)
             }
-            logger.info("Error during streaming", error: error)
+            logger.info("Error during streaming. Error \(error)")
             do {
                 try await write(.buffer(.init(string: "Unexpected error while streaming data: \(error)")))
                 try await write(.end)
             } catch {
-                logger.info("Error during streaming end", error: error)
+                logger.info("Error during streaming end. Error \(error)")
             }
         }
     }

--- a/Sources/App/Helper/Writer/JsonWriter.swift
+++ b/Sources/App/Helper/Writer/JsonWriter.swift
@@ -5,18 +5,19 @@ extension AsyncBodyStreamWriter {
     /// Execute async code and capture any errors. In case of error, print the error to the output stream
     func submit(concurrencySlot: Int?, _ task: @escaping () async throws -> Void) async throws {
         if let concurrencySlot {
-            try await apiConcurrencyLimiter.wait(slot: concurrencySlot, maxConcurrent: .max, maxConcurrentHard: .max)
-        }
-        defer {
-            if let concurrencySlot {
-                apiConcurrencyLimiter.release(slot: concurrencySlot)
-            }
+            try await ConcurrencyGroupLimiter.instance.wait(slot: concurrencySlot, maxConcurrent: .max, maxConcurrentHard: .max)
         }
         do {
             try await task()
+            if let concurrencySlot {
+                await ConcurrencyGroupLimiter.instance.release(slot: concurrencySlot)
+            }
         } catch {
             try await write(.buffer(.init(string: "Unexpected error while streaming data: \(error)")))
             try await write(.end)
+            if let concurrencySlot {
+                await ConcurrencyGroupLimiter.instance.release(slot: concurrencySlot)
+            }
         }
     }
 }

--- a/Sources/App/Helper/Writer/XlsxFormat.swift
+++ b/Sources/App/Helper/Writer/XlsxFormat.swift
@@ -87,7 +87,7 @@ public final class XlsxWriter {
         if float.isInfinite || float.isNaN {
             sheet_xml.write("<c t=\"e\"><v>#NUM!</v></c>")
         } else {
-            sheet_xml.write("<c><v>\(String(format: "%.\(significantDigits)f", float))</v></c>")
+            sheet_xml.write("<c><v>\(float.formatted(decimals: significantDigits))</v></c>")
         }
     }
 

--- a/Tests/AppTests/ConcurrencyGroupLimiterTests.swift
+++ b/Tests/AppTests/ConcurrencyGroupLimiterTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+@testable import App
+import Testing
+import Synchronization
+
+@Suite struct ConcurrencyGroupLimiterTests {
+    /// A request queued past maxConcurrent is unblocked when a slot is released
+    @Test func queuedRequestIsUnblocked() async throws {
+        let limiter = ConcurrencyGroupLimiter()
+        // Fill up to the soft limit
+        try await limiter.wait(slot: 7, maxConcurrent: 1, maxConcurrentHard: 3)
+
+        // This request should queue because count (1) >= maxConcurrent (1)
+        let waiterTask = Task<Void, any Error> {
+            try await limiter.wait(slot: 7, maxConcurrent: 1, maxConcurrentHard: 3)
+        }
+        
+        // This request should queue because count (1) >= maxConcurrent (1)
+        let waiterTask2 = Task<Void, any Error> {
+            try await limiter.wait(slot: 7, maxConcurrent: 1, maxConcurrentHard: 3)
+        }
+        
+        // Give the waiter task time to enqueue
+        try await Task.sleep(nanoseconds: 10_000_000)
+        
+        await #expect(throws: RateLimitError.tooManyConcurrentRequests) {
+            try await limiter.wait(slot: 7, maxConcurrent: 1, maxConcurrentHard: 3)
+        }
+
+        let s = await limiter.stats()
+        #expect(s.total_running == 3)
+        #expect(s.queued_requests == 2)
+
+        // Releasing the first slot should unblock the waiter;
+        // awaiting the task proves it actually ran.
+        await limiter.release(slot: 7)
+        
+        let s2 = await limiter.stats()
+        #expect(s2.queued_requests == 1)
+        #expect(s2.total_running == 2)
+        
+        await limiter.release(slot: 7)
+        let s3 = await limiter.stats()
+        #expect(s3.queued_requests == 0)
+        #expect(s3.total_running == 1)
+        
+        try await waiterTask.value
+        try await waiterTask2.value
+        
+        await limiter.release(slot: 7)
+        let s4 = await limiter.stats()
+        #expect(s4.queued_requests == 0)
+        #expect(s4.total_running == 0)
+    }
+
+    /// Different slots are tracked independently
+    @Test func independentSlots() async throws {
+        let limiter = ConcurrencyGroupLimiter()
+        try await limiter.wait(slot: 1, maxConcurrent: 1, maxConcurrentHard: 2)
+        try await limiter.wait(slot: 2, maxConcurrent: 1, maxConcurrentHard: 2)
+        let s = await limiter.stats()
+        #expect(s.monitored_ips == 2)
+        #expect(s.total_running == 2)
+        await limiter.release(slot: 1)
+        let s2 = await limiter.stats()
+        #expect(s2.monitored_ips == 1)
+        #expect(s2.total_running == 1)
+        await limiter.release(slot: 2)
+    }
+}

--- a/Tests/AppTests/OutputformatTests.swift
+++ b/Tests/AppTests/OutputformatTests.swift
@@ -176,12 +176,13 @@ struct DummyDataProvider: ModelFlatbufferSerialisable {
     }
 
     @Test func formats() async throws {
+        let logger = Logger(label: "OutputformatTests")
         let data = DummyDataProvider.makeData(timeformat: .iso8601, locationCount: 1)
         #expect(data.calculateQueryWeight(nVariablesModels: 2) == 1)
         #expect(data.calculateQueryWeight(nVariablesModels: 15) == 1.5)
         #expect(data.calculateQueryWeight(nVariablesModels: 20) == 2)
 
-        let json = await drainString(try data.response(format: .json(fixedGenerationTime: 12)))
+        let json = await drainString(try data.response(format: .json(fixedGenerationTime: 12), logger: logger))
         #expect(json == """
             {"latitude":41.0,"longitude":2.0,"generationtime_ms":12.0,"utc_offset_seconds":3600,"timezone":"GMT","timezone_abbreviation":"GMT","current_weather_units":{"time":"iso8601","interval":"seconds","temperature_20m":"°C","windspeed_100m":"km/h"},"current_weather":{"time":"2022-07-12T02:15","interval":900,"temperature_20m":20.0,"windspeed_100m":10.0},"hourly_units":{"time":"iso8601","temperature_2m":"°C","windspeed_10m":"km/h"},"hourly":{"time":["2022-07-12T01:00","2022-07-12T02:00","2022-07-12T03:00","2022-07-12T04:00","2022-07-12T05:00","2022-07-12T06:00","2022-07-12T07:00","2022-07-12T08:00","2022-07-12T09:00","2022-07-12T10:00","2022-07-12T11:00","2022-07-12T12:00","2022-07-12T13:00","2022-07-12T14:00","2022-07-12T15:00","2022-07-12T16:00","2022-07-12T17:00","2022-07-12T18:00","2022-07-12T19:00","2022-07-12T20:00","2022-07-12T21:00","2022-07-12T22:00","2022-07-12T23:00","2022-07-13T00:00","2022-07-13T01:00","2022-07-13T02:00","2022-07-13T03:00","2022-07-13T04:00","2022-07-13T05:00","2022-07-13T06:00","2022-07-13T07:00","2022-07-13T08:00","2022-07-13T09:00","2022-07-13T10:00","2022-07-13T11:00","2022-07-13T12:00","2022-07-13T13:00","2022-07-13T14:00","2022-07-13T15:00","2022-07-13T16:00","2022-07-13T17:00","2022-07-13T18:00","2022-07-13T19:00","2022-07-13T20:00","2022-07-13T21:00","2022-07-13T22:00","2022-07-13T23:00","2022-07-14T00:00"],"temperature_2m":[20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0],"windspeed_10m":[10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0]},"daily_units":{"time":"iso8601","temperature_2m_mean":"°C","windspeed_10m_mean":"km/h"},"daily":{"time":["2022-07-12","2022-07-13"],"temperature_2m_mean":[20.0,20.0],"windspeed_10m_mean":[10.0,10.0]},"monthly_units":{"time":"iso8601","apparent_temperature_mean":"°C","cloud_cover_mean":"%"},"monthly":{"time":["2022-07-01","2022-08-01"],"apparent_temperature_mean":[20.0,20.0],"cloud_cover_mean":[10,10]}}
             """)
@@ -189,12 +190,12 @@ struct DummyDataProvider: ModelFlatbufferSerialisable {
 
         let dataUnix = DummyDataProvider.makeData(timeformat: .unixtime, locationCount: 1)
 
-        let jsonUnix = await drainString(try dataUnix.response(format: .json(fixedGenerationTime: 12)))
+        let jsonUnix = await drainString(try dataUnix.response(format: .json(fixedGenerationTime: 12), logger: logger))
         #expect(jsonUnix == """
             {"latitude":41.0,"longitude":2.0,"generationtime_ms":12.0,"utc_offset_seconds":3600,"timezone":"GMT","timezone_abbreviation":"GMT","current_weather_units":{"time":"unixtime","interval":"seconds","temperature_20m":"°C","windspeed_100m":"km/h"},"current_weather":{"time":1657588500,"interval":900,"temperature_20m":20.0,"windspeed_100m":10.0},"hourly_units":{"time":"unixtime","temperature_2m":"°C","windspeed_10m":"km/h"},"hourly":{"time":[1657584000,1657587600,1657591200,1657594800,1657598400,1657602000,1657605600,1657609200,1657612800,1657616400,1657620000,1657623600,1657627200,1657630800,1657634400,1657638000,1657641600,1657645200,1657648800,1657652400,1657656000,1657659600,1657663200,1657666800,1657670400,1657674000,1657677600,1657681200,1657684800,1657688400,1657692000,1657695600,1657699200,1657702800,1657706400,1657710000,1657713600,1657717200,1657720800,1657724400,1657728000,1657731600,1657735200,1657738800,1657742400,1657746000,1657749600,1657753200],"temperature_2m":[20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0],"windspeed_10m":[10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0]},"daily_units":{"time":"unixtime","temperature_2m_mean":"°C","windspeed_10m_mean":"km/h"},"daily":{"time":[1657584000,1657670400],"temperature_2m_mean":[20.0,20.0],"windspeed_10m_mean":[10.0,10.0]},"monthly_units":{"time":"unixtime","apparent_temperature_mean":"°C","cloud_cover_mean":"%"},"monthly":{"time":[1656633600,1659312000],"apparent_temperature_mean":[20.0,20.0],"cloud_cover_mean":[10,10]}}
             """)
 
-        let csv = await drainString(try data.response(format: .csv(locationInformation: .section)))
+        let csv = await drainString(try data.response(format: .csv(locationInformation: .section), logger: logger))
         #expect(csv == """
             latitude,longitude,elevation,utc_offset_seconds,timezone,timezone_abbreviation
             41.0,2.0,NaN,3600,GMT,GMT
@@ -262,7 +263,7 @@ struct DummyDataProvider: ModelFlatbufferSerialisable {
 
             """)
 
-        let csvUnix = await drainString(try dataUnix.response(format: .csv(locationInformation: .section)))
+        let csvUnix = await drainString(try dataUnix.response(format: .csv(locationInformation: .section), logger: logger))
         #expect(csvUnix == """
             latitude,longitude,elevation,utc_offset_seconds,timezone,timezone_abbreviation
             41.0,2.0,NaN,3600,GMT,GMT
@@ -330,7 +331,7 @@ struct DummyDataProvider: ModelFlatbufferSerialisable {
 
             """)
 
-        let csvUnixNoHeader = await drainString(try dataUnix.response(format: .csv(locationInformation: .omit)))
+        let csvUnixNoHeader = await drainString(try dataUnix.response(format: .csv(locationInformation: .omit), logger: logger))
         #expect(csvUnixNoHeader == """
             time,temperature_20m (°C),windspeed_100m (km/h)
             1657588500,20.0,10.0
@@ -397,10 +398,10 @@ struct DummyDataProvider: ModelFlatbufferSerialisable {
         )
 
         /// needs to set a timestamp, because of zip compression headers
-        let xlsx = await drainData(try data.response(format: .xlsx(timestamp: Timestamp(2022, 7, 13), locationInformation: .section))).sha256
+        let xlsx = await drainData(try data.response(format: .xlsx(timestamp: Timestamp(2022, 7, 13), locationInformation: .section), logger: logger)).sha256
         #expect(xlsx == "6efa5ee262cef5073ef5fb27f05beb235db21db163eca31c4b4175b0c96d9b03")
 
-        let flatbuffers = await drainData(try data.response(format: .flatbuffers(fixedGenerationTime: 12)))
+        let flatbuffers = await drainData(try data.response(format: .flatbuffers(fixedGenerationTime: 12), logger: logger))
         //print(flatbuffers.hex)
         #expect(flatbuffers.count == 912)
         #expect(flatbuffers.sha256 == "319106d7379e730b1f83dcf4e86a79cb25f1dbf25518a402aacfe0efcb2c1039")
@@ -408,25 +409,26 @@ struct DummyDataProvider: ModelFlatbufferSerialisable {
 
     /// Test output formats for 2 locations
     @Test func formatsMultiLocation() async throws {
+        let logger = Logger(label: "OutputformatTests")
         let data = DummyDataProvider.makeData(timeformat: .iso8601, locationCount: 2)
 
         #expect(data.calculateQueryWeight(nVariablesModels: 2) == 2)
         #expect(data.calculateQueryWeight(nVariablesModels: 15) == 3)
         #expect(data.calculateQueryWeight(nVariablesModels: 20) == 4)
 
-        let json = await drainString(try data.response(format: .json(fixedGenerationTime: 12)))
+        let json = await drainString(try data.response(format: .json(fixedGenerationTime: 12), logger: logger))
         #expect(json == """
             [{"latitude":41.0,"longitude":2.0,"generationtime_ms":12.0,"utc_offset_seconds":3600,"timezone":"GMT","timezone_abbreviation":"GMT","current_weather_units":{"time":"iso8601","interval":"seconds","temperature_20m":"°C","windspeed_100m":"km/h"},"current_weather":{"time":"2022-07-12T02:15","interval":900,"temperature_20m":20.0,"windspeed_100m":10.0},"hourly_units":{"time":"iso8601","temperature_2m":"°C","windspeed_10m":"km/h"},"hourly":{"time":["2022-07-12T01:00","2022-07-12T02:00","2022-07-12T03:00","2022-07-12T04:00","2022-07-12T05:00","2022-07-12T06:00","2022-07-12T07:00","2022-07-12T08:00","2022-07-12T09:00","2022-07-12T10:00","2022-07-12T11:00","2022-07-12T12:00","2022-07-12T13:00","2022-07-12T14:00","2022-07-12T15:00","2022-07-12T16:00","2022-07-12T17:00","2022-07-12T18:00","2022-07-12T19:00","2022-07-12T20:00","2022-07-12T21:00","2022-07-12T22:00","2022-07-12T23:00","2022-07-13T00:00","2022-07-13T01:00","2022-07-13T02:00","2022-07-13T03:00","2022-07-13T04:00","2022-07-13T05:00","2022-07-13T06:00","2022-07-13T07:00","2022-07-13T08:00","2022-07-13T09:00","2022-07-13T10:00","2022-07-13T11:00","2022-07-13T12:00","2022-07-13T13:00","2022-07-13T14:00","2022-07-13T15:00","2022-07-13T16:00","2022-07-13T17:00","2022-07-13T18:00","2022-07-13T19:00","2022-07-13T20:00","2022-07-13T21:00","2022-07-13T22:00","2022-07-13T23:00","2022-07-14T00:00"],"temperature_2m":[20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0],"windspeed_10m":[10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0]},"daily_units":{"time":"iso8601","temperature_2m_mean":"°C","windspeed_10m_mean":"km/h"},"daily":{"time":["2022-07-12","2022-07-13"],"temperature_2m_mean":[20.0,20.0],"windspeed_10m_mean":[10.0,10.0]},"monthly_units":{"time":"iso8601","apparent_temperature_mean":"°C","cloud_cover_mean":"%"},"monthly":{"time":["2022-07-01","2022-08-01"],"apparent_temperature_mean":[20.0,20.0],"cloud_cover_mean":[10,10]}},{"latitude":41.0,"longitude":2.0,"generationtime_ms":12.0,"utc_offset_seconds":3600,"timezone":"GMT","timezone_abbreviation":"GMT","location_id":1,"current_weather_units":{"time":"iso8601","interval":"seconds","temperature_20m":"°C","windspeed_100m":"km/h"},"current_weather":{"time":"2022-07-12T02:15","interval":900,"temperature_20m":20.0,"windspeed_100m":10.0},"hourly_units":{"time":"iso8601","temperature_2m":"°C","windspeed_10m":"km/h"},"hourly":{"time":["2022-07-12T01:00","2022-07-12T02:00","2022-07-12T03:00","2022-07-12T04:00","2022-07-12T05:00","2022-07-12T06:00","2022-07-12T07:00","2022-07-12T08:00","2022-07-12T09:00","2022-07-12T10:00","2022-07-12T11:00","2022-07-12T12:00","2022-07-12T13:00","2022-07-12T14:00","2022-07-12T15:00","2022-07-12T16:00","2022-07-12T17:00","2022-07-12T18:00","2022-07-12T19:00","2022-07-12T20:00","2022-07-12T21:00","2022-07-12T22:00","2022-07-12T23:00","2022-07-13T00:00","2022-07-13T01:00","2022-07-13T02:00","2022-07-13T03:00","2022-07-13T04:00","2022-07-13T05:00","2022-07-13T06:00","2022-07-13T07:00","2022-07-13T08:00","2022-07-13T09:00","2022-07-13T10:00","2022-07-13T11:00","2022-07-13T12:00","2022-07-13T13:00","2022-07-13T14:00","2022-07-13T15:00","2022-07-13T16:00","2022-07-13T17:00","2022-07-13T18:00","2022-07-13T19:00","2022-07-13T20:00","2022-07-13T21:00","2022-07-13T22:00","2022-07-13T23:00","2022-07-14T00:00"],"temperature_2m":[20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0],"windspeed_10m":[10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0]},"daily_units":{"time":"iso8601","temperature_2m_mean":"°C","windspeed_10m_mean":"km/h"},"daily":{"time":["2022-07-12","2022-07-13"],"temperature_2m_mean":[20.0,20.0],"windspeed_10m_mean":[10.0,10.0]},"monthly_units":{"time":"iso8601","apparent_temperature_mean":"°C","cloud_cover_mean":"%"},"monthly":{"time":["2022-07-01","2022-08-01"],"apparent_temperature_mean":[20.0,20.0],"cloud_cover_mean":[10,10]}}]
             """)
 
         let dataUnix = DummyDataProvider.makeData(timeformat: .unixtime, locationCount: 2)
 
-        let jsonUnix = await drainString(try dataUnix.response(format: .json(fixedGenerationTime: 12)))
+        let jsonUnix = await drainString(try dataUnix.response(format: .json(fixedGenerationTime: 12), logger: logger))
         #expect(jsonUnix == """
             [{"latitude":41.0,"longitude":2.0,"generationtime_ms":12.0,"utc_offset_seconds":3600,"timezone":"GMT","timezone_abbreviation":"GMT","current_weather_units":{"time":"unixtime","interval":"seconds","temperature_20m":"°C","windspeed_100m":"km/h"},"current_weather":{"time":1657588500,"interval":900,"temperature_20m":20.0,"windspeed_100m":10.0},"hourly_units":{"time":"unixtime","temperature_2m":"°C","windspeed_10m":"km/h"},"hourly":{"time":[1657584000,1657587600,1657591200,1657594800,1657598400,1657602000,1657605600,1657609200,1657612800,1657616400,1657620000,1657623600,1657627200,1657630800,1657634400,1657638000,1657641600,1657645200,1657648800,1657652400,1657656000,1657659600,1657663200,1657666800,1657670400,1657674000,1657677600,1657681200,1657684800,1657688400,1657692000,1657695600,1657699200,1657702800,1657706400,1657710000,1657713600,1657717200,1657720800,1657724400,1657728000,1657731600,1657735200,1657738800,1657742400,1657746000,1657749600,1657753200],"temperature_2m":[20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0],"windspeed_10m":[10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0]},"daily_units":{"time":"unixtime","temperature_2m_mean":"°C","windspeed_10m_mean":"km/h"},"daily":{"time":[1657584000,1657670400],"temperature_2m_mean":[20.0,20.0],"windspeed_10m_mean":[10.0,10.0]},"monthly_units":{"time":"unixtime","apparent_temperature_mean":"°C","cloud_cover_mean":"%"},"monthly":{"time":[1656633600,1659312000],"apparent_temperature_mean":[20.0,20.0],"cloud_cover_mean":[10,10]}},{"latitude":41.0,"longitude":2.0,"generationtime_ms":12.0,"utc_offset_seconds":3600,"timezone":"GMT","timezone_abbreviation":"GMT","location_id":1,"current_weather_units":{"time":"unixtime","interval":"seconds","temperature_20m":"°C","windspeed_100m":"km/h"},"current_weather":{"time":1657588500,"interval":900,"temperature_20m":20.0,"windspeed_100m":10.0},"hourly_units":{"time":"unixtime","temperature_2m":"°C","windspeed_10m":"km/h"},"hourly":{"time":[1657584000,1657587600,1657591200,1657594800,1657598400,1657602000,1657605600,1657609200,1657612800,1657616400,1657620000,1657623600,1657627200,1657630800,1657634400,1657638000,1657641600,1657645200,1657648800,1657652400,1657656000,1657659600,1657663200,1657666800,1657670400,1657674000,1657677600,1657681200,1657684800,1657688400,1657692000,1657695600,1657699200,1657702800,1657706400,1657710000,1657713600,1657717200,1657720800,1657724400,1657728000,1657731600,1657735200,1657738800,1657742400,1657746000,1657749600,1657753200],"temperature_2m":[20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0,20.0],"windspeed_10m":[10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0,10.0]},"daily_units":{"time":"unixtime","temperature_2m_mean":"°C","windspeed_10m_mean":"km/h"},"daily":{"time":[1657584000,1657670400],"temperature_2m_mean":[20.0,20.0],"windspeed_10m_mean":[10.0,10.0]},"monthly_units":{"time":"unixtime","apparent_temperature_mean":"°C","cloud_cover_mean":"%"},"monthly":{"time":[1656633600,1659312000],"apparent_temperature_mean":[20.0,20.0],"cloud_cover_mean":[10,10]}}]
             """)
 
-        let csv = await drainString(try data.response(format: .csv(locationInformation: .section)))
+        let csv = await drainString(try data.response(format: .csv(locationInformation: .section), logger: logger))
         #expect(csv == """
             location_id,latitude,longitude,elevation,utc_offset_seconds,timezone,timezone_abbreviation
             0,41.0,2.0,NaN,3600,GMT,GMT
@@ -548,7 +550,7 @@ struct DummyDataProvider: ModelFlatbufferSerialisable {
 
             """)
 
-        let csvUnix = await drainString(try dataUnix.response(format: .csv(locationInformation: .section)))
+        let csvUnix = await drainString(try dataUnix.response(format: .csv(locationInformation: .section), logger: logger))
         #expect(csvUnix == """
             location_id,latitude,longitude,elevation,utc_offset_seconds,timezone,timezone_abbreviation
             0,41.0,2.0,NaN,3600,GMT,GMT
@@ -671,10 +673,10 @@ struct DummyDataProvider: ModelFlatbufferSerialisable {
             """)
 
         /// needs to set a timestamp, because of zip compression headers
-        let xlsx = await drainData(try data.response(format: .xlsx(timestamp: Timestamp(2022, 7, 13), locationInformation: .section))).sha256
+        let xlsx = await drainData(try data.response(format: .xlsx(timestamp: Timestamp(2022, 7, 13), locationInformation: .section), logger: logger)).sha256
         #expect(xlsx == "6e30672c1461d2b1c4196f860e311cb742957392acd66c0e63b76f9c0656d3ce")
 
-        let flatbuffers = await drainData(try data.response(format: .flatbuffers(fixedGenerationTime: 12)))
+        let flatbuffers = await drainData(try data.response(format: .flatbuffers(fixedGenerationTime: 12), logger: logger))
         //print(flatbuffers.hex)
         #expect(flatbuffers.count == 1840)
         #expect(flatbuffers.sha256 == "3b7d3373403f4ccf5f0cb530ec486d80518fd8f784c055df3383c667cb2378ff")


### PR DESCRIPTION
Potential fix for slow down at high number of API calls. Rewrite code in structured concurrency to remove lock contention and replace search with hash map