### PR TITLE
Add AirIndex Today and Weather Journey to apps showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The API is available for non-commercial use at no cost. Despite being free of ch
 
 Apps:
 
+- [AirIndex Today](https://airindex.today/) Air quality forecasts across the globe.
 - [Alpine Conditions](https://www.alpineconditions.com) Allows a user to compare multiple models at once & create ensemble forecasts for any location
 - [BusyRunner](https://busyrunner.com/) Allows users to plan their weekly runs based on the weather.
 - [Breezy Weather](https://github.com/breezy-weather/breezy-weather) A feature-rich, free and open source Material 3 Expressive Android weather app.
@@ -83,6 +84,7 @@ Apps:
 - [WeatherGraph](https://weathergraph.app) Apple Watch App
 - [WeatherMaster](https://github.com/PranshulGG/WeatherMaster) A Weather app for android inspired by the Google Pixel weather app.
 - [Weatherian](https://weatherian.com/) Multi-model meteogram (multi-platform)
+- [Weather Journey](https://weatherjourney.com/) Historical weather records, temperature trends & climate anomalies for 6,000+ cities since 1940.
 - [weewx-DWD](https://github.com/roe-dl/weewx-DWD) Weather forecasts etc. for WeeWX
 - [WetBulb](https://github.com/Isma1306/wetbulb-forecast) A simple app that shows you the wetbulb temp 24h forecast and tells you if it is dangerous.
 - [WorldWeatherMonitor](https://world-weather-monitor.vercel.app/) An interactive world weather map that displays real-time weather conditions for cities around the globe.


### PR DESCRIPTION
Hi! Adding two weather and climate apps that use Open-Meteo APIs:

[AirIndex Today](https://airindex.today/) Air quality forecasts across the globe.

[Weather Journey](https://weatherjourney.com/) Historical weather records, temperature trends & climate anomalies for 6,000+ cities since 1940.

Thanks!