### PR TITLE
fix: update eu AQI to 2024 bands and hourly pm

### DIFF
--- a/Sources/App/Cams/CamsReader.swift
+++ b/Sources/App/Cams/CamsReader.swift
@@ -24,13 +24,11 @@ struct CamsReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             })
             return DataAndUnit(max, .europeanAirQualityIndex)
         case .european_aqi_pm2_5:
-            let timeAhead = time.with(start: time.range.lowerBound.add(-24 * 3600))
-            let pm2_5 = try await get(raw: .pm2_5, time: timeAhead).data.slidingAverageDroppingFirstDt(dt: 24 * 3600 / time.dtSeconds)
+            let pm2_5 = try await get(raw: .pm2_5, time: time).data
             return DataAndUnit(pm2_5.map(EuropeanAirQuality.indexPm2_5), .europeanAirQualityIndex)
         case .european_aqi_pm10:
-            let timeAhead = time.with(start: time.range.lowerBound.add(-24 * 3600))
-            let pm10avg = try await get(raw: .pm10, time: timeAhead).data.slidingAverageDroppingFirstDt(dt: 24 * 3600 / time.dtSeconds)
-            return DataAndUnit(pm10avg.map(EuropeanAirQuality.indexPm10), .europeanAirQualityIndex)
+            let pm10 = try await get(raw: .pm10, time: time).data
+            return DataAndUnit(pm10.map(EuropeanAirQuality.indexPm10), .europeanAirQualityIndex)
         case .european_aqi_nitrogen_dioxide, .european_aqi_no2:
             let no2 = try await get(raw: .nitrogen_dioxide, time: time).data
             return DataAndUnit(no2.map(EuropeanAirQuality.indexNo2), .europeanAirQualityIndex)
@@ -94,9 +92,9 @@ struct CamsReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             try await prefetchData(derived: .european_aqi_o3, time: time)
             try await prefetchData(derived: .european_aqi_so2, time: time)
         case .european_aqi_pm2_5:
-            try await prefetchData(raw: .pm2_5, time: time.with(start: time.range.lowerBound.add(-24 * 3600)))
+            try await prefetchData(raw: .pm2_5, time: time)
         case .european_aqi_pm10:
-            try await prefetchData(raw: .pm10, time: time.with(start: time.range.lowerBound.add(-24 * 3600)))
+            try await prefetchData(raw: .pm10, time: time)
         case .european_aqi_nitrogen_dioxide, .european_aqi_no2:
             try await prefetchData(raw: .nitrogen_dioxide, time: time)
         case .european_aqi_ozone, .european_aqi_o3:

--- a/Sources/App/Helper/AirQuality.swift
+++ b/Sources/App/Helper/AirQuality.swift
@@ -1,12 +1,13 @@
 import Foundation
 
-/// European Air Quality index: https://www.eea.europa.eu/themes/air/air-quality-index in the right legend press "About the European Air Quality Index"
+/// European Air Quality index: https://airindex.eea.europa.eu/AQI/index.html
+/// Index bands as revised by the EEA in 2024, see ETC HE Report 2024/17. Hourly concentrations are used for all five pollutants.
 enum EuropeanAirQuality {
-    static let no2HourlyThresholds: [Float] = [0, 40, 90, 120, 230, 340]
-    static let o3HourlyThresholds: [Float] = [0, 50, 100, 130, 240, 380]
-    static let so2HourlyThresholds: [Float] = [0, 100, 200, 350, 500, 750]
-    static let pm2_5_24HourlyMeanThresholds: [Float] = [0, 10, 20, 25, 50, 75]
-    static let pm10_24HourlyMeanThresholds: [Float] = [0, 20, 40, 50, 100, 150]
+    static let no2HourlyThresholds: [Float] = [0, 10, 25, 60, 100, 150]
+    static let o3HourlyThresholds: [Float] = [0, 60, 100, 120, 160, 180]
+    static let so2HourlyThresholds: [Float] = [0, 20, 40, 125, 190, 275]
+    static let pm2_5HourlyThresholds: [Float] = [0, 5, 15, 50, 90, 140]
+    static let pm10HourlyThresholds: [Float] = [0, 15, 45, 120, 195, 270]
 
     /// Accept hourly values
     @inlinable static func indexNo2(no2: Float) -> Float {
@@ -23,14 +24,14 @@ enum EuropeanAirQuality {
         return so2HourlyThresholds.positionExtrapolated(of: so2) * 20
     }
 
-    /// Accept 24h running mean
-    @inlinable static func indexPm10(pm10_24h_mean: Float) -> Float {
-        return pm10_24HourlyMeanThresholds.positionExtrapolated(of: pm10_24h_mean) * 20
+    /// Accept hourly values
+    @inlinable static func indexPm10(pm10: Float) -> Float {
+        return pm10HourlyThresholds.positionExtrapolated(of: pm10) * 20
     }
 
-    /// Accept 24h running mean
-    @inlinable static func indexPm2_5(pm2_5_24h_mean: Float) -> Float {
-        return pm2_5_24HourlyMeanThresholds.positionExtrapolated(of: pm2_5_24h_mean) * 20
+    /// Accept hourly values
+    @inlinable static func indexPm2_5(pm2_5: Float) -> Float {
+        return pm2_5HourlyThresholds.positionExtrapolated(of: pm2_5) * 20
     }
 }
 

--- a/Tests/AppTests/AirQualityTests.swift
+++ b/Tests/AppTests/AirQualityTests.swift
@@ -7,18 +7,31 @@ import Testing
     @Test func europeanAirQuality() {
         #expect(EuropeanAirQuality.indexNo2(no2: -1).isNaN)
         #expect(EuropeanAirQuality.indexNo2(no2: 0) == 0)
-        #expect(EuropeanAirQuality.indexNo2(no2: 20) == 10)
-        #expect(EuropeanAirQuality.indexNo2(no2: 65) == 30)
-        #expect(EuropeanAirQuality.indexNo2(no2: 105) == 50)
-        #expect(EuropeanAirQuality.indexNo2(no2: 175) == 70)
-        #expect(EuropeanAirQuality.indexNo2(no2: 285) == 90)
-        #expect(EuropeanAirQuality.indexNo2(no2: 395) == 110)
+        #expect(EuropeanAirQuality.indexNo2(no2: 5) == 10)
+        #expect(EuropeanAirQuality.indexNo2(no2: 17.5) == 30)
+        #expect(EuropeanAirQuality.indexNo2(no2: 42.5) == 50)
+        #expect(EuropeanAirQuality.indexNo2(no2: 80) == 70)
+        #expect(EuropeanAirQuality.indexNo2(no2: 125) == 90)
+        #expect(EuropeanAirQuality.indexNo2(no2: 175) == 110)
 
-        #expect(EuropeanAirQuality.indexO3(o3: 30) == 12.0)
-        #expect(EuropeanAirQuality.indexO3(o3: 90) == 36.0)
-        #expect(EuropeanAirQuality.indexO3(o3: 150).isApproximatelyEqual(to: 63.636364, absoluteTolerance: 0.001))
-        #expect(EuropeanAirQuality.indexO3(o3: 210).isApproximatelyEqual(to: 74.545456, absoluteTolerance: 0.001))
-        #expect(EuropeanAirQuality.indexO3(o3: 260).isApproximatelyEqual(to: 82.85714, absoluteTolerance: 0.001))
+        #expect(EuropeanAirQuality.indexO3(o3: 30) == 10)
+        #expect(EuropeanAirQuality.indexO3(o3: 80) == 30)
+        #expect(EuropeanAirQuality.indexO3(o3: 110) == 50)
+        #expect(EuropeanAirQuality.indexO3(o3: 140) == 70)
+        #expect(EuropeanAirQuality.indexO3(o3: 170) == 90)
+        #expect(EuropeanAirQuality.indexO3(o3: 190) == 110)
+
+        #expect(EuropeanAirQuality.indexPm2_5(pm2_5: 2.5) == 10)
+        #expect(EuropeanAirQuality.indexPm2_5(pm2_5: 10) == 30)
+        #expect(EuropeanAirQuality.indexPm2_5(pm2_5: 32.5) == 50)
+        #expect(EuropeanAirQuality.indexPm2_5(pm2_5: 70) == 70)
+        #expect(EuropeanAirQuality.indexPm2_5(pm2_5: 115) == 90)
+
+        #expect(EuropeanAirQuality.indexPm10(pm10: 7.5) == 10)
+        #expect(EuropeanAirQuality.indexPm10(pm10: 30) == 30)
+        #expect(EuropeanAirQuality.indexPm10(pm10: 82.5) == 50)
+        #expect(EuropeanAirQuality.indexPm10(pm10: 157.5) == 70)
+        #expect(EuropeanAirQuality.indexPm10(pm10: 232.5) == 90)
     }
 
     @Test func usAirQuality() {


### PR DESCRIPTION
# Update European AQI to the 2024 EEA index bands

The EEA revised the European Air Quality Index in 2024 ([ETC HE Report 2024/17](https://www.eionet.europa.eu/etcs/etc-he/products/etc-he-products/etc-he-reports/etc-he-report-2024-17-eeas-revision-of-the-european-air-quality-index-bands/)). Our thresholds still reflect the pre-2024 index. Two things changed upstream: the breakpoints themselves, and the averaging period.

## New breakpoints (µg/m³)

| Pollutant | Current | Revised 2024 |
|---|---|---|
| PM2.5 | 0, 10, 20, 25, 50, 75 | 0, 5, 15, 50, 90, 140 |
| PM10 | 0, 20, 40, 50, 100, 150 | 0, 15, 45, 120, 195, 270 |
| NO2 | 0, 40, 90, 120, 230, 340 | 0, 10, 25, 60, 100, 150 |
| O3 | 0, 50, 100, 130, 240, 380 | 0, 60, 100, 120, 160, 180 |
| SO2 | 0, 100, 200, 350, 500, 750 | 0, 20, 40, 125, 190, 275 |

The 6 band structure and the 0-20 / 20-40 / ... index mapping are unchanged. The top band is now open ended rather than having a stated cap, which suits the existing extrapolation past the last threshold.

## Averaging period: PM moves from a 24h running mean to hourly values

The EEA now states that "hourly concentrations of all five pollutants (PM2.5, PM10, NO2, O3, SO2) are used". `CamsReader` therefore reads hourly PM2.5 and PM10 directly instead of building a 24h sliding mean, and the matching `prefetchData` cases no longer widen the requested range by 24 hours. `pm2_5_24HourlyMeanThresholds` / `indexPm2_5(pm2_5_24h_mean:)` are renamed accordingly.

These two halves cannot be applied independently. A breakpoint table is only meaningful against the statistic it is applied to, and the revised numbers are much wider at the top (140 for PM2.5 versus the old 75) precisely because hourly readings are spikier than 24h means. For six hours of smoke at 200 µg/m³ inside an otherwise clean day at 5 µg/m³:

| Thresholds | Applied to | Index |
|---|---|---|
| Old | 24h mean of 53.75 | 83, very poor (self consistent) |
| New | 24h mean of 53.75 | 62, poor (understates a 200 µg/m³ plume) |
| New | hourly value | 124 during the plume, 20 outside it |

The US index is untouched. EPA still specifies 24h averages for PM, so `slidingAverageDroppingFirstDt` stays in the `us_aqi_pm2_5` / `us_aqi_pm10` paths.

## Impact on API output

⚠️ This changes `european_aqi`, `european_aqi_pm2_5`, `european_aqi_pm10`, `european_aqi_nitrogen_dioxide`, `european_aqi_ozone` and `european_aqi_sulphur_dioxide` for all users, and not marginally. An O3 of 200 µg/m³ goes from roughly 74 to 130.

- The index now responds within the hour to rush hour NO2, dust intrusions, fireworks or smoke plumes, instead of having them diluted across 23 other hours.
- The 24h trailing shadow is gone. Values no longer stay elevated for up to a day after the air has cleared.
- Series are noticeably spikier, and since `european_aqi` is the max across pollutants, the PM components now drive that max more often.
- Each hour is self contained, so the first hours of a series no longer depend on data preceding the requested range.