### PR TITLE
fix: jma vertical velocity unit and conversion

### DIFF
--- a/Sources/App/Controllers/VariableHourly.swift
+++ b/Sources/App/Controllers/VariableHourly.swift
@@ -741,10 +741,28 @@ struct VariableHourlyDeriver<Domain: GenericDomain, Variable: GenericVariable & 
         let pressure = variable.variable
         // Preserve exact stored fields such as ECMWF's legacy `windspeed_*` variables.
         if let input = pressureLevelInput(pressure.variable, at: pressure.level) {
-            if isJmaForecastDomain && pressure.variable == .geopotential_height {
-                // Preserve the legacy JMA API conversion applied after download-time scaling.
-                return .one(input) { geopotentialHeight, _ in
-                    return DataAndUnit(geopotentialHeight.data.map { $0 * 9.80665 }, geopotentialHeight.unit)
+            if isJmaForecastDomain {
+                if pressure.variable == .vertical_velocity {
+                    guard let temperature = pressureLevelInput(.temperature, at: pressure.level) else {
+                        return nil
+                    }
+                    // JMA archives store pressure vertical velocity (omega) in Pa/s.
+                    // Convert at read time so historical and newly downloaded files use
+                    // the same on-disk representation.
+                    return .two(input, temperature) { omega, temperature, _ in
+                        let verticalVelocity = Meteorology.verticalVelocityPressureToGeometric(
+                            omega: omega.data,
+                            temperature: temperature.data,
+                            pressureLevel: Float(pressure.level)
+                        )
+                        return DataAndUnit(verticalVelocity, .metrePerSecondNotUnitConverted)
+                    }
+                }
+                if pressure.variable == .geopotential_height {
+                    // Preserve the legacy JMA API conversion applied after download-time scaling.
+                    return .one(input) { geopotentialHeight, _ in
+                        return DataAndUnit(geopotentialHeight.data.map { $0 * 9.80665 }, geopotentialHeight.unit)
+                    }
                 }
             }
             return .from(input: input)

--- a/Sources/App/JMA/JmaDownloader.swift
+++ b/Sources/App/JMA/JmaDownloader.swift
@@ -17,14 +17,8 @@ struct JmaDownload: AsyncCommand {
         @Option(name: "run")
         var run: String?
 
-        @Option(name: "past-days")
-        var pastDays: Int?
-
         @Flag(name: "create-netcdf")
         var createNetcdf: Bool
-
-        @Flag(name: "upper-level", help: "Download upper-level variables on pressure levels")
-        var upperLevel: Bool
 
         @Option(name: "timeinterval", short: "t", help: "Timeinterval to download past forecasts. Format 20220101-20220131")
         var timeinterval: String?

--- a/Sources/App/JMA/JmaDownloader.swift
+++ b/Sources/App/JMA/JmaDownloader.swift
@@ -464,7 +464,9 @@ struct JmaPressureVariable: PressureVariableRespresentable, JmaVariableDownloada
         case .geopotential_height:
             return .metre
         case .vertical_velocity:
-            return .metrePerSecond
+            // Stored in the provider-native pressure coordinate unit Pa/s and
+            // converted to geometric m/s by VariableHourlyDeriver.
+            return .undefined
         case .relative_humidity:
             return .percentage
         }


### PR DESCRIPTION
JMA vertical velocity is originally Pa/s and has not been converted during download. This PR applies a small patch in the API to convert to the expected unit during reading.
At some point we should consider fixing the downloader and rewriting the historical records at the same time, but that needs to be well-coordinated.