### PR TITLE
Add Going Blue to the list of apps using Open-Meteo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Apps:
 - [Emojiton Weather](https://emojiton.com/weather) Get the local weather forecast for your location with fun emoji representations
 - [Evaporative Cooler Forecaster](https://SwampCooler.app) Swamp cooler effectiveness forecast with cost & energy savings, Android/iOS app
 - [FlyDecision](https://flydecision.com/) Automated weather forecast analysis and flight condition scoring for paragliding pilots, with interactive takeoff mapping.
-- [Going Blue](https://going.blue/) Backcountry weather forecasts via satellite, with a custom codec that packs hundreds of forecast data points into each message.
+- [Going Blue](https://going.blue/) Expedition weather forecasts via satellite, with a custom codec that packs hundreds of forecast data points into each message.
 - [Heat Rules](https://heatrules.com/) A free browser-based calculator for occupational heat exposure limits. Inputs: location, work intensity, acclimatization status. Outputs: work/rest schedule, water intake, and the standard each number comes from.
 - [Home Assistant](https://www.home-assistant.io/integrations/open_meteo/) A popular open source smart home platform.
 - [Lively Weather](https://www.rocksdanister.com/weather) Windows native weather app powered by DirectX12 animations.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Apps:
 - [Emojiton Weather](https://emojiton.com/weather) Get the local weather forecast for your location with fun emoji representations
 - [Evaporative Cooler Forecaster](https://SwampCooler.app) Swamp cooler effectiveness forecast with cost & energy savings, Android/iOS app
 - [FlyDecision](https://flydecision.com/) Automated weather forecast analysis and flight condition scoring for paragliding pilots, with interactive takeoff mapping.
+- [Going Blue](https://going.blue/) Backcountry weather forecasts via satellite, with a custom codec that packs hundreds of forecast data points into each message.
 - [Heat Rules](https://heatrules.com/) A free browser-based calculator for occupational heat exposure limits. Inputs: location, work intensity, acclimatization status. Outputs: work/rest schedule, water intake, and the standard each number comes from.
 - [Home Assistant](https://www.home-assistant.io/integrations/open_meteo/) A popular open source smart home platform.
 - [Lively Weather](https://www.rocksdanister.com/weather) Windows native weather app powered by DirectX12 animations.


### PR DESCRIPTION
[Going Blue](https://going.blue/) is a weather app designed specifically for satellite messengers. Its goal is to provide detailed weather forecasts to skiers, climbers, and other backcountry users who don't have cell reception on expeditions. It uses a custom codec trained on historical weather data to fit hundreds of forecast data points into each message. 

The Going Blue app is available on the [App Store](https://apps.apple.com/app/id6798411927). Android support is in development. 

Going Blue is open source and Apache-2.0 licensed. The source, along with a detailed description of the codec, is available here: https://github.com/aaasen/goingblue

Thank you so much for the Open-Meteo API and for making it open source!