### PR TITLE
fix: subhourly and daily et0 calculation

### DIFF
--- a/Sources/App/Cmip6/CmipReader.swift
+++ b/Sources/App/Cmip6/CmipReader.swift
@@ -664,7 +664,7 @@ struct Cmip6ReaderPreBiasCorrection<ReaderNext: GenericReaderProtocol>: GenericR
             let tempmean = try await get(raw: .temperature_2m_mean, time: time).data
             let wind = try await get(raw: .wind_speed_10m_mean, time: time).data
             let radiation = try await get(raw: .shortwave_radiation_sum, time: time).data
-            let exrad = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time.time.with(dtSeconds: 3600)).sum(by: 24)
+            let exradMJSum = Zensun.extraTerrestrialRadiationBackwards(latitude: reader.modelLat, longitude: reader.modelLon, timerange: time.time.with(dtSeconds: 3600)).map { $0 * 0.0036 }.sum(by: 24)
             let hasRhMinMax = !(domain == .FGOALS_f3_H || domain == .HiRAM_SIT_HR || domain == .MPI_ESM1_2_XR || domain == .FGOALS_f3_H)
             let rhmin = hasRhMinMax ? try await get(raw: .relative_humidity_2m_min, time: time).data : nil
             let rhmaxOrMean = hasRhMinMax ? try await get(raw: .relative_humidity_2m_max, time: time).data : try await get(raw: .relative_humidity_2m_mean, time: time).data
@@ -686,7 +686,7 @@ struct Cmip6ReaderPreBiasCorrection<ReaderNext: GenericReaderProtocol>: GenericR
                     windspeed10mMeterPerSecondMean: wind[i],
                     shortwaveRadiationMJSum: radiation[i],
                     elevation: elevation.isNaN ? 0 : elevation,
-                    extraTerrestrialRadiationSum: exrad[i] * 0.0036,
+                    extraTerrestrialRadiationMJSum: exradMJSum[i],
                     relativeHumidity: rh))
             }
             return DataAndUnit(et0, .millimetre)

--- a/Sources/App/Helper/FaoEvapotranspiration.swift
+++ b/Sources/App/Helper/FaoEvapotranspiration.swift
@@ -79,9 +79,9 @@ extension Meteorology {
     }
 
     /// Daily FAO et0 calculation based on https://marais.ch/doc/fao56.pdf
-    public static func et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: Float, temperature2mCelsiusDailyMin: Float, temperature2mCelsiusDailyMean: Float, windspeed10mMeterPerSecondMean: Float, shortwaveRadiationMJSum: Float, elevation: Float, extraTerrestrialRadiationSum: Float, relativeHumidity: MaxAndMinOrMean) -> Float {
+    public static func et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: Float, temperature2mCelsiusDailyMin: Float, temperature2mCelsiusDailyMean: Float, windspeed10mMeterPerSecondMean: Float, shortwaveRadiationMJSum: Float, elevation: Float, extraTerrestrialRadiationMJSum: Float, relativeHumidity: MaxAndMinOrMean) -> Float {
         /// short wave radiaton or use Hargreaves' radiation formula (Page 60)
-        let Rs = shortwaveRadiationMJSum.isNaN ? 0.16 * sqrtf(temperature2mCelsiusDailyMax - temperature2mCelsiusDailyMin) * extraTerrestrialRadiationSum : shortwaveRadiationMJSum
+        let Rs = shortwaveRadiationMJSum.isNaN ? 0.16 * sqrtf(temperature2mCelsiusDailyMax - temperature2mCelsiusDailyMin) * extraTerrestrialRadiationMJSum : shortwaveRadiationMJSum
 
         let windspeed2m = scaleWindFactor(from: 10, to: 2) * windspeed10mMeterPerSecondMean
 
@@ -126,10 +126,10 @@ extension Meteorology {
         let Rns = Rs * (1 - albedo)
 
         /// clear-sky solar radiation [MJ m-2 day-1] approximated, (Page 51)
-        let Rso = (0.75 + 0.00002 * elevation) * extraTerrestrialRadiationSum
+        let Rso = (0.75 + 0.00002 * elevation) * extraTerrestrialRadiationMJSum
 
         /// relative shortwave radiation (limited to ≤ 1.0. Although daily, could still happen at poles
-        let Rrel = extraTerrestrialRadiationSum <= 0 ? RrelAproximation : min(Rs / Rso, 1)
+        let Rrel = extraTerrestrialRadiationMJSum <= 0 ? RrelAproximation : min(Rs / Rso, 1)
 
         /// net outgoing longwave radiation [MJ m-2 day-1]
         let Rnl = boltzmanConstant * (powf(temperature2mCelsiusDailyMax + 273.16, 4) + powf(temperature2mCelsiusDailyMin + 273.16, 4)) / 2 * (0.34 - 0.14 * sqrt(ea)) * (1.35 * Rrel - 0.35)

--- a/Sources/App/Helper/FaoEvapotranspiration.swift
+++ b/Sources/App/Helper/FaoEvapotranspiration.swift
@@ -200,6 +200,6 @@ extension Meteorology {
         // evapotranspiration
         let et0 = (0.408 * vaporPressurCurveSlope * (Rn - Ghr) + γ * (37.0 / (temperature2mCelsius + 273)) * windspeed2m * vaporPressureDeficit) / (vaporPressurCurveSlope + γ * (1 + 0.34 * windspeed2m))
 
-        return max(et0 * Float(dtSeconds / 3600), 0)
+        return max(et0 * Float(dtSeconds) / 3600, 0)
     }
 }

--- a/Sources/App/Helper/FaoEvapotranspiration.swift
+++ b/Sources/App/Helper/FaoEvapotranspiration.swift
@@ -78,7 +78,7 @@ extension Meteorology {
         return vaporPressureDeficit
     }
 
-    /// FAO et0 calculation based on https://marais.ch/doc/fao56.pdf
+    /// Daily FAO et0 calculation based on https://marais.ch/doc/fao56.pdf
     public static func et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: Float, temperature2mCelsiusDailyMin: Float, temperature2mCelsiusDailyMean: Float, windspeed10mMeterPerSecondMean: Float, shortwaveRadiationMJSum: Float, elevation: Float, extraTerrestrialRadiationSum: Float, relativeHumidity: MaxAndMinOrMean) -> Float {
         /// short wave radiaton or use Hargreaves' radiation formula (Page 60)
         let Rs = shortwaveRadiationMJSum.isNaN ? 0.16 * sqrtf(temperature2mCelsiusDailyMax - temperature2mCelsiusDailyMin) * extraTerrestrialRadiationSum : shortwaveRadiationMJSum
@@ -137,16 +137,14 @@ extension Meteorology {
         // radiation balance
         let Rn = Rns - Rnl
 
-        /// soil heat flux [MJ m-2 day-1], During night, calculation is different
-        let Ghr = (Rs <= 0) ? 0.5 * Rn : 0.1 * Rn
-
-        // evapotranspiration
-        let et0 = (0.408 * vaporPressurCurveSlope * (Rn - Ghr) + γ * (37.0 / (temperature2mCelsiusDailyMean + 273)) * windspeed2m * vaporPressureDeficit) / (vaporPressurCurveSlope + γ * (1 + 0.34 * windspeed2m))
+        /// FAO-56 Equation 42 assumes soil heat flux G = 0 for daily and ten-day periods.
+        /// FAO-56 Equation 6 uses 900 for the aerodynamic term of the daily equation.
+        let et0 = (0.408 * vaporPressurCurveSlope * Rn + γ * (900.0 / (temperature2mCelsiusDailyMean + 273)) * windspeed2m * vaporPressureDeficit) / (vaporPressurCurveSlope + γ * (1 + 0.34 * windspeed2m))
 
         return max(et0, 0)
     }
 
-    /// FAO et0 calculation based on https://marais.ch/doc/fao56.pdf
+    /// Hourly and sub-hourly FAO et0 calculation based on https://marais.ch/doc/fao56.pdf
     public static func et0Evapotranspiration(temperature2mCelsius: Float, windspeed10mMeterPerSecond: Float, dewpointCelsius: Float, shortwaveRadiationWatts: Float, elevation: Float, extraTerrestrialRadiation: Float, dtSeconds: Int) -> Float {
         let Rs = shortwaveRadiationWatts
 
@@ -174,10 +172,10 @@ extension Meteorology {
         /// 0.23 is defined by FAO for albedo
         let albedo = Float(0.23)
 
-        /// net solar or shortwave radiation [MJ m-2 day-1], (Page 51)
+        /// net solar or shortwave radiation [MJ m-2 hour-1], (Page 51)
         let Rns = Rs * (1 - albedo) * 0.0864 / 24
 
-        /// clear-sky solar radiation [MJ m-2 day-1] approximated, (Page 51)
+        /// clear-sky solar radiation [W m-2] approximated for the relative radiation ratio, (Page 51)
         let Rso = (0.75 + 0.00002 * elevation) * extraTerrestrialRadiation
 
         let relativeHumidity = relativeHumidity(temperature: temperature2mCelsius, dewpoint: dewpointCelsius)
@@ -188,16 +186,17 @@ extension Meteorology {
         /// relative shortwave radiation (limited to ≤ 1.0
         let Rrel = extraTerrestrialRadiation <= 0 ? RrelAproximation : min(Rs / Rso, 1)
 
-        /// net outgoing longwave radiation [MJ m-2 day-1]
+        /// net outgoing longwave radiation [MJ m-2 hour-1]
         let Rnl = boltzmanConstant * powf(temperature2mCelsius + 273.16, 4) * (0.34 - 0.14 * sqrt(ea)) * (1.35 * Rrel - 0.35)
 
         // radiation balance
         let Rn = Rns - Rnl
 
-        /// soil heat flux [MJ m-2 day-1], During night, calculation is different
+        /// Hourly soil heat flux [MJ m-2 hour-1], using FAO-56 Equations 45 and 46.
         let Ghr = (Rs <= 0) ? 0.5 * Rn : 0.1 * Rn
 
-        // evapotranspiration
+        /// FAO-56 Equation 53 uses 37 for hourly and shorter calculation periods. This
+        /// calculates an hourly rate, which is scaled to the requested period below.
         let et0 = (0.408 * vaporPressurCurveSlope * (Rn - Ghr) + γ * (37.0 / (temperature2mCelsius + 273)) * windspeed2m * vaporPressureDeficit) / (vaporPressurCurveSlope + γ * (1 + 0.34 * windspeed2m))
 
         return max(et0 * Float(dtSeconds) / 3600, 0)

--- a/Sources/App/Helper/FaoEvapotranspiration.swift
+++ b/Sources/App/Helper/FaoEvapotranspiration.swift
@@ -8,6 +8,14 @@ extension Meteorology {
         case maxmin(max: Float, min: Float)
     }
 
+    /// Approximate nighttime Rs/Rso from relative humidity when the preferred
+    /// pre-sunset ratio is unavailable. FAO-56 assigns lower ratios to humid
+    /// climates and higher ratios to arid climates.
+    static func relativeShortwaveRadiationApproximation(relativeHumidity: Float) -> Float {
+        let relativeHumidityFraction = min(max(relativeHumidity, 0), 100) / 100
+        return 0.8 - relativeHumidityFraction * 0.4
+    }
+
     /// Rought approximation for leaf wetness probability. With only daily data, this wont be very accurate
     /// https://www.umfcv.ro/files/!/x/4/_/4_%20Intro_Env_MED_.pdf
     public static func leafwetnessPorbabilityDaily(temperature2mCelsiusDaily: (max: Float, min: Float), relativeHumidity: MaxAndMinOrMean, precipitation: Float) -> Float {
@@ -17,8 +25,8 @@ extension Meteorology {
         }
 
         let Tmean = (temperature2mCelsiusDaily.max + temperature2mCelsiusDaily.min) / 2
-        /// Leaf wetness inlikely below 10°C. Scale a factor from 5°C - 15°C from 0 to 1
-        let temperatureProbability = max(min((Tmean - 5) * 10, 1), 0)
+        /// Scale the temperature contribution linearly from 0 at 5°C to 1 at 15°C.
+        let temperatureProbability = max(min((Tmean - 5) / 10, 1), 0)
 
         /// Leaf wetness likely at low VPD
         let vpd = vaporPressureDeficitDaily(temperature2mCelsiusDailyMax: temperature2mCelsiusDaily.max, temperature2mCelsiusDailyMin: temperature2mCelsiusDaily.min, relativeHumidity: relativeHumidity)
@@ -33,8 +41,8 @@ extension Meteorology {
         if precipitation > 1 {
             return min(80 + precipitation * 2, 100)
         }
-        /// Leaf wetness inlikely below 10°C. Scale a factor from 5°C - 15°C from 0 to 1
-        let temperatureProbability = max(min((temperature2mCelsius - 5) * 10, 1), 0)
+        /// Scale the temperature contribution linearly from 0 at 5°C to 1 at 15°C.
+        let temperatureProbability = max(min((temperature2mCelsius - 5) / 10, 1), 0)
 
         /// Leaf wetness likely at low VPD
         let vpd = vaporPressureDeficit(temperature2mCelsius: temperature2mCelsius, dewpointCelsius: dewpointCelsius)
@@ -106,15 +114,15 @@ extension Meteorology {
         let ea: Float
 
         /// As a more approximate alternative, one can assume Rs/Rso = 0.4 to 0.6 during nighttime periods in humid and subhumid climates and Rs/Rso = 0.7 to 0.8 in arid and semiarid climates. (Page 75)
-        let RrelAproximation: Float
+        let RrelApproximation: Float
 
         switch relativeHumidity {
         case .mean(mean: let mean):
             ea = mean / 100 * (e0max + e0min) / 2
-            RrelAproximation = 0.4 + mean / 100 * 0.4
+            RrelApproximation = relativeShortwaveRadiationApproximation(relativeHumidity: mean)
         case .maxmin(max: let max, min: let min):
             ea = (e0min * max / 100 + e0max * min / 100) / 2
-            RrelAproximation = 0.4 + (max + min) / 2 / 100 * 0.4
+            RrelApproximation = relativeShortwaveRadiationApproximation(relativeHumidity: (max + min) / 2)
         }
 
         let vaporPressureDeficit = esat - ea
@@ -129,7 +137,7 @@ extension Meteorology {
         let Rso = (0.75 + 0.00002 * elevation) * extraTerrestrialRadiationMJSum
 
         /// relative shortwave radiation (limited to ≤ 1.0. Although daily, could still happen at poles
-        let Rrel = extraTerrestrialRadiationMJSum <= 0 ? RrelAproximation : min(Rs / Rso, 1)
+        let Rrel = extraTerrestrialRadiationMJSum <= 0 ? RrelApproximation : min(Rs / Rso, 1)
 
         /// net outgoing longwave radiation [MJ m-2 day-1]
         let Rnl = boltzmanConstant * (powf(temperature2mCelsiusDailyMax + 273.16, 4) + powf(temperature2mCelsiusDailyMin + 273.16, 4)) / 2 * (0.34 - 0.14 * sqrt(ea)) * (1.35 * Rrel - 0.35)
@@ -181,10 +189,10 @@ extension Meteorology {
         let relativeHumidity = relativeHumidity(temperature: temperature2mCelsius, dewpoint: dewpointCelsius)
 
         /// As a more approximate alternative, one can assume Rs/Rso = 0.4 to 0.6 during nighttime periods in humid and subhumid climates and Rs/Rso = 0.7 to 0.8 in arid and semiarid climates. (Page 75)
-        let RrelAproximation = 0.4 + relativeHumidity / 100 * 0.4
+        let RrelApproximation = relativeShortwaveRadiationApproximation(relativeHumidity: relativeHumidity)
 
         /// relative shortwave radiation (limited to ≤ 1.0
-        let Rrel = extraTerrestrialRadiation <= 0 ? RrelAproximation : min(Rs / Rso, 1)
+        let Rrel = extraTerrestrialRadiation <= 0 ? RrelApproximation : min(Rs / Rso, 1)
 
         /// net outgoing longwave radiation [MJ m-2 hour-1]
         let Rnl = boltzmanConstant * powf(temperature2mCelsius + 273.16, 4) * (0.34 - 0.14 * sqrt(ea)) * (1.35 * Rrel - 0.35)

--- a/Tests/AppTests/MeteorologyTests.swift
+++ b/Tests/AppTests/MeteorologyTests.swift
@@ -86,13 +86,13 @@ import Testing
         #expect(Meteorology.et0Evapotranspiration(temperature2mCelsius: .nan, windspeed10mMeterPerSecond: 2, dewpointCelsius: 13.8, shortwaveRadiationWatts: 0, elevation: 250, extraTerrestrialRadiation: 0, dtSeconds: 3600).isNaN)
 
         var et0day = Meteorology.et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: 32, temperature2mCelsiusDailyMin: 18, temperature2mCelsiusDailyMean: 24, windspeed10mMeterPerSecondMean: 8, shortwaveRadiationMJSum: 20, elevation: 100, extraTerrestrialRadiationSum: 28, relativeHumidity: .maxmin(max: 78, min: 54))
-        #expect(et0day == 2.7935097)
+        #expect(et0day == 7.095501)
 
         et0day = Meteorology.et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: 32, temperature2mCelsiusDailyMin: 18, temperature2mCelsiusDailyMean: 24, windspeed10mMeterPerSecondMean: 8, shortwaveRadiationMJSum: 20, elevation: 100, extraTerrestrialRadiationSum: 28, relativeHumidity: .mean(mean: 66))
-        #expect(et0day == 2.7744882)
+        #expect(et0day == 6.5863943)
 
         et0day = Meteorology.et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: 32, temperature2mCelsiusDailyMin: 18, temperature2mCelsiusDailyMean: 24, windspeed10mMeterPerSecondMean: 8, shortwaveRadiationMJSum: .nan, elevation: 100, extraTerrestrialRadiationSum: 28, relativeHumidity: .mean(mean: 66))
-        #expect(et0day == 2.351875)
+        #expect(et0day == 6.116824)
     }
 
     @Test func vaporPressureDeficit() {

--- a/Tests/AppTests/MeteorologyTests.swift
+++ b/Tests/AppTests/MeteorologyTests.swift
@@ -85,13 +85,13 @@ import Testing
 
         #expect(Meteorology.et0Evapotranspiration(temperature2mCelsius: .nan, windspeed10mMeterPerSecond: 2, dewpointCelsius: 13.8, shortwaveRadiationWatts: 0, elevation: 250, extraTerrestrialRadiation: 0, dtSeconds: 3600).isNaN)
 
-        var et0day = Meteorology.et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: 32, temperature2mCelsiusDailyMin: 18, temperature2mCelsiusDailyMean: 24, windspeed10mMeterPerSecondMean: 8, shortwaveRadiationMJSum: 20, elevation: 100, extraTerrestrialRadiationSum: 28, relativeHumidity: .maxmin(max: 78, min: 54))
+        var et0day = Meteorology.et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: 32, temperature2mCelsiusDailyMin: 18, temperature2mCelsiusDailyMean: 24, windspeed10mMeterPerSecondMean: 8, shortwaveRadiationMJSum: 20, elevation: 100, extraTerrestrialRadiationMJSum: 28, relativeHumidity: .maxmin(max: 78, min: 54))
         #expect(et0day == 7.095501)
 
-        et0day = Meteorology.et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: 32, temperature2mCelsiusDailyMin: 18, temperature2mCelsiusDailyMean: 24, windspeed10mMeterPerSecondMean: 8, shortwaveRadiationMJSum: 20, elevation: 100, extraTerrestrialRadiationSum: 28, relativeHumidity: .mean(mean: 66))
+        et0day = Meteorology.et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: 32, temperature2mCelsiusDailyMin: 18, temperature2mCelsiusDailyMean: 24, windspeed10mMeterPerSecondMean: 8, shortwaveRadiationMJSum: 20, elevation: 100, extraTerrestrialRadiationMJSum: 28, relativeHumidity: .mean(mean: 66))
         #expect(et0day == 6.5863943)
 
-        et0day = Meteorology.et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: 32, temperature2mCelsiusDailyMin: 18, temperature2mCelsiusDailyMean: 24, windspeed10mMeterPerSecondMean: 8, shortwaveRadiationMJSum: .nan, elevation: 100, extraTerrestrialRadiationSum: 28, relativeHumidity: .mean(mean: 66))
+        et0day = Meteorology.et0EvapotranspirationDaily(temperature2mCelsiusDailyMax: 32, temperature2mCelsiusDailyMin: 18, temperature2mCelsiusDailyMean: 24, windspeed10mMeterPerSecondMean: 8, shortwaveRadiationMJSum: .nan, elevation: 100, extraTerrestrialRadiationMJSum: 28, relativeHumidity: .mean(mean: 66))
         #expect(et0day == 6.116824)
     }
 

--- a/Tests/AppTests/MeteorologyTests.swift
+++ b/Tests/AppTests/MeteorologyTests.swift
@@ -81,7 +81,7 @@ import Testing
         #expect(et0 == 0.23535295)
 
         let et0night = Meteorology.et0Evapotranspiration(temperature2mCelsius: 25, windspeed10mMeterPerSecond: 2, dewpointCelsius: 13.8, shortwaveRadiationWatts: 0, elevation: 250, extraTerrestrialRadiation: 0, dtSeconds: 3600)
-        #expect(et0night == 0.05091571)
+        #expect(et0night == 0.05084415)
 
         #expect(Meteorology.et0Evapotranspiration(temperature2mCelsius: .nan, windspeed10mMeterPerSecond: 2, dewpointCelsius: 13.8, shortwaveRadiationWatts: 0, elevation: 250, extraTerrestrialRadiation: 0, dtSeconds: 3600).isNaN)
 


### PR DESCRIPTION
- subhourly et0 calculation was always zero because of integer division
- daily et0 calculation (only used in CMIP6 calculations) was using hourly aerodynamic coefficient (37) instead of daily coefficient (900)
- soil heat flux can be neglected in daily calculations according to eq. 42: $$G_\text{day} \approx 42$$
- leaf-wetness temperature scaling claimed to map 5–15°C to 0–1, but multiplied by 10
- nighttime Rs/Rso fallback increased from 0.4 to 0.8 as humidity rises. This is opposite to the cited FAO guidance: humid climates should be roughly 0.4–0.6 and arid climates 0.7–0.8