### PR TITLE
README: add Seantral (sea conditions along the Italian coast)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Apps:
 - [Raindrop](https://github.com/metalfoxdev/Raindrop) Simple and intuitive weather app for the linux terminal.
 - [Rapid Update Wind Map](https://wind.zink.tv) Hourly updated short term wind forecasts. Based on rapid update models. Also for wind sports.
 - [Road Vagabond](https://roadvagabond.com) A camping destination discovery app showing zones within your drive time with weather-based filtering.
+- [Seantral](https://seantral.com) Sea conditions hour by hour along the Italian coast, with a 0-10 score per activity (swimming, snorkelling, diving, SUP, kayak, boat, sailing, fishing) from Open-Meteo wind and wave data and measured coast shelter. Free web app.
 - [SkyMuse](https://github.com/cakephone/skymuse) Minimal, privacy-respecting weather app. Built with web technologies.
 - [Slideshow](https://slideshow.digital/) Digital Signage app for Android
 - [solXpect](https://github.com/woheller69/solxpect) Android app which forecasts the output of your solar power plant


### PR DESCRIPTION
Adds Seantral (https://seantral.com) to the list of projects built with Open-Meteo.

Seantral shows sea conditions hour by hour at ~300 spots along the Italian coast, with a 0-10 score per activity, built on Open-Meteo wind and wave forecasts plus coast shelter measured on bathymetry. It is a free web app, currently in alpha. Open-Meteo is credited in the app and in the public method page.

Thank you for the API.