### PR TITLE
Add outdoor-embeds to Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Repositories:
 - [Captain Cold](https://github.com/cburton-godaddy/captain-cold) Simple Open-Meteo -> Discord integration
 - [DIY Arduino esp8266 weather station](https://github.com/AlexeyMal/esp8266-weather-station) esp8266 weather station using Open-Meteo API, an embedded C++ implementation example
 - [Homepage](https://github.com/benphelps/homepage/) A highly customizable homepage (or startpage / application dashboard) with Docker and service API integrations.
+- [outdoor-embeds](https://github.com/Great-Outdoor-Hubs/outdoor-embeds) Dependency-free embeddable surf and marine forecast widget, no build step and no API key
 - [Spots Guru](https://www.spots.guru) Weather forecast for lazy, the best wind & wave spots around you.
 - [Weather-Cli](https://github.com/Rayrsn/Weather-Cli) A CLI program written in golang that allows you to get weather information from the terminal
 - [WeatherReport.jl](https://github.com/vnegi10/WeatherReport.jl) A simple weather app for the Julia REPL


### PR DESCRIPTION
Adding a project that uses the Marine API, as invited at the bottom of the "Who is using Open-Meteo?" section.

[outdoor-embeds](https://github.com/Great-Outdoor-Hubs/outdoor-embeds) is a small MIT-licensed set of embeddable conditions widgets. The surf and marine forecast widget calls the Open-Meteo Marine API directly from the browser, with no backend, no build step, and no API key. It renders into a Shadow DOM so it does not inherit or leak page CSS.

Placed alphabetically under `Repositories:`, between Homepage and Spots Guru. One line added, nothing else changed.

Thanks for keeping the Marine API free and keyless. It is the reason the widget can work without any server of ours in the path.