### PR TITLE
fix: add missing best_match model option to Ensemble API spec

### DIFF
--- a/openapi/ensemble.yml
+++ b/openapi/ensemble.yml
@@ -386,6 +386,7 @@ paths:
             items:
               type: string
               enum:
+                - best_match
                 - dwd_icon_seamless_eps
                 - dwd_icon_global_eps
                 - dwd_icon_eu_eps


### PR DESCRIPTION
openapi/ensemble.yml lists the accepted values of `models` but leaves out
`best_match`, which the endpoint does accept - `MultiDomains` includes it
and `ForecastapiController` rewrites it to the route's default model
before the ensemble remap, so `models=best_match` on the ensemble
endpoint resolves to `ncep_gefs_seamless`. The other specs (forecast,
historical, marine, seasonal) all list it first, so this adds it in the
same position.

Spec-only change, no code touched. If you would rather the ensemble
endpoint rejected `best_match` instead of aliasing it to the default, say
so and I will close this - the spec is the easier half to change.
