### PR TITLE
feat: add cgroup memory limit of 90% for openmeteo-api

### DIFF
--- a/.github/workflows/build_parquet.yml
+++ b/.github/workflows/build_parquet.yml
@@ -48,7 +48,7 @@ jobs:
           # -d swiftlang-slim -d libeccodes0
           # -d gir1.2-parquet-1.0... ideally would get the correct library version....
           # -d libarrow-glib-dev -d libparquet-glib-dev
-          fpm_opts: '-s dir -t deb -n openmeteo-api -v 0.0.0 -d tzdata -d libnetcdf19 -d libeccodes0 -d gir1.2-parquet-1.0 --deb-systemd-enable --deb-systemd-auto-start --deb-systemd build/openmeteo-sync.service --deb-systemd build/openmeteo-api.service  --deb-systemd build/openmeteo-api2.service  --deb-systemd build/openmeteo-api3.service --deb-default build/openmeteo-api.env --before-install build/openmeteo-before-install.sh --before-upgrade build/openmeteo-before-install.sh build/openmeteo-notify.sh=/usr/local/bin/ openmeteo-api=/usr/local/bin/ swift-backtrace=/usr/local/bin/ Public=/var/lib/openmeteo-api Resources=/var/lib/openmeteo-api'
+          fpm_opts: '-s dir -t deb -n openmeteo-api -v 0.0.0 -d tzdata -d libnetcdf19 -d libeccodes0 -d gir1.2-parquet-1.0 --deb-systemd-enable --deb-systemd-auto-start --deb-systemd build/openmeteo.slice --deb-systemd build/openmeteo-sync.service --deb-systemd build/openmeteo-api.service  --deb-systemd build/openmeteo-api2.service  --deb-systemd build/openmeteo-api3.service --deb-default build/openmeteo-api.env --before-install build/openmeteo-before-install.sh --before-upgrade build/openmeteo-before-install.sh build/openmeteo-notify.sh=/usr/local/bin/ openmeteo-api=/usr/local/bin/ swift-backtrace=/usr/local/bin/ Public=/var/lib/openmeteo-api Resources=/var/lib/openmeteo-api'
       - name: Rename deb file
         run: mv openmeteo-api_0.0.0_amd64.deb openmeteo-api_0.0.0_jammy_amd64.deb
       # - name: 'Upload Artifact'

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -46,7 +46,7 @@ jobs:
       with:
         fpm_args: './build'
         # -d swiftlang-slim -d libeccodes0
-        fpm_opts: '-s dir -t deb -n openmeteo-api -v 0.0.0 -d tzdata -d libnetcdf19 -d libeccodes0 --deb-systemd-enable --deb-systemd-auto-start --deb-systemd build/openmeteo-sync.service --deb-systemd build/openmeteo-api.service  --deb-systemd build/openmeteo-api2.service  --deb-systemd build/openmeteo-api3.service --deb-default build/openmeteo-api.env --before-install build/openmeteo-before-install.sh --before-upgrade build/openmeteo-before-install.sh build/openmeteo-notify.sh=/usr/local/bin/ openmeteo-api=/usr/local/bin/ swift-backtrace=/usr/local/bin/ Public=/var/lib/openmeteo-api Resources=/var/lib/openmeteo-api'
+        fpm_opts: '-s dir -t deb -n openmeteo-api -v 0.0.0 -d tzdata -d libnetcdf19 -d libeccodes0 --deb-systemd-enable --deb-systemd-auto-start --deb-systemd build/openmeteo.slice --deb-systemd build/openmeteo-sync.service --deb-systemd build/openmeteo-api.service  --deb-systemd build/openmeteo-api2.service  --deb-systemd build/openmeteo-api3.service --deb-default build/openmeteo-api.env --before-install build/openmeteo-before-install.sh --before-upgrade build/openmeteo-before-install.sh build/openmeteo-notify.sh=/usr/local/bin/ openmeteo-api=/usr/local/bin/ swift-backtrace=/usr/local/bin/ Public=/var/lib/openmeteo-api Resources=/var/lib/openmeteo-api'
     - name: Rename deb file
       run: mv openmeteo-api_0.0.0_amd64.deb openmeteo-api_0.0.0_jammy_amd64.deb
     # - name: 'Upload Artifact'

--- a/.github/workflows/build_ubuntu_noble.yml
+++ b/.github/workflows/build_ubuntu_noble.yml
@@ -46,7 +46,7 @@ jobs:
       with:
         fpm_args: './build'
         # -d swiftlang-slim -d libeccodes0
-        fpm_opts: '-s dir -t deb -n openmeteo-api -v 0.0.0 -d tzdata -d libnetcdf19t64 -d libeccodes0 --deb-systemd-enable --deb-systemd-auto-start --deb-systemd build/openmeteo-sync.service --deb-systemd build/openmeteo-api.service  --deb-systemd build/openmeteo-api2.service  --deb-systemd build/openmeteo-api3.service --deb-default build/openmeteo-api.env --before-install build/openmeteo-before-install.sh --before-upgrade build/openmeteo-before-install.sh build/openmeteo-notify.sh=/usr/local/bin/ openmeteo-api=/usr/local/bin/ swift-backtrace=/usr/local/bin/ Public=/var/lib/openmeteo-api Resources=/var/lib/openmeteo-api'
+        fpm_opts: '-s dir -t deb -n openmeteo-api -v 0.0.0 -d tzdata -d libnetcdf19t64 -d libeccodes0 --deb-systemd-enable --deb-systemd-auto-start --deb-systemd build/openmeteo.slice --deb-systemd build/openmeteo-sync.service --deb-systemd build/openmeteo-api.service  --deb-systemd build/openmeteo-api2.service  --deb-systemd build/openmeteo-api3.service --deb-default build/openmeteo-api.env --before-install build/openmeteo-before-install.sh --before-upgrade build/openmeteo-before-install.sh build/openmeteo-notify.sh=/usr/local/bin/ openmeteo-api=/usr/local/bin/ swift-backtrace=/usr/local/bin/ Public=/var/lib/openmeteo-api Resources=/var/lib/openmeteo-api'
     - name: Rename deb file
       run: mv openmeteo-api_0.0.0_amd64.deb openmeteo-api_0.0.0_noble_amd64.deb
     # - name: 'Upload Artifact'

--- a/.github/workflows/debug_ubuntu.yml
+++ b/.github/workflows/debug_ubuntu.yml
@@ -46,7 +46,7 @@ jobs:
       with:
         fpm_args: './build'
         # -d swiftlang-slim -d libeccodes0
-        fpm_opts: '-s dir -t deb -n openmeteo-api -v 0.0.0 -d tzdata -d libnetcdf19 -d libeccodes0 --deb-systemd-enable --deb-systemd-auto-start --deb-systemd build/openmeteo-sync.service --deb-systemd build/openmeteo-api.service  --deb-systemd build/openmeteo-api2.service  --deb-systemd build/openmeteo-api3.service --deb-default build/openmeteo-api.env --before-install build/openmeteo-before-install.sh --before-upgrade build/openmeteo-before-install.sh build/openmeteo-notify.sh=/usr/local/bin/ openmeteo-api=/usr/local/bin/ swift-backtrace=/usr/local/bin/ Public=/var/lib/openmeteo-api Resources=/var/lib/openmeteo-api'
+        fpm_opts: '-s dir -t deb -n openmeteo-api -v 0.0.0 -d tzdata -d libnetcdf19 -d libeccodes0 --deb-systemd-enable --deb-systemd-auto-start --deb-systemd build/openmeteo.slice --deb-systemd build/openmeteo-sync.service --deb-systemd build/openmeteo-api.service  --deb-systemd build/openmeteo-api2.service  --deb-systemd build/openmeteo-api3.service --deb-default build/openmeteo-api.env --before-install build/openmeteo-before-install.sh --before-upgrade build/openmeteo-before-install.sh build/openmeteo-notify.sh=/usr/local/bin/ openmeteo-api=/usr/local/bin/ swift-backtrace=/usr/local/bin/ Public=/var/lib/openmeteo-api Resources=/var/lib/openmeteo-api'
     - name: Rename deb file
       run: mv openmeteo-api_0.0.0_amd64.deb openmeteo-api_0.0.0_jammy_amd64.deb
     # - name: 'Upload Artifact'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         fpm_args: './build'
         # -d swiftlang-slim -d libeccodes0
-        fpm_opts: '-s dir -t deb -n openmeteo-api -v ${{github.ref_name}} -d tzdata -d libnetcdf19 -d libeccodes0 --deb-systemd-enable --deb-systemd-auto-start --deb-systemd build/openmeteo-sync.service --deb-systemd build/openmeteo-api.service  --deb-systemd build/openmeteo-api2.service  --deb-systemd build/openmeteo-api3.service --deb-default build/openmeteo-api.env --before-install build/openmeteo-before-install.sh --before-upgrade build/openmeteo-before-install.sh build/openmeteo-notify.sh=/usr/local/bin/ openmeteo-api=/usr/local/bin/ swift-backtrace=/usr/local/bin/ Public=/var/lib/openmeteo-api Resources=/var/lib/openmeteo-api'
+        fpm_opts: '-s dir -t deb -n openmeteo-api -v ${{github.ref_name}} -d tzdata -d libnetcdf19 -d libeccodes0 --deb-systemd-enable --deb-systemd-auto-start --deb-systemd build/openmeteo.slice --deb-systemd build/openmeteo-sync.service --deb-systemd build/openmeteo-api.service  --deb-systemd build/openmeteo-api2.service  --deb-systemd build/openmeteo-api3.service --deb-default build/openmeteo-api.env --before-install build/openmeteo-before-install.sh --before-upgrade build/openmeteo-before-install.sh build/openmeteo-notify.sh=/usr/local/bin/ openmeteo-api=/usr/local/bin/ swift-backtrace=/usr/local/bin/ Public=/var/lib/openmeteo-api Resources=/var/lib/openmeteo-api'
     - name: Rename deb file
       run: mv openmeteo-api_${{github.ref_name}}_amd64.deb openmeteo-api_${{github.ref_name}}_jammy_amd64.deb
     - name: Release

--- a/build/openmeteo-api.service
+++ b/build/openmeteo-api.service
@@ -8,6 +8,8 @@ PassEnvironment=VAPOR_ENV API_SYNC_APIKEYS NGINX_SENDFILE_PREFIX LOG_LEVEL CACHE
 Type=simple
 User=openmeteo-api
 Group=openmeteo-api
+Slice=openmeteo.slice
+OOMPolicy=stop
 WorkingDirectory=/var/lib/openmeteo-api/
 ExecStart=/usr/local/bin/openmeteo-api serve -b $API_BIND --env $VAPOR_ENV
 ExecStopPost=/bin/bash -c 'if [ "$$EXIT_STATUS" != 0 ]; then /usr/local/bin/openmeteo-notify.sh $NOTIFICATION_EMAIL %N; fi'

--- a/build/openmeteo-api.service
+++ b/build/openmeteo-api.service
@@ -9,7 +9,7 @@ Type=simple
 User=openmeteo-api
 Group=openmeteo-api
 Slice=openmeteo.slice
-OOMPolicy=stop
+OOMPolicy=kill
 WorkingDirectory=/var/lib/openmeteo-api/
 ExecStart=/usr/local/bin/openmeteo-api serve -b $API_BIND --env $VAPOR_ENV
 ExecStopPost=/bin/bash -c 'if [ "$$EXIT_STATUS" != 0 ]; then /usr/local/bin/openmeteo-notify.sh $NOTIFICATION_EMAIL %N; fi'

--- a/build/openmeteo-api2.service
+++ b/build/openmeteo-api2.service
@@ -9,7 +9,7 @@ Type=simple
 User=openmeteo-api
 Group=openmeteo-api
 Slice=openmeteo.slice
-OOMPolicy=stop
+OOMPolicy=kill
 WorkingDirectory=/var/lib/openmeteo-api/
 ExecStart=/usr/local/bin/openmeteo-api serve -b $API_BIND2 --env $VAPOR_ENV
 ExecStopPost=/bin/bash -c 'if [[ "$$EXIT_STATUS" != 0 && -n "$API_BIND2" ]]; then /usr/local/bin/openmeteo-notify.sh $NOTIFICATION_EMAIL %N; fi'

--- a/build/openmeteo-api2.service
+++ b/build/openmeteo-api2.service
@@ -8,6 +8,8 @@ PassEnvironment=VAPOR_ENV API_SYNC_APIKEYS NGINX_SENDFILE_PREFIX LOG_LEVEL CACHE
 Type=simple
 User=openmeteo-api
 Group=openmeteo-api
+Slice=openmeteo.slice
+OOMPolicy=stop
 WorkingDirectory=/var/lib/openmeteo-api/
 ExecStart=/usr/local/bin/openmeteo-api serve -b $API_BIND2 --env $VAPOR_ENV
 ExecStopPost=/bin/bash -c 'if [[ "$$EXIT_STATUS" != 0 && -n "$API_BIND2" ]]; then /usr/local/bin/openmeteo-notify.sh $NOTIFICATION_EMAIL %N; fi'

--- a/build/openmeteo-api3.service
+++ b/build/openmeteo-api3.service
@@ -8,6 +8,8 @@ PassEnvironment=VAPOR_ENV API_SYNC_APIKEYS NGINX_SENDFILE_PREFIX LOG_LEVEL CACHE
 Type=simple
 User=openmeteo-api
 Group=openmeteo-api
+Slice=openmeteo.slice
+OOMPolicy=stop
 WorkingDirectory=/var/lib/openmeteo-api/
 ExecStart=/usr/local/bin/openmeteo-api serve -b $API_BIND3 --env $VAPOR_ENV
 ExecStopPost=/bin/bash -c 'if [[ "$$EXIT_STATUS" != 0 && -n "$API_BIND3" ]]; then /usr/local/bin/openmeteo-notify.sh $NOTIFICATION_EMAIL %N; fi'

--- a/build/openmeteo-api3.service
+++ b/build/openmeteo-api3.service
@@ -9,7 +9,7 @@ Type=simple
 User=openmeteo-api
 Group=openmeteo-api
 Slice=openmeteo.slice
-OOMPolicy=stop
+OOMPolicy=kill
 WorkingDirectory=/var/lib/openmeteo-api/
 ExecStart=/usr/local/bin/openmeteo-api serve -b $API_BIND3 --env $VAPOR_ENV
 ExecStopPost=/bin/bash -c 'if [[ "$$EXIT_STATUS" != 0 && -n "$API_BIND3" ]]; then /usr/local/bin/openmeteo-notify.sh $NOTIFICATION_EMAIL %N; fi'

--- a/build/openmeteo.slice
+++ b/build/openmeteo.slice
@@ -1,0 +1,9 @@
+[Unit]
+Description=Open-Meteo API services
+
+[Slice]
+MemoryAccounting=yes
+MemoryMax=90%
+
+[Install]
+WantedBy=slices.target


### PR DESCRIPTION
### Summary 
Caps the combined memory usage of all API instances at 90% of physical RAM. 
Memory-mapped page cache counts toward the limit and is reclaimed first! Only if reclaim is insufficient this should kill and restart the (one) affected API service, while the other instances remain available.