### PR TITLE
fix: glofas ensemble members and improve percentile calculation

### DIFF
--- a/Sources/App/GloFas/GloFasReader.swift
+++ b/Sources/App/GloFas/GloFasReader.swift
@@ -41,13 +41,13 @@ struct GloFasReader: GenericReaderDerivedSimple, GenericReaderProtocol {
     }
 
     func prefetchData(derived: GlofasDerivedVariable, time: TimerangeDtAndSettings) async throws {
-        for member in 0..<51 {
+        for member in 0..<reader.domain.countEnsembleMember {
             try await reader.prefetchData(variable: .river_discharge, time: time.with(ensembleMember: member))
         }
     }
 
     func get(derived: GlofasDerivedVariable, time: TimerangeDtAndSettings) async throws -> DataAndUnit {
-        let data = try await (0..<51).asyncMap({
+        let data = try await (0..<reader.domain.countEnsembleMember).asyncMap({
             try await reader.get(variable: .river_discharge, time: time.with(ensembleMember: $0)).data
         })
         if data[0].onlyNaN() {

--- a/Sources/App/GloFas/GloFasReader.swift
+++ b/Sources/App/GloFas/GloFasReader.swift
@@ -68,15 +68,15 @@ struct GloFasReader: GenericReaderDerivedSimple, GenericReaderProtocol {
             }, .cubicMetrePerSecond)
         case .river_discharge_median:
             return DataAndUnit((0..<time.time.count).map { t in
-                data.map({ $0[t] }).sorted().interpolateLinear(Int(Float(data.count) * 0.5), (Float(data.count) * 0.5).truncatingRemainder(dividingBy: 1) )
+                data.map({ $0[t] }).percentile(0.5)
             }, .cubicMetrePerSecond)
         case .river_discharge_p25:
             return DataAndUnit((0..<time.time.count).map { t in
-                data.map({ $0[t] }).sorted().interpolateLinear(Int(Float(data.count) * 0.25), (Float(data.count) * 0.25).truncatingRemainder(dividingBy: 1) )
+                data.map({ $0[t] }).percentile(0.25)
             }, .cubicMetrePerSecond)
         case .river_discharge_p75:
             return DataAndUnit((0..<time.time.count).map { t in
-                data.map({ $0[t] }).sorted().interpolateLinear(Int(Float(data.count) * 0.75), (Float(data.count) * 0.75).truncatingRemainder(dividingBy: 1) )
+                data.map({ $0[t] }).percentile(0.75)
             }, .cubicMetrePerSecond)
         }
     }

--- a/Sources/App/Helper/Array.swift
+++ b/Sources/App/Helper/Array.swift
@@ -20,6 +20,16 @@ extension Sequence where Element == Float {
     }
 }
 
+extension Collection where Element == Float {
+    /// Calculate a linearly interpolated percentile. `percentile` must be between 0 and 1.
+    @inlinable func percentile(_ percentile: Float) -> Float {
+        assert(!isEmpty)
+        assert(0...1 ~= percentile)
+        let position = Float(count - 1) * percentile
+        return self.sorted().interpolateLinear(Int(position), position.truncatingRemainder(dividingBy: 1))
+    }
+}
+
 extension Array where Element == Float {
     /// Return trailing means after the initial lookback window, optionally keeping every nth result.
     func slidingAverageDroppingFirstDt(dt: Int, outputStride: Int = 1) -> [Float] {

--- a/Tests/AppTests/ArrayTests.swift
+++ b/Tests/AppTests/ArrayTests.swift
@@ -3,6 +3,17 @@ import Foundation
 import Testing
 
 @Suite struct ArrayTests {
+    @Test func percentile() {
+        let ensemble = (0...50).reversed().map(Float.init)
+        #expect(ensemble.percentile(0) == 0)
+        #expect(ensemble.percentile(0.25) == 12.5)
+        #expect(ensemble.percentile(0.5) == 25)
+        #expect(ensemble.percentile(0.75) == 37.5)
+        #expect(ensemble.percentile(1) == 50)
+        #expect([Float(4), 1, 3, 2].percentile(0.5) == 2.5)
+        #expect([Float(42)].percentile(0.75) == 42)
+    }
+
     @Test func runningMeanUsesExactWindowForNonDivisibleOutputSteps() {
         let threeHourly = TimerangeDt(start: Timestamp(0), nTime: 2, dtSeconds: 3 * 3600)
         let threeHourlyRead = threeHourly.runningMeanReadTime(windowSeconds: 8 * 3600, maximumStepSeconds: 3600)


### PR DESCRIPTION
### Summary
- Use `countEnsembleMember` instead of hardcoded 51 during prefetching and derived variable calculation
- Improve percentile calculation by using `(count - 1) * percentile` for the position, instead of `count * percentile`