### PR TITLE
fix: reuse cache keys across 8MB boundary in OmReaderBlockCache

### DIFF
--- a/Sources/OmFileIO/OmReader/OmReaderBlockCache.swift
+++ b/Sources/OmFileIO/OmReader/OmReaderBlockCache.swift
@@ -31,7 +31,7 @@ public final class OmReaderBlockCache<Backend: OmFileReaderBackend, Cache: Atomi
         return 8*1024*1024 / cache.cache.blockSize
     }
     
-    /// Calculate cache key for block. 100 blocks are stored consecutive in cache.
+    /// Calculate a cache key with consecutive keys within each 8 MB super block.
     func calculateCacheKey(block: Int) -> UInt64 {
         return cacheKey.addFnv1aHash(UInt64(block / superBlockLength)) &+ UInt64(block % superBlockLength)
     }
@@ -55,9 +55,8 @@ public final class OmReaderBlockCache<Backend: OmFileReaderBackend, Cache: Atomi
         /// Prefetch data from the HTTP backend in a detached task
         Task {
             for superBlock in superBlocks {
-                let superKey = cacheKey.addFnv1aHash(UInt64(superBlock))
                 let blocks = (superBlock * superBlockLength ..< (superBlock + 1) * superBlockLength).clamped(to: blocks)
-                let keyStart = superKey &+ UInt64(blocks.lowerBound)
+                let keyStart = calculateCacheKey(block: blocks.lowerBound)
                 //print("withData blocks \(blocks)")
                 try await cache.get(key: keyStart, count: blocks.count, provider: ({ (key, count) in
                     let block = blocks.lowerBound + Int(key &- keyStart)
@@ -105,9 +104,8 @@ public final class OmReaderBlockCache<Backend: OmFileReaderBackend, Cache: Atomi
         let data = UnsafeMutableRawBufferPointer.allocate(byteCount: count, alignment: 1)
         do {
             for superBlock in superBlocks {
-                let superKey = cacheKey.addFnv1aHash(UInt64(superBlock))
                 let blocks = (superBlock * superBlockLength ..< (superBlock + 1) * superBlockLength).clamped(to: blocks)
-                let keyStart = superKey &+ UInt64(blocks.lowerBound)
+                let keyStart = calculateCacheKey(block: blocks.lowerBound)
                 //print("withData blocks \(blocks)")
                 try await cache.get(key: keyStart, count: blocks.count, provider: ({ (key, count) in
                     let block = blocks.lowerBound + Int(key &- keyStart)
@@ -188,9 +186,8 @@ public final class OmReaderBlockCache<Backend: OmFileReaderBackend, Cache: Atomi
         let superBlocks = dataRange.divideRoundedUp(divisor: blockSize * superBlockLength)
         var deletedCount = 0
         for superBlock in superBlocks {
-            let superKey = cacheKey.addFnv1aHash(UInt64(superBlock))
             let blocks = (superBlock * superBlockLength ..< (superBlock + 1) * superBlockLength).clamped(to: blocks)
-            deletedCount += cache.cache.delete(key: superKey, count: UInt64(blocks.count), olderThanSeconds: olderThanSeconds)
+            deletedCount += cache.cache.delete(key: calculateCacheKey(block: blocks.lowerBound), count: UInt64(blocks.count), olderThanSeconds: olderThanSeconds)
         }
         return deletedCount
     }

--- a/Sources/OmFileIO/OmReader/OmReaderBlockCache.swift
+++ b/Sources/OmFileIO/OmReader/OmReaderBlockCache.swift
@@ -32,8 +32,9 @@ public final class OmReaderBlockCache<Backend: OmFileReaderBackend, Cache: Atomi
     }
     
     /// Calculate a cache key with consecutive keys within each 8 MB super block.
+    /// Keep the absolute block index for compatibility with existing fetch/prefetch entries.
     func calculateCacheKey(block: Int) -> UInt64 {
-        return cacheKey.addFnv1aHash(UInt64(block / superBlockLength)) &+ UInt64(block % superBlockLength)
+        return cacheKey.addFnv1aHash(UInt64(block / superBlockLength)) &+ UInt64(block)
     }
     
     public func prefetchData(offset: Int, count: Int) async throws {

--- a/Sources/OmFileIO/OmReader/OmReaderBlockCache.swift
+++ b/Sources/OmFileIO/OmReader/OmReaderBlockCache.swift
@@ -47,7 +47,7 @@ public final class OmReaderBlockCache<Backend: OmFileReaderBackend, Cache: Atomi
         let sameSuperBlock = superBlocks.count == 1
         if sameSuperBlock, let ptr = cache.cache.get(key: calculateCacheKey(block: blocks.lowerBound), count: UInt64(blocks.count)) {
             let offset = cache.cache.data.withMutableUnsafeBytes { data in
-                data.distance(from: data.startIndex, to: ptr.startIndex)
+                UnsafeRawPointer(data.baseAddress!).distance(to: ptr.baseAddress!)
             }
             cache.cache.data.prefetchData(offset: offset, count: ptr.count)
             return
@@ -64,7 +64,7 @@ public final class OmReaderBlockCache<Backend: OmFileReaderBackend, Cache: Atomi
                     return try await backend.getData(offset: fileRange.lowerBound, count: fileRange.count)
                 }), dataCallback: {(_, value) in
                     let offset = cache.cache.data.withMutableUnsafeBytes { data in
-                        data.distance(from: data.startIndex, to: value.startIndex)
+                        UnsafeRawPointer(data.baseAddress!).distance(to: value.baseAddress!)
                     }
                     cache.cache.data.prefetchData(offset: offset, count: value.count)
                 })

--- a/Tests/OmFileIOTests/OmReaderTests.swift
+++ b/Tests/OmFileIOTests/OmReaderTests.swift
@@ -4,7 +4,7 @@ import Testing
 import OmFileFormat
 
 @Suite struct OmReaderTests {
-    @Test(arguments: ["read", "preload", "prefetch"])
+    @Test(arguments: ["read", "preload", "prefetch", "existing"])
     func blockCacheAcrossSuperBlockBoundary(path: String) async throws {
         let blockSize = 64 * 1024
         let blocks = 127..<130 // Straddles the 8 MB boundary at block 128.
@@ -25,6 +25,12 @@ import OmFileFormat
             #expect(try await reader.getData(offset: offset, count: count) == expected)
         case "preload":
             try await reader.preloadBlocks(blocks: [blocks])
+        case "existing":
+            // Seed entries using main's original fetch/prefetch placement.
+            for block in blocks {
+                let key = UInt64(123).addFnv1aHash(UInt64(block / 128)) &+ UInt64(block)
+                cache.set(key: key, value: Data(repeating: UInt8(block), count: blockSize))
+            }
         default:
             try await reader.prefetchData(offset: offset, count: count)
             // Prefetch returns before its background task commits the blocks.

--- a/Tests/OmFileIOTests/OmReaderTests.swift
+++ b/Tests/OmFileIOTests/OmReaderTests.swift
@@ -4,6 +4,51 @@ import Testing
 import OmFileFormat
 
 @Suite struct OmReaderTests {
+    @Test(arguments: ["read", "preload", "prefetch"])
+    func blockCacheAcrossSuperBlockBoundary(path: String) async throws {
+        let blockSize = 64 * 1024
+        let blocks = 127..<130 // Straddles the 8 MB boundary at block 128.
+        var contents = Data()
+        for block in 0..<130 {
+            contents.append(Data(repeating: UInt8(block), count: blockSize))
+        }
+        let file = FileManager.default.temporaryDirectory.appendingPathComponent("block-cache-\(UUID().uuidString).bin").path
+        defer { try? FileManager.default.removeItem(atPath: file) }
+        let cache = try AtomicBlockCache(file: file, blockSize: blockSize, blockCount: 256)
+        let reader = OmReaderBlockCache(backend: DataAsClass(data: contents), cache: AtomicCacheCoordinator(cache: cache), cacheKey: 123)
+        let offset = blocks.lowerBound * blockSize + 17
+        let count = blocks.count * blockSize - 34
+        let expected = contents.subdata(in: offset..<offset + count)
+
+        switch path {
+        case "read":
+            #expect(try await reader.getData(offset: offset, count: count) == expected)
+        case "preload":
+            try await reader.preloadBlocks(blocks: [blocks])
+        default:
+            try await reader.prefetchData(offset: offset, count: count)
+            // Prefetch returns before its background task commits the blocks.
+            let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+            while reader.listOfActiveBlocks(maxAgeSeconds: 60) != [blocks], ContinuousClock.now < deadline {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+
+        #expect(reader.listOfActiveBlocks(maxAgeSeconds: 60) == [blocks])
+        for block in blocks {
+            let cached = try #require(cache.get(key: reader.calculateCacheKey(block: block), count: 1))
+            let cachedAddress = UInt(bitPattern: cached.baseAddress!)
+            // A single-block hit must borrow the cache buffer, including after 8 MB.
+            try await reader.withData(offset: block * blockSize + 17, count: 31) { data in
+                #expect(UInt(bitPattern: data.baseAddress!) == cachedAddress + 17)
+                #expect(Data(data) == Data(repeating: UInt8(block), count: 31))
+            }
+        }
+        #expect(try await reader.getData(offset: offset, count: count) == expected)
+        #expect(reader.deleteCachedBlocks(olderThanSeconds: 0) == blocks.count)
+        #expect(reader.listOfActiveBlocks(maxAgeSeconds: 60).isEmpty)
+    }
+
     /*@Test func metaCache() throws {
         #expect(MemoryLayout<HttpMetaCache.Entry>.stride == 72)
         


### PR DESCRIPTION
Fix inconsistent cache keys for reads at offsets of 8 MiB or greater and offset calculation.

1. Slow `fetch` and `prefetchData` used the absolute block index, while other paths used the index within the super-block. This caused missed fast-path hits and incomplete active-block enumeration and deletion, although slow-path reads did reuse cached data.
Use `calculateCacheKey(block:)` throughout.
2. `offset` was always 0. As `startIndex` describes a position inside a buffer, not where that buffer sits in memory, using `data.distance(from: data.startIndex, to: value.startIndex)` was effectively doing `data.distance(from: 0, to: 0)`.