### PR TITLE
Add Rapid Update Wind Map to weather apps list

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Apps:
 - [QuickWeather](https://github.com/TylerWilliamson/QuickWeather) Fast, free, and open source Android app
 - [Rain](https://github.com/DarkMooNight/Rain) Free, open source, beautiful, minimal and fast weather app
 - [Raindrop](https://github.com/metalfoxdev/Raindrop) Simple and intuitive weather app for the linux terminal.
+- [Rapid Update Wind Map](https://wind.zink.tv) Hourly updated short term wind forecasts. Based on rapid update models. Also for wind sports.
 - [Road Vagabond](https://roadvagabond.com) A camping destination discovery app showing zones within your drive time with weather-based filtering.
 - [SkyMuse](https://github.com/cakephone/skymuse) Minimal, privacy-respecting weather app. Built with web technologies.
 - [Slideshow](https://slideshow.digital/) Digital Signage app for Android


### PR DESCRIPTION
Currently Arome PI is used. Icon D2 RUC is still parsed directly from DWD. Looking forward to integrate more of the hourly updated models. Acknowledgements see https://wind.zink.tv/info.html (accessible via the logo) and on GitHub.