### PR TITLE
change severity to "Notice" for OmFileManager heartbeat messages

### DIFF
--- a/Sources/App/Helper/File/RemoteOmFileManager.swift
+++ b/Sources/App/Helper/File/RemoteOmFileManager.swift
@@ -225,9 +225,9 @@ final class RemoteFileManager: Sendable {
         }
         let total = await cache.count()
         if total > 0, OmStatistics.lastPrintUnitTimestampSeconds.load(ordering: .relaxed) < Timestamp.now().subtract(minutes: 1).timeIntervalSince1970 {
-            logger.error("OmFileManager: \(total) open files. Revalidation took \(startRevalidation.timeElapsedPretty()). \(OmStatistics.toString())")
+            logger.notice("OmFileManager: \(total) open files. Revalidation took \(startRevalidation.timeElapsedPretty()). \(OmStatistics.toString())")
             if OpenMeteo.remoteDataDirectory != nil {
-                logger.error("\(OpenMeteo.dataBlockCache.cache.statistics().prettyPrint)")
+                logger.notice("\(OpenMeteo.dataBlockCache.cache.statistics().prettyPrint)")
             }
             OmStatistics.reset()
         }


### PR DESCRIPTION
changes severity from "ERROR" to "NOTICE" for OmFileManager heartbeat messages:

```
[ ERROR ] OmFileManager: 195 open files. Revalidation took 0.12ms. inactivity=0 localModified=0 remoteModified=0 remoteDeleted=0 remoteRevalidated=0 remoteCheckedExist=0 currentlyOpeningFiles=0 currentlyWaitingOnOpeningFiles=0
```