### PR TITLE
fix: erroneous daily aggregations in single runs api

### DIFF
--- a/Sources/App/Controllers/ForecastapiController.swift
+++ b/Sources/App/Controllers/ForecastapiController.swift
@@ -315,6 +315,9 @@ struct WeatherApiController {
                 locations = try await coordinates.asyncMap { prepared in
                     let coordinates = prepared.coordinate
                     let timezone = prepared.timezone
+                    if params.run != nil {
+                        try params.validateSingleRunAggregationsAlignWithLocalPeriodStart(timezone: timezone)
+                    }
                     let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: forecastDayDefault, forecastDaysMax: forecastDaysMax, startEndDate: prepared.startEndDate, allowedRange: allowedRange, pastDaysMax: pastDaysMax)
                     let readers: [MultiDomainsReader] = try await domains.asyncCompactMap { domain in
                         guard let r = try await domain.getReaders(lat: coordinates.latitude, lon: coordinates.longitude, elevation: coordinates.elevation, mode: cellSelection, options: options, biasCorrection: biasCorrection, include15Min: include15Min) else {
@@ -342,6 +345,9 @@ struct WeatherApiController {
                     let run = (domain.useLatestRun && run == nil) ? try await domain.getDomainAndVariable()?.singleDomain?.getLatestFullRun(client: options.httpClient, logger: options.logger)?.toIsoDateTime() : run
 
                     if dates.count == 0 {
+                        if params.run != nil {
+                            try params.validateSingleRunAggregationsAlignWithLocalPeriodStart(timezone: timezone)
+                        }
                         let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: forecastDayDefault, forecastDaysMax: forecastDaysMax, startEndDate: nil, allowedRange: allowedRange, pastDaysMax: pastDaysMax)
                         let timeLocal = TimerangeLocal(range: time.dailyRead.range, utcOffsetSeconds: timezone.utcOffsetSeconds)
                         var locationId = -1
@@ -354,6 +360,9 @@ struct WeatherApiController {
                     }
                     
                     return try await dates.asyncFlatMap({ date -> [ForecastapiResult<MultiDomainsReader>.PerLocation] in
+                        if params.run != nil {
+                            try params.validateSingleRunAggregationsAlignWithLocalPeriodStart(timezone: timezone)
+                        }
                         let time = try params.getTimerange2(timezone: timezone, current: currentTime, forecastDaysDefault: forecastDayDefault, forecastDaysMax: forecastDaysMax, startEndDate: date, allowedRange: allowedRange, pastDaysMax: pastDaysMax)
                         let timeLocal = TimerangeLocal(range: time.dailyRead.range, utcOffsetSeconds: timezone.utcOffsetSeconds)
                         var locationId = -1

--- a/Sources/App/Helper/ForecastapiQuery.swift
+++ b/Sources/App/Helper/ForecastapiQuery.swift
@@ -419,7 +419,7 @@ struct ApiQueryParameter: Content, ApiUnitsSelectable {
         // If a single run is selected, start time-range from run
         if let run {
             let current = run.toTimestamp()
-            let daily = Self.forecastTimeRange2(currentTime: current, utcOffset: 0, pastSteps: 0, forecastSteps: forecast_days ?? forecastDaysDefault, initialStep: 0, dtSeconds: 86400)
+            let daily = TimerangeDt(start: current, nTime: forecast_days ?? forecastDaysDefault, dtSeconds: 86400)
 
             let defaultForecastHours = (forecast_days ?? forecastDaysDefault)*24
             let hourly = Self.forecastTimeRange2(currentTime: current, utcOffset: 0, pastSteps: 0, forecastSteps: forecast_hours ?? defaultForecastHours, initialStep: run.hour, dtSeconds: 3600)
@@ -486,6 +486,24 @@ struct ApiQueryParameter: Content, ApiUnitsSelectable {
             hourlyRead: hourly.add(-1 * utcOffset),
             minutely15: minutely_15.add(-1 * actualUtcOffset)
         )
+    }
+
+    func validateSingleRunAggregationsAlignWithLocalPeriodStart(timezone: TimezoneWithOffset) throws {
+        guard let run else {
+            return
+        }
+        let localRun = run.toTimestamp().add(timezone.utcOffsetSeconds)
+        let localRunDate = localRun.toComponents()
+        let isLocalMidnight = localRun.hour == 0 && localRun.minute == 0 && localRun.second == 0
+        if daily?.isEmpty == false && !isLocalMidnight {
+            throw ForecastApiError.generic(message: "Parameter 'daily' is only supported for single-runs-api if 'run' starts at 00:00 in the requested timezone")
+        }
+        if weekly?.isEmpty == false && (!isLocalMidnight || localRun.weekday != .monday) {
+            throw ForecastApiError.generic(message: "Parameter 'weekly' is only supported for single-runs-api if 'run' starts at Monday 00:00 in the requested timezone")
+        }
+        if monthly?.isEmpty == false && (!isLocalMidnight || localRunDate.day != 1) {
+            throw ForecastApiError.generic(message: "Parameter 'monthly' is only supported for single-runs-api if 'run' starts on day 1 at 00:00 in the requested timezone")
+        }
     }
 
     /// Return an aligned timerange for a local-time 7 day forecast. Timestamps are in UTC time. UTC offset has not been subtracted.

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -27,6 +27,31 @@ import VaporTesting
         #expect(b?.prettyString() == "2024-02-03T00:00 to 2024-02-03T03:00 (1-hourly)")
     }
 
+    @Test func singleRunDailyRequiresLocalMidnight() throws {
+        let timezone = TimezoneWithOffset(utcOffsetSeconds: -4 * 3600, identifier: "America/New_York", abbreviation: "GMT-4")
+        let invalidDaily = try JSONDecoder().decode(ApiQueryParameter.self, from: Data("""
+        {"run":"2026-06-01T00:00","daily":["temperature_2m_mean"]}
+        """.utf8))
+
+        #expect(throws: ForecastApiError.self) {
+            try invalidDaily.validateSingleRunAggregationsAlignWithLocalPeriodStart(timezone: timezone)
+        }
+
+        let valid = try JSONDecoder().decode(ApiQueryParameter.self, from: Data("""
+        {"run":"2026-06-01T04:00","forecast_days":3,"daily":["temperature_2m_mean"]}
+        """.utf8))
+        try valid.validateSingleRunAggregationsAlignWithLocalPeriodStart(timezone: timezone)
+
+        let current = Timestamp(2026, 6, 24)
+        let allowedRange = Timestamp(2023, 1, 1)..<Timestamp(2026, 7, 1)
+        let time = try valid.getTimerange2(timezone: timezone, current: current, forecastDaysDefault: 7, forecastDaysMax: 16, startEndDate: nil, allowedRange: allowedRange, pastDaysMax: 3650)
+        let dailyDates = Array(time.dailyDisplay.iterate(format: .iso8601, utc_offset_seconds: timezone.utcOffsetSeconds, quotedString: false, onlyDate: true))
+
+        #expect(dailyDates == ["2026-06-01", "2026-06-02", "2026-06-03"])
+        #expect(time.dailyRead.range.lowerBound == Timestamp(2026, 6, 1, 4))
+        #expect(time.hourlyRead.range.lowerBound == Timestamp(2026, 6, 1, 4))
+    }
+
     @Test func timeAlignmentMinutely15() throws {
         // Test that unaligned timestamps are properly rounded to 15-minute boundaries
         let start = Timestamp(2025, 12, 03, 0, 20)  // 00:20 should round down to 00:15


### PR DESCRIPTION
Proposed fix for https://github.com/open-meteo/open-meteo/issues/1917.

If the selected run does not resolve to start at hour 0 in the detected or selected timezone, daily aggregations are not allowed. 