### PR TITLE
fix: continuation-token broken url-encoding was causing S3 download issues

### DIFF
--- a/Sources/App/Helper/Download/AWSSigner.swift
+++ b/Sources/App/Helper/Download/AWSSigner.swift
@@ -16,6 +16,13 @@ extension CharacterSet {
     }()
 }
 
+extension String {
+    /// Add Percentage encoding, but keep alphanumerics and -_.~
+    var awsPercentEncoded: String {
+        addingPercentEncoding(withAllowedCharacters: .awsUriAllowed) ?? self
+    }
+}
+
 /// Sign AWS URLs with AWS4-HMAC-SHA256
 public struct AWSSigner {
     public let accessKey: String

--- a/Sources/App/Helper/Download/S3List.swift
+++ b/Sources/App/Helper/Download/S3List.swift
@@ -34,19 +34,14 @@ enum S3List {
         var continuation: String? = nil
         let logger = Logger(label: "S3List")
         while true {
-            guard var urlComponents = URLComponents(string: server) else {
-                fatalError("Could not parse URL \(server) to URLComponents")
+            var url = "\(server)?list-type=2&delimiter=%2F&prefix=\(prefix.awsPercentEncoded)"
+            if let continuation {
+                url += "&continuation-token=\(continuation.awsPercentEncoded)"
             }
-            // Encode all reserved chars incl. `+` and `/`. `queryItems` leaves `+` literal and S3 decodes it as a space -> "continuation token provided is incorrect".
-            func enc(_ value: String) -> String { value.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? value }
-            urlComponents.percentEncodedQueryItems = [
-                URLQueryItem(name: "list-type", value: "2"),
-                URLQueryItem(name: "delimiter", value: enc("/")),
-                URLQueryItem(name: "prefix", value: enc(prefix)),
-                continuation.map { URLQueryItem(name: "continuation-token", value: enc($0)) },
-                apikey.map { URLQueryItem(name: "apikey", value: enc($0)) }
-            ].compactMap { $0 }
-            let request = HTTPClientRequest(url: urlComponents.url!.absoluteString)
+            if let apikey {
+                url += "&apikey=\(apikey.awsPercentEncoded)"
+            }
+            let request = HTTPClientRequest(url: url)
 
             var response = try await client.executeRetryAndCollect(request, logger: logger, upTo: 50 * 1024 * 1024, timeoutPerRequest: .seconds(90))
             guard let body = response.readString(length: response.readableBytes) else {

--- a/Sources/App/Helper/Download/S3List.swift
+++ b/Sources/App/Helper/Download/S3List.swift
@@ -26,7 +26,7 @@ enum S3List {
         let modificationTime: Date
         let fileSize: Int
     }
-    
+
     /// Use the AWS ListObjectsV2 to list files and directories inside a bucket with a prefix. No support more than 1000 objects yet
     static func s3list(client: HTTPClient, server: String, prefix: String, apikey: String?, deadLineHours: Double) async throws -> (files: [S3List.ListV2File], directories: [String]) {
         var allFiles: [S3List.ListV2File] = []
@@ -34,28 +34,25 @@ enum S3List {
         var continuation: String? = nil
         let logger = Logger(label: "S3List")
         while true {
-            /*var vaporRequest = ClientRequest(method: .GET, url: URI("\(server)"))
-            let params = S3List.ListV2Query(list_type: 2, delimiter: "/", prefix: prefix, apikey: apikey, continuation_token: continuation)
-            try vaporRequest.query.encode(params)
-            let request = HTTPClientRequest(url: vaporRequest.url.string)*/
-            
             guard var urlComponents = URLComponents(string: server) else {
                 fatalError("Could not parse URL \(server) to URLComponents")
             }
-            urlComponents.queryItems = [
+            // Encode all reserved chars incl. `+` and `/`. `queryItems` leaves `+` literal and S3 decodes it as a space -> "continuation token provided is incorrect".
+            func enc(_ value: String) -> String { value.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? value }
+            urlComponents.percentEncodedQueryItems = [
                 URLQueryItem(name: "list-type", value: "2"),
-                URLQueryItem(name: "delimiter", value: "/"),
-                URLQueryItem(name: "prefix", value: prefix),
-                continuation.map { URLQueryItem(name: "continuation-token", value: $0) },
-                apikey.map { URLQueryItem(name: "apikey", value: $0) }
+                URLQueryItem(name: "delimiter", value: enc("/")),
+                URLQueryItem(name: "prefix", value: enc(prefix)),
+                continuation.map { URLQueryItem(name: "continuation-token", value: enc($0)) },
+                apikey.map { URLQueryItem(name: "apikey", value: enc($0)) }
             ].compactMap { $0 }
             let request = HTTPClientRequest(url: urlComponents.url!.absoluteString)
-            
+
             var response = try await client.executeRetryAndCollect(request, logger: logger, upTo: 50 * 1024 * 1024, timeoutPerRequest: .seconds(90))
             guard let body = response.readString(length: response.readableBytes) else {
                 return (allFiles, allDirectories)
             }
-            
+
             let files = body.xmlSection("Contents").map {
                 guard let name = $0.xmlFirst("Key"),
                       let modificationTimeString = $0.xmlFirst("LastModified"),


### PR DESCRIPTION
@patrick-zippenfenig , This PR solves the S3 continuation-token encoding issue, which causes error like this:

```
[ INFO ] Download failed unrecoverable with badRequest(body: Optional("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>InvalidArgument</Code><Message>The continuation token provided is incorrect</Message><ArgumentName>continuation-token</ArgumentName><RequestId>HZXH6QAKAESX9BA9</RequestId><HostId>7FLYLUZXC31CVOAUQMzFXGoi4OyPvmt2D6VUUDycoyswdFvjWSha85cJ1/YuZY3BgQmZ4JcAOv0DWuZlnDQ4LAUjCLbKij44</HostId></Error>")). URL https://openmeteo.s3.amazonaws.com/?list-type=2&delimiter=/&prefix=data/meteofrance_arome_france_hd_15min/cape/&continuation-token=1uUbI5tzFY1ypVK1UlY+BBZs0kWd4G5Ah9I8DGjvFO/uoCEAfE0lSg954qGWkVE//tdhyMD29t+4Qc+1OsSFnNK6fbek9jWlwKKa6Qquxuh4%3D
```