### PR TITLE
fix: hashable version for groupedPreservedOrder

### DIFF
--- a/Sources/App/Helper/Intrinsics/Sequence.swift
+++ b/Sources/App/Helper/Intrinsics/Sequence.swift
@@ -19,4 +19,29 @@ extension Sequence {
         }
         return groups
     }
+
+    /// Group the sequence by the given criterion.
+    ///
+    /// This Hashable version avoids O(N^2) runtime for large sequences!
+    /// - Parameter criterion: The basis by which to group the sequence.
+    /// - Throws: `Error`.
+    /// - Returns: Array of `(key: Group, values: [Element])`
+    func groupedPreservedOrder<Group: Hashable>(
+        by criterion: (Element) throws -> Group
+    ) rethrows -> [(key: Group, values: [Element])] {
+        var groupIndex: [Group: Int] = [:]
+        var groups: [(key: Group, values: [Element])] = []
+
+        for element in self {
+            let key = try criterion(element)
+            if let existingIndex = groupIndex[key] {
+                groups[existingIndex].values.append(element)
+            } else {
+                groupIndex[key] = groups.count
+                groups.append((key: key, values: [element]))
+            }
+        }
+
+        return groups
+    }
 }

--- a/Sources/App/Helper/Intrinsics/Sequence.swift
+++ b/Sources/App/Helper/Intrinsics/Sequence.swift
@@ -2,27 +2,8 @@ import Foundation
 
 extension Sequence {
     /// Group the sequence by the given criterion.
-    /// - Parameter criterion: The basis by which to group the sequence.
-    /// - Throws: `Error`.
-    /// - Returns: Array of `(key: Group, values: [Element])`
-    func groupedPreservedOrder<Group: Equatable>(
-        by criterion: (_ transforming: Element) throws -> Group
-    ) rethrows -> [(key: Group, values: [Element])] {
-        var groups = [(key: Group, values: [Element])]()
-        for element in self {
-            let key = try criterion(_: element)
-            if let keyIndex = groups.firstIndex(where: { $0.key == key }) {
-                groups[keyIndex] = (key, groups[keyIndex].values + [element])
-            } else {
-                groups.append((key: key, values: [element]))
-            }
-        }
-        return groups
-    }
-
-    /// Group the sequence by the given criterion.
     ///
-    /// This Hashable version avoids O(N^2) runtime for large sequences!
+    /// This Hashable version avoids O(N^2) runtime for large sequences (compared to an Equatable version)!
     /// - Parameter criterion: The basis by which to group the sequence.
     /// - Throws: `Error`.
     /// - Returns: Array of `(key: Group, values: [Element])`

--- a/Sources/App/Helper/Writer/VariablePerMemberStorage.swift
+++ b/Sources/App/Helper/Writer/VariablePerMemberStorage.swift
@@ -17,7 +17,7 @@ actor VariablePerMemberStorage<V: Hashable & Sendable> {
         }
     }
 
-    struct TimestampAndMember: Equatable {
+    struct TimestampAndMember: Equatable, Hashable {
         let timestamp: Timestamp
         let member: Int
     }


### PR DESCRIPTION
For very large Sequences groupedPreservedOrder is slow due to O(N^2) behaviour.