### PR TITLE
fix: seaLevelPressure elevation indexing

### DIFF
--- a/Sources/App/Helper/Meteorology.swift
+++ b/Sources/App/Helper/Meteorology.swift
@@ -103,11 +103,11 @@ enum Meteorology {
         }
     }
     
-    /// Calculate mea nsea level pressure, corrected by temperature.
+    /// Calculate mean sea level pressure, corrected by temperature.
     static func sealevelPressure(temperature2m: Array2DFastTime, surfacePressure: Array2DFastTime, elevation: [Float]) -> [Float] {
         return zip(temperature2m.data, surfacePressure.data).enumerated().map { i, arg1 -> Float in
             let (t, p) = arg1
-            let elevation = elevation[i % temperature2m.nTime]
+            let elevation = elevation[i / temperature2m.nTime]
             return p * Meteorology.sealevelPressureFactor(temperature: t, elevation: elevation)
         }
     }


### PR DESCRIPTION
`Array2DFastTime` stores values as:
```
index = location * nTime + time
```

Therefore, the location for flattened index `i` is `i / nTime`. The current % expression in Sources/App/Helper/Meteorology.swift:110 instead produces the time index:

```swift
let elevation = elevation[i % temperature2m.nTime]
```
For two locations and three times, it selects elevations [0, 1, 2, 0, 1, 2]; it should select [0, 0, 0, 1, 1, 1]. It also goes out of bounds whenever `nTime > elevation.count`.

This function was not currently used anywhere in active code. Still worth fixing to prevent potential future mistakes.