### PR TITLE
fix: final exit(1) after errors during s3 uploads

### DIFF
--- a/Sources/App/Helper/Download/S3SyncManager.swift
+++ b/Sources/App/Helper/Download/S3SyncManager.swift
@@ -21,7 +21,7 @@ actor S3SyncManager: LifecycleHandler {
         if let queue = queues.first(where: {$0.endpoint == endpoint}) {
             return queue
         }
-        let queue = S3UploadQueue(endpoint: endpoint, client: client, logger: logger) { _ in
+        let queue = S3UploadQueue(endpoint: endpoint, client: client, logger: logger) {
             self.exitStatus.markFailure()
         }
         queues.append(queue)

--- a/Sources/App/Helper/Download/S3SyncManager.swift
+++ b/Sources/App/Helper/Download/S3SyncManager.swift
@@ -7,12 +7,13 @@ import OmFileIO
 actor S3SyncManager: LifecycleHandler {
     private let logger: Logger
     private var queues: [S3UploadQueue] = []
-    private var isShuttingDown = false
     private let client: HTTPClient
+    private let exitStatus: ProcessExitStatus
 
-    init(client: HTTPClient, logger: Logger) {
+    init(client: HTTPClient, logger: Logger, exitStatus: ProcessExitStatus = .shared) {
         self.client = client
         self.logger = logger
+        self.exitStatus = exitStatus
     }
 
     /// Get task queue for S3 Endpoint
@@ -20,7 +21,9 @@ actor S3SyncManager: LifecycleHandler {
         if let queue = queues.first(where: {$0.endpoint == endpoint}) {
             return queue
         }
-        let queue = S3UploadQueue(endpoint: endpoint, client: client, logger: logger)
+        let queue = S3UploadQueue(endpoint: endpoint, client: client, logger: logger) { _ in
+            self.exitStatus.markFailure()
+        }
         queues.append(queue)
         return queue
     }
@@ -44,13 +47,16 @@ actor S3SyncManager: LifecycleHandler {
         return getQueues(buckets: bucketsOpt)
     }
     
-    /// Called from lifecycle manager to shutdown application
-    /// Stop accepting new work and wait for all queued syncs to finish.
-    func shutdownAsync(_ application: Application) async {
-        isShuttingDown = true
+    /// Wait for all queued syncs to finish.
+    func finish() async {
         for queue in queues {
             await queue.finish()
         }
+    }
+
+    /// Called from lifecycle manager to shutdown application.
+    func shutdownAsync(_ application: Application) async {
+        await finish()
     }
 }
 

--- a/Sources/App/Helper/ProcessExitStatus.swift
+++ b/Sources/App/Helper/ProcessExitStatus.swift
@@ -1,0 +1,26 @@
+#if os(Linux)
+    @preconcurrency import Glibc
+#else
+    import Darwin.C
+#endif
+
+import Synchronization
+
+public final class ProcessExitStatus: Sendable {
+    public static let shared = ProcessExitStatus()
+    private let failed = Atomic(false)
+
+    var hasFailed: Bool {
+        failed.load(ordering: .relaxed)
+    }
+
+    func markFailure() {
+        failed.store(true, ordering: .relaxed)
+    }
+
+    public func exitIfFailure() {
+        if hasFailed {
+            exit(EXIT_FAILURE)
+        }
+    }
+}

--- a/Sources/OmFileIO/Intrinsics/ProcessingQueue.swift
+++ b/Sources/OmFileIO/Intrinsics/ProcessingQueue.swift
@@ -39,10 +39,12 @@ import Logging
 actor ProcessingSerialQueue {
     private var continuation: AsyncStream<() async -> ()>.Continuation
     private var processingTask: Task<Void, Never>
+    private let onError: @Sendable (any Error) async -> Void
     
-    init() {
+    init(onError: @escaping @Sendable (any Error) async -> Void = { _ in }) {
         let (stream, continuation) = AsyncStream<() async -> ()>.makeStream()
         self.continuation = continuation
+        self.onError = onError
         self.processingTask = Task {
             for await taskBlock in stream {
                 await taskBlock()
@@ -56,11 +58,13 @@ actor ProcessingSerialQueue {
     }
     
     func enqueueIgnoreError(logger: Logger, _ work: @escaping @Sendable () async throws -> ()) {
+        let onError = onError
         continuation.yield({
             do {
                 try await work()
             } catch {
                 logger.error("Error during queued work: \(error)")
+                await onError(error)
             }
         })
     }
@@ -80,10 +84,12 @@ actor ProcessingSerialQueue {
 actor ProcessingParallelQueue<T: Sendable> {
     private var continuation: AsyncStream<@Sendable () async -> T?>.Continuation
     private var processingTask: Task<[T], Never>
+    private let onError: @Sendable (any Error) async -> Void
     
-    init(executor: LimitedConcurrencyExecutor) {
+    init(executor: LimitedConcurrencyExecutor, onError: @escaping @Sendable (any Error) async -> Void = { _ in }) {
         let (stream, continuation) = AsyncStream<@Sendable () async -> T?>.makeStream()
         self.continuation = continuation
+        self.onError = onError
         self.processingTask = Task {
             var results = [T]()
             await withTaskGroup(of: T?.self) { group in
@@ -125,11 +131,13 @@ actor ProcessingParallelQueue<T: Sendable> {
     
     /// Enqueues work into the parallel queue. Ignores errors
     func enqueueIgnoreError(logger: Logger, _ work: @escaping @Sendable () async throws -> T) {
+        let onError = onError
         continuation.yield({
             do {
                 return try await work()
             } catch {
                 logger.error("Error during queued work: \(error)")
+                await onError(error)
             }
             return nil
         })

--- a/Sources/OmFileIO/Intrinsics/ProcessingQueue.swift
+++ b/Sources/OmFileIO/Intrinsics/ProcessingQueue.swift
@@ -39,9 +39,9 @@ import Logging
 actor ProcessingSerialQueue {
     private var continuation: AsyncStream<() async -> ()>.Continuation
     private var processingTask: Task<Void, Never>
-    private let onError: @Sendable (any Error) async -> Void
+    private let onError: @Sendable () -> Void
     
-    init(onError: @escaping @Sendable (any Error) async -> Void = { _ in }) {
+    init(onError: @escaping @Sendable () -> Void = {}) {
         let (stream, continuation) = AsyncStream<() async -> ()>.makeStream()
         self.continuation = continuation
         self.onError = onError
@@ -64,7 +64,7 @@ actor ProcessingSerialQueue {
                 try await work()
             } catch {
                 logger.error("Error during queued work: \(error)")
-                await onError(error)
+                onError()
             }
         })
     }
@@ -84,9 +84,9 @@ actor ProcessingSerialQueue {
 actor ProcessingParallelQueue<T: Sendable> {
     private var continuation: AsyncStream<@Sendable () async -> T?>.Continuation
     private var processingTask: Task<[T], Never>
-    private let onError: @Sendable (any Error) async -> Void
+    private let onError: @Sendable () -> Void
     
-    init(executor: LimitedConcurrencyExecutor, onError: @escaping @Sendable (any Error) async -> Void = { _ in }) {
+    init(executor: LimitedConcurrencyExecutor, onError: @escaping @Sendable () -> Void = {}) {
         let (stream, continuation) = AsyncStream<@Sendable () async -> T?>.makeStream()
         self.continuation = continuation
         self.onError = onError
@@ -137,7 +137,7 @@ actor ProcessingParallelQueue<T: Sendable> {
                 return try await work()
             } catch {
                 logger.error("Error during queued work: \(error)")
-                await onError(error)
+                onError()
             }
             return nil
         })

--- a/Sources/OmFileIO/S3UploadQueue.swift
+++ b/Sources/OmFileIO/S3UploadQueue.swift
@@ -9,11 +9,11 @@ public struct S3UploadQueue: Sendable {
     public let endpoint: S3BucketEndpoint
     let client: HTTPClient
     let logger: Logger
-    let onError: @Sendable (any Error) async -> Void
+    let onError: @Sendable () -> Void
     
     let queue: ProcessingSerialQueue
     
-    public init(endpoint: S3BucketEndpoint, client: HTTPClient, logger: Logger = Logger(label: "S3UploadQueue"), onError: @escaping @Sendable (any Error) async -> Void = { _ in }) {
+    public init(endpoint: S3BucketEndpoint, client: HTTPClient, logger: Logger = Logger(label: "S3UploadQueue"), onError: @escaping @Sendable () -> Void = {}) {
         self.endpoint = endpoint
         self.client = client
         self.logger = logger
@@ -64,7 +64,7 @@ public struct S3UploadQueue: Sendable {
                 try await work(client, endpoint)
             } catch {
                 logger.error("Error during queued upload \(description) to \(endpoint): \(error)")
-                await onError(error)
+                onError()
             }
         }
     }
@@ -93,7 +93,7 @@ public struct S3MultiFileUploadQueue: Sendable {
     /// Max number of concurrent file uploads. 4 should be fine
     let queue: ProcessingParallelQueue<S3MultiPartUploadPrepared>
     
-    public init(endpoint: S3BucketEndpoint, client: HTTPClient, logger: Logger = Logger(label: "S3MultiFileUploadQueue"), onError: @escaping @Sendable (any Error) async -> Void = { _ in }, maxConcurrentFiles: Int, maxConcurrentPartUploads: Int) {
+    public init(endpoint: S3BucketEndpoint, client: HTTPClient, logger: Logger = Logger(label: "S3MultiFileUploadQueue"), onError: @escaping @Sendable () -> Void = {}, maxConcurrentFiles: Int, maxConcurrentPartUploads: Int) {
         self.partUploadExecutor = .init(maxConcurrency: maxConcurrentPartUploads)
         self.queue = .init(executor: LimitedConcurrencyExecutor(maxConcurrency: maxConcurrentFiles), onError: onError)
         self.client = client

--- a/Sources/OmFileIO/S3UploadQueue.swift
+++ b/Sources/OmFileIO/S3UploadQueue.swift
@@ -9,18 +9,21 @@ public struct S3UploadQueue: Sendable {
     public let endpoint: S3BucketEndpoint
     let client: HTTPClient
     let logger: Logger
+    let onError: @Sendable (any Error) async -> Void
     
-    let queue = ProcessingSerialQueue()
+    let queue: ProcessingSerialQueue
     
-    public init(endpoint: S3BucketEndpoint, client: HTTPClient, logger: Logger = Logger(label: "S3UploadQueue")) {
+    public init(endpoint: S3BucketEndpoint, client: HTTPClient, logger: Logger = Logger(label: "S3UploadQueue"), onError: @escaping @Sendable (any Error) async -> Void = { _ in }) {
         self.endpoint = endpoint
         self.client = client
         self.logger = logger
+        self.onError = onError
+        self.queue = ProcessingSerialQueue(onError: onError)
     }
     
     /// Start uploading multiple files in the background that are committed at a later stage
     public func startMultiPartUploads() -> S3MultiFileUploadQueue {
-        S3MultiFileUploadQueue(endpoint: endpoint, client: client, maxConcurrentFiles: 4, maxConcurrentPartUploads: 16)
+        S3MultiFileUploadQueue(endpoint: endpoint, client: client, onError: onError, maxConcurrentFiles: 4, maxConcurrentPartUploads: 16)
     }
     
     /// Enqueue completion of multi files
@@ -61,6 +64,7 @@ public struct S3UploadQueue: Sendable {
                 try await work(client, endpoint)
             } catch {
                 logger.error("Error during queued upload \(description) to \(endpoint): \(error)")
+                await onError(error)
             }
         }
     }
@@ -89,9 +93,9 @@ public struct S3MultiFileUploadQueue: Sendable {
     /// Max number of concurrent file uploads. 4 should be fine
     let queue: ProcessingParallelQueue<S3MultiPartUploadPrepared>
     
-    public init(endpoint: S3BucketEndpoint, client: HTTPClient, logger: Logger = Logger(label: "S3MultiFileUploadQueue"), maxConcurrentFiles: Int, maxConcurrentPartUploads: Int) {
+    public init(endpoint: S3BucketEndpoint, client: HTTPClient, logger: Logger = Logger(label: "S3MultiFileUploadQueue"), onError: @escaping @Sendable (any Error) async -> Void = { _ in }, maxConcurrentFiles: Int, maxConcurrentPartUploads: Int) {
         self.partUploadExecutor = .init(maxConcurrency: maxConcurrentPartUploads)
-        self.queue = .init(executor: LimitedConcurrencyExecutor(maxConcurrency: maxConcurrentFiles))
+        self.queue = .init(executor: LimitedConcurrencyExecutor(maxConcurrency: maxConcurrentFiles), onError: onError)
         self.client = client
         self.logger = logger
         self.endpoint = endpoint

--- a/Sources/openmeteo-api/main.swift
+++ b/Sources/openmeteo-api/main.swift
@@ -21,6 +21,7 @@ do {
     try configure(app)
     try await app.execute()
     try await app.asyncShutdown()
+    ProcessExitStatus.shared.exitIfFailure()
 } catch let error as CommandError {
     fputs("\(error)\n", stderr)
 } catch {
@@ -29,5 +30,5 @@ do {
         "type": "\(type(of: error))",
         "message": "\(error)"
     ])
-    exit(1)
+    exit(EXIT_FAILURE)
 }

--- a/Tests/OmFileIOTests/LimitedConcurrencyExecutorTests.swift
+++ b/Tests/OmFileIOTests/LimitedConcurrencyExecutorTests.swift
@@ -1,4 +1,5 @@
 @testable import OmFileIO
+import Logging
 import Testing
 
 @Suite struct LimitedConcurrencyExecutorTests {
@@ -87,6 +88,26 @@ import Testing
 
         let results = await collectTask.value
         #expect(results.sorted() == Array(0..<20))
+    }
+
+    @Test func processingParallelQueueReportsIgnoredErrorsAndContinues() async {
+        enum TestError: Error {
+            case failed
+        }
+
+        let errorCounter = Counter()
+        let queue = ProcessingParallelQueue<Int>(
+            executor: LimitedConcurrencyExecutor(maxConcurrency: 2),
+            onError: { _ in await errorCounter.increment() }
+        )
+        await queue.enqueueIgnoreError(logger: Logger(label: "ProcessingParallelQueueTests")) {
+            throw TestError.failed
+        }
+        await queue.enqueue { 42 }
+
+        let results = await queue.collect()
+        #expect(results == [42])
+        #expect(await errorCounter.value == 1)
     }
 }
 

--- a/Tests/OmFileIOTests/LimitedConcurrencyExecutorTests.swift
+++ b/Tests/OmFileIOTests/LimitedConcurrencyExecutorTests.swift
@@ -1,5 +1,6 @@
 @testable import OmFileIO
 import Logging
+import Synchronization
 import Testing
 
 @Suite struct LimitedConcurrencyExecutorTests {
@@ -95,10 +96,10 @@ import Testing
             case failed
         }
 
-        let errorCounter = Counter()
+        let failed = Atomic(false)
         let queue = ProcessingParallelQueue<Int>(
             executor: LimitedConcurrencyExecutor(maxConcurrency: 2),
-            onError: { _ in await errorCounter.increment() }
+            onError: { failed.store(true, ordering: .relaxed) }
         )
         await queue.enqueueIgnoreError(logger: Logger(label: "ProcessingParallelQueueTests")) {
             throw TestError.failed
@@ -107,7 +108,8 @@ import Testing
 
         let results = await queue.collect()
         #expect(results == [42])
-        #expect(await errorCounter.value == 1)
+        let hasFailed = failed.load(ordering: .relaxed)
+        #expect(hasFailed)
     }
 }
 


### PR DESCRIPTION
If any queued upload failed during S3-uploading, the remaining jobs are processed normally, but the final exit status is set to `exit(1)` instead of silently swallowing the errors.