### PR TITLE
fix: encode hourly min/max aggregation metadata

### DIFF
--- a/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
+++ b/Sources/App/Helper/FlatBufferWriter/FlatBuffers+WeatherApi.swift
@@ -397,9 +397,9 @@ extension VariableAndPreviousDay: FlatBuffersVariable {
         case .snow_depth_water_equivalent:
             return .init(variable: .snowDepthWaterEquivalent, previousDay: previousDay)
         case .temperature_2m_max:
-            return .init(variable: .temperature, aggregation: .max, altitude: 2, previousDay: previousDay)
+            return .init(variable: .temperature, aggregation: .maximum, altitude: 2, previousDay: previousDay)
         case .temperature_2m_min:
-            return .init(variable: .temperature, aggregation: .min, altitude: 2, previousDay: previousDay)
+            return .init(variable: .temperature, aggregation: .minimum, altitude: 2, previousDay: previousDay)
         case .soil_moisture_81_to_243cm:
             return .init(variable: .soilMoisture, depth: 81, depthTo: 243, previousDay: previousDay)
         case .soil_moisture_243_to_729cm:

--- a/Tests/AppTests/OutputformatTests.swift
+++ b/Tests/AppTests/OutputformatTests.swift
@@ -113,6 +113,14 @@ struct DummyDataProvider: ModelFlatbufferSerialisable {
         })
     }*/
 
+    @Test func hourlyMinMaxFlatBufferAggregation() {
+        let minimum = VariableAndPreviousDay(.temperature_2m_min, 0).getFlatBuffersMeta()
+        let maximum = VariableAndPreviousDay(.temperature_2m_max, 0).getFlatBuffersMeta()
+
+        #expect(minimum.aggregation == .minimum)
+        #expect(maximum.aggregation == .maximum)
+    }
+
     /// Test adjustment of API call weights
     /// "Heavy" API calls are counted more than just 1 API call
     ///


### PR DESCRIPTION
## Summary

- encode hourly `temperature_2m_min` and `temperature_2m_max` metadata with the schema's `.minimum` and `.maximum` aggregation cases
- add regression coverage for both hourly FlatBuffers metadata mappings

The generated SDK also exposes `.min` and `.max` as enum-bound helpers. Those resolve to `.none_` (raw value 0) and `.efi` (raw value 15), which caused the incorrect metadata reported in the issue.

## Testing

- `CPATH=/opt/homebrew/opt/eccodes/include LIBRARY_PATH=/opt/homebrew/opt/eccodes/lib swift build --target App` (passed)
- executable metadata probe: reproduced `minimum=0 maximum=15` before the fix and passed after the fix
- `swift test --filter hourlyMinMaxFlatBufferAggregation` (locally blocked before AppTests because this Command Line Tools installation does not provide the `Testing` module required by VaporTesting)

Closes #1985

AI assistance: OpenAI Codex was used to help implement and test this change.
